### PR TITLE
Add .NET releases file-based sample and markdownlint config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,23 +51,6 @@ jobs:
         run: |
           set -e
           
-          # Create markdownlint config
-          # Disabled rules:
-          #   MD013 - Long lines OK (tool output isn't wrapped)
-          #   MD024 - Duplicate headings OK (nested docs repeat Features/Reviews)
-          #   MD032 - Lists without surrounding blank lines OK (compact output)
-          #   MD034 - Bare URLs OK (source links like https://github.com/...)
-          #   MD040 - Code block language OK (tree/schema output)
-          cat > .markdownlint-smoke.json << 'EOF'
-          {
-            "MD013": false,
-            "MD024": false,
-            "MD032": false,
-            "MD034": false,
-            "MD040": false
-          }
-          EOF
-          
           # Get available demos dynamically (filter to just demo names)
           demos=$(dotnet run --project src/Markout.Demo --no-build | grep -E '^\s+\w+$' | tr -d ' ')
           echo "Available demos: $demos"
@@ -77,7 +60,7 @@ jobs:
             echo "Running demo: $demo"
             output="demo-${demo}.md"
             dotnet run --project src/Markout.Demo --no-build -- $demo > "$output"
-            markdownlint "$output" --config .markdownlint-smoke.json
+            markdownlint "$output"
           done
           
           echo "All demos passed markdownlint!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Test
         run: dotnet test -c Release --no-build --verbosity normal
 
+      - name: Smoke test
+        run: |
+          npm install -g markdownlint-cli
+          dotnet run --project src/Markout.Demo -c Release --no-build -- nested > smoke-test.md
+          markdownlint smoke-test.md
+
       - name: Pack
         run: dotnet pack -c Release -p:OfficialBuild=true --no-build
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,19 @@
+# Markout tool characteristics
+# These are inherent to how Markout generates markdown
+
+# Long lines OK (Markout doesn't wrap output)
+MD013: false
+
+# Lists without surrounding blank lines OK (compact output)
+MD032: false
+
+# Bare URLs OK (source links like https://github.com/...)
+MD034: false
+
+# Code block language OK (tree/schema output uses plain blocks)
+MD040: false
+
+# Domain-specific (depends on serialized data structure)
+
+# Duplicate headings OK (nested docs may repeat section names like Features/Reviews)
+MD024: false

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.1.*
+#:package Markout@0.1.5
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,0 +1,98 @@
+#!/usr/bin/env dotnet run
+#:package Markout@0.1.*
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Markout;
+
+// Fetch the .NET release index
+using var http = new HttpClient();
+var json = await http.GetStringAsync(
+    "https://github.com/dotnet/core/raw/release-index/release-notes/index.json");
+
+var index = JsonSerializer.Deserialize(json, ReleasesJsonContext.Default.ReleaseIndex)!;
+
+// Project to view model
+var view = new ReleasesView
+{
+    Title = index.Title ?? ".NET Releases",
+    LatestMajor = index.LatestMajor,
+    LatestLtsMajor = index.LatestLtsMajor,
+    Releases = index.Embedded?.Releases?.Select(r => new ReleaseRow
+    {
+        Version = r.Version,
+        Type = r.ReleaseType?.ToUpperInvariant() ?? "",
+        Supported = r.Supported
+    }).ToList()
+};
+
+// Serialize to markdown
+MarkoutSerializer.Serialize(view, Console.Out, ReleasesContext.Default);
+
+// --- Models ---
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ReleasesView
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+    
+    [MarkoutPropertyName("Latest Major")]
+    public string? LatestMajor { get; set; }
+    
+    [MarkoutPropertyName("Latest LTS")]
+    public string? LatestLtsMajor { get; set; }
+    
+    [MarkoutSection(Name = "All Releases")]
+    public List<ReleaseRow>? Releases { get; set; }
+}
+
+[MarkoutSerializable]
+public class ReleaseRow
+{
+    public string Version { get; set; } = "";
+    public string Type { get; set; } = "";
+    public bool Supported { get; set; }
+}
+
+[MarkoutContext(typeof(ReleasesView))]
+[MarkoutContext(typeof(ReleaseRow))]
+public partial class ReleasesContext : MarkoutSerializerContext { }
+
+// --- JSON Models ---
+
+public class ReleaseIndex
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+    
+    [JsonPropertyName("latest_major")]
+    public string? LatestMajor { get; set; }
+    
+    [JsonPropertyName("latest_lts_major")]
+    public string? LatestLtsMajor { get; set; }
+    
+    [JsonPropertyName("_embedded")]
+    public EmbeddedReleases? Embedded { get; set; }
+}
+
+public class EmbeddedReleases
+{
+    [JsonPropertyName("releases")]
+    public List<Release>? Releases { get; set; }
+}
+
+public class Release
+{
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "";
+    
+    [JsonPropertyName("release_type")]
+    public string? ReleaseType { get; set; }
+    
+    [JsonPropertyName("supported")]
+    public bool Supported { get; set; }
+}
+
+[JsonSerializable(typeof(ReleaseIndex))]
+internal partial class ReleasesJsonContext : JsonSerializerContext { }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.1.3</Version>
+    <Version>0.1.5</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">


### PR DESCRIPTION
- Add `samples/DotNetReleases/DotNetReleases.cs` file-based app using NuGet package reference
- Add `.markdownlint.yaml` for repo-wide linting config
- Simplify CI workflow to use repo config (no inline JSON)
- Add smoke test to release workflow

The file-based sample uses `#:package Markout@0.1.*` to demonstrate real package usage, while the existing demos use project references to test the repo code.