### PR TITLE
Fix all MARKOUT001 warnings

### DIFF
--- a/tests/Markout.Tests/BuildResultsTests.cs
+++ b/tests/Markout.Tests/BuildResultsTests.cs
@@ -117,9 +117,11 @@ public class DiagnosticsInfo
     public int Errors { get; set; }
     
     [MarkoutPropertyName("Warning Codes")]
+    [MarkoutIgnoreInTable]
     public List<string>? WarningCodes { get; set; }
     
     [MarkoutPropertyName("Error Codes")]
+    [MarkoutIgnoreInTable]
     public List<string>? ErrorCodes { get; set; }
 }
 

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -29,7 +29,9 @@ public class Person
     public class Team
     {
         public string Name { get; set; } = "";
+        [MarkoutIgnoreInTable]
         public List<string>? Tags { get; set; }
+        [MarkoutIgnoreInTable]
         public List<Member>? Members { get; set; }
     }
 
@@ -57,6 +59,7 @@ public class Person
     {
         public string? Lead { get; set; }
         public int Size { get; set; }
+        [MarkoutIgnoreInTable]
         public List<Contributor>? Contributors { get; set; }
     }
 
@@ -154,6 +157,7 @@ public class Person
         [MarkoutSection(Name = "Dependencies")]
         public List<Dependency>? Dependencies { get; set; }
         
+        [MarkoutIgnoreInTable]
         public List<string>? Features { get; set; }
     }
 

--- a/tests/Markout.Tests/RenderingStrategyTests.cs
+++ b/tests/Markout.Tests/RenderingStrategyTests.cs
@@ -80,12 +80,15 @@ public class PackageWithMultipleLists
     public string PackageName { get; set; } = "";
     
     [MarkoutPropertyName("Dependencies (net6.0)")]
+    [MarkoutIgnoreInTable]
     public List<string>? Net6Dependencies { get; set; }
     
     [MarkoutPropertyName("Dependencies (net8.0)")]
+    [MarkoutIgnoreInTable]
     public List<string>? Net8Dependencies { get; set; }
     
     [MarkoutPropertyName("Dependencies (netstandard2.0)")]
+    [MarkoutIgnoreInTable]
     public List<string>? NetStandardDependencies { get; set; }
 }
 

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -9,7 +9,9 @@ public class Package
     public string? Name { get; set; }
     public string? Version { get; set; }
     public bool Signed { get; set; }
+    [MarkoutIgnoreInTable]
     public List<string>? Frameworks { get; set; }
+    [MarkoutIgnoreInTable]
     public List<Assembly>? Assemblies { get; set; }
 }
 


### PR DESCRIPTION
Add `[MarkoutIgnoreInTable]` attributes to all properties in test types that trigger MARKOUT001 warnings.

Build now has 0 warnings.