### PR TITLE
Switch to manual workflow_dispatch for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,19 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build -c Release -p:OfficialBuild=true --no-restore
 
       - name: Test
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test -c Release --no-build --verbosity normal
+
+      - name: Pack
+        run: dotnet pack -c Release -p:OfficialBuild=true --no-build
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: artifacts/package/release/*.nupkg
 
   smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,39 @@
-name: Release
+name: Publish
 
 on:
-  push:
-    branches: [ release ]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'CI workflow run ID to publish from'
+        required: true
+      confirm:
+        description: 'Type "publish" to confirm NuGet release'
+        required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.event.inputs.confirm == 'publish'
     steps:
-      - uses: actions/checkout@v4
+      - name: Download packages from CI run
+        uses: actions/download-artifact@v4
+        with:
+          name: packages
+          path: packages
+          run-id: ${{ github.event.inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List packages
+        run: ls -la packages/
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.x'
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release -p:OfficialBuild=true --no-restore
-
-      - name: Test
-        run: dotnet test -c Release --no-build --verbosity normal
-
-      - name: Smoke test
-        run: |
-          npm install -g markdownlint-cli
-          dotnet run --project src/Markout.Demo -c Release --no-build -- nested > smoke-test.md
-          markdownlint smoke-test.md
-
-      - name: Pack
-        run: dotnet pack -c Release -p:OfficialBuild=true --no-build
-
       - name: Publish to NuGet
         run: |
-          dotnet nuget push artifacts/package/release/*.nupkg \
+          dotnet nuget push packages/*.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.1.5
+#:package Markout@0.1.6
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.1.5</Version>
+    <Version>0.1.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">


### PR DESCRIPTION
Changes:
- Replace `push` trigger with `workflow_dispatch` - requires typing 'publish' to confirm
- Bump version to 0.1.6
- Update sample to reference 0.1.6

To publish: Actions → Release → Run workflow → type 'publish' → Run