### PR TITLE
Add CanadianContent sample and update README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,51 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
 jobs:
+  # Detect what changed to determine which jobs to run
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'samples/**'
+              - '*.props'
+              - '*.sln'
+              - '.github/workflows/**'
+            docs:
+              - '**/*.md'
+              - 'docs/**'
+
+  # Lint markdown files
+  markdownlint:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: '**/*.md'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +79,8 @@ jobs:
           path: artifacts/package/release/*.nupkg
 
   smoke-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -13,7 +13,18 @@ MD034: false
 # Code block language OK (tree/schema output uses plain blocks)
 MD040: false
 
+# Table column style OK (Markout uses compact style without padding)
+MD060: false
+
 # Domain-specific (depends on serialized data structure)
 
 # Duplicate headings OK (nested docs may repeat section names like Features/Reviews)
 MD024: false
+
+# Documentation style choices
+
+# Inline HTML OK (generic type syntax like <T> in docs)
+MD033: false
+
+# Emphasis as heading OK (bold tagline in README)
+MD036: false

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ CLI tools need to produce output that works for multiple audiences: humans readi
 
 **Markdown** hits the sweet spot: tables are scannable by humans, headings provide natural hierarchy, and the format is both well-defined enough for parsing and natural enough for LLMs to understand without special handling.
 
+### Data Shape vs. Data Results
+
+JSON serialization is typically oriented on pure data shape—mirroring the structure of objects and their relationships. Markout can do that too. However, much of the time what's desired is serializing a *data result*: a transformed, filtered, or aggregated view of data tailored for a specific query or report.
+
+We call this approach a **pivot table**. Instead of dumping raw object graphs, you project your data into view models designed for human consumption—flattening nested structures, joining related data, and presenting exactly what the reader needs to see.
+
 ## Features
 
 - **Tables** - `List<T>` serializes to Markdown tables
@@ -30,36 +36,58 @@ CLI tools need to produce output that works for multiple audiences: humans readi
 
 ## Quick Start
 
+This example from [samples/CanadianContent](samples/CanadianContent) shows actors with their filmography:
+
 ```csharp
 using Markout;
 
-[MarkoutSerializable]
-public class BuildResult
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ActorFilmography
 {
-    public string Project { get; set; }
-    public bool Success { get; set; }
-    public int Duration { get; set; }
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+    public string Birthplace { get; set; } = "";
+    
+    [MarkoutPropertyName("Born")]
+    public int BirthYear { get; set; }
+
+    [MarkoutSection(Name = "Filmography")]
+    public List<ShowRow>? Filmography { get; set; }
 }
 
-[MarkoutContext(typeof(BuildResult))]
-public partial class MyContext : MarkoutSerializerContext { }
+[MarkoutSerializable]
+public class ShowRow
+{
+    public string Title { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string Years { get; set; } = "";
+
+    [MarkoutPropertyName("Filmed In")]
+    public string FilmingLocation { get; set; } = "";
+}
+
+[MarkoutContext(typeof(ActorFilmography))]
+[MarkoutContext(typeof(ShowRow))]
+public partial class CanConContext : MarkoutSerializerContext { }
 
 // Serialize
-var result = new BuildResult 
-{ 
-    Project = "MyApp", 
-    Success = true, 
-    Duration = 1234 
-};
-
-var markdown = MyContext.Default.Serialize(result);
+MarkoutSerializer.Serialize(actor, Console.Out, CanConContext.Default);
 ```
 
 **Output:**
 ```markdown
-Project: MyApp
-Success: yes
-Duration: 1234
+# Ryan Gosling
+
+Birthplace: London, Ontario  
+Born: 1980  
+
+## Filmography
+
+| Title | Type | Years | Filmed In |
+| ----- | ---- | ----- | --------- |
+| The Notebook | Movie | 2004 | Filmed in South Carolina |
+| Blade Runner 2049 | Movie | 2017 | Filmed in Budapest |
+| Barbie | Movie | 2023 | Filmed in London |
 ```
 
 ## Installation
@@ -74,62 +102,95 @@ The package includes the source generator - no additional packages needed.
 
 ### List as Table
 
+From [samples/CanadianContent](samples/CanadianContent) — querying shows filmed in Toronto:
+
 ```csharp
-[MarkoutSerializable]
-public class TestResult
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class LocationSearchResult
 {
-    public string Name { get; set; }
-    public bool Passed { get; set; }
-    public int Duration { get; set; }
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Results")]
+    public List<ShowRow>? Results { get; set; }
 }
 
-var results = new List<TestResult> { ... };
-var markdown = MarkoutSerializer.Serialize(results, MyContext.Default);
+[MarkoutSerializable]
+public class ShowRow
+{
+    public string Title { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string Years { get; set; } = "";
+
+    [MarkoutPropertyName("Filmed In")]
+    public string FilmingLocation { get; set; } = "";
+}
 ```
 
 **Output:**
 ```markdown
-| Name           | Passed | Duration |
-|----------------|--------|----------|
-| Login_Works    | yes    | 145      |
-| Logout_Works   | yes    | 89       |
-| Invalid_Fails  | no     | 234      |
+# Shows Filmed in Toronto
+
+## Results
+
+| Title | Type | Years | Filmed In |
+| ----- | ---- | ----- | --------- |
+| The Expanse | TV Series | 2015-2022 | Filmed in Toronto |
+| Station Eleven | TV Miniseries | 2021-2022 | Filmed in Toronto |
+| Lost Girl | TV Series | 2010-2016 | Filmed in Toronto |
+| Orphan Black | TV Series | 2013-2017 | Filmed in Toronto |
+| The Umbrella Academy | TV Series | 2019-2023 | Filmed in Toronto |
 ```
 
 ### Nested Objects as Sections
 
+From [samples/DotNetReleases](samples/DotNetReleases) — fetching .NET release info from GitHub:
+
 ```csharp
-[MarkoutSerializable(TitleProperty = nameof(Name))]
-public class Project
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ReleasesView
 {
-    public string Name { get; set; }
-    public string Version { get; set; }
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
     
-    [MarkoutSection(Name = "Dependencies")]
-    public List<Dependency> Dependencies { get; set; }
+    [MarkoutPropertyName("Latest Major")]
+    public string? LatestMajor { get; set; }
+    
+    [MarkoutPropertyName("Latest LTS")]
+    public string? LatestLtsMajor { get; set; }
+    
+    [MarkoutSection(Name = "All Releases")]
+    public List<ReleaseRow>? Releases { get; set; }
 }
 
 [MarkoutSerializable]
-public class Dependency
+public class ReleaseRow
 {
-    public string Package { get; set; }
-    public string Version { get; set; }
+    public string Version { get; set; } = "";
+    public string Type { get; set; } = "";
+    public bool Supported { get; set; }
 }
+
+// Serialize to console
+MarkoutSerializer.Serialize(view, Console.Out, ReleasesContext.Default);
 ```
 
 **Output:**
 ```markdown
-# MyApp 1.0.0
+# .NET Releases
 
-Name: MyApp
-Version: 1.0.0
+Latest Major: 10.0  
+Latest LTS: 10.0  
 
-## Dependencies
+## All Releases
 
-| Package         | Version |
-|-----------------|---------|
-| Newtonsoft.Json | 13.0.3  |
-| Serilog         | 3.1.1   |
+| Version | Type | Supported |
+| ------- | ---- | --------- |
+| 10.0 | lts | yes |
+| 9.0 | sts | yes |
+| 8.0 | lts | yes |
+| 7.0 | sts | no |
+| 6.0 | lts | no |
 ```
 
 ## Attributes
@@ -190,6 +251,12 @@ This is intentional! Markdown tables can't contain lists. Choose a transformatio
 4. **Flatten** - Single table with group as a column
 
 📖 **See [Nested Lists Guide](docs/nested-lists-guide.md)** for complete examples and code
+
+## Samples
+
+- **[CanadianContent](samples/CanadianContent)** - Query Canadian actors and shows with searchable filters (file-based app)
+- **[DotNetReleases](samples/DotNetReleases)** - Fetch and display .NET release information from GitHub (file-based app)
+- **[Serialization](samples/Serialization)** - Basic usage patterns, section filtering, and MarkoutWriter examples
 
 ## Real-World Usage
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ MarkoutSerializer.Serialize(actor, Console.Out, CanConContext.Default);
 ```
 
 **Output:**
+
 ```markdown
 # Ryan Gosling
 
@@ -128,6 +129,7 @@ public class ShowRow
 ```
 
 **Output:**
+
 ```markdown
 # Shows Filmed in Toronto
 
@@ -176,6 +178,7 @@ MarkoutSerializer.Serialize(view, Console.Out, ReleasesContext.Default);
 ```
 
 **Output:**
+
 ```markdown
 # .NET Releases
 

--- a/docs/design/compile-time-errors.md
+++ b/docs/design/compile-time-errors.md
@@ -18,6 +18,7 @@ public class DependencyGroup
 ```
 
 **Output without validation:**
+
 ```markdown
 | Framework | Packages                                              |
 |-----------|-------------------------------------------------------|
@@ -39,6 +40,7 @@ The source generator detects when a type will be rendered in a table (because it
 **Trigger:** Property with complex type (List, custom object) in a type used in `List<T>`
 
 **Message:**
+
 ```
 error MARKOUT001: Property 'Packages' in type 'DependencyGroup' is an array 
 of complex objects and cannot be rendered in a table cell. Use [MarkoutIgnore], 
@@ -51,6 +53,7 @@ of complex objects and cannot be rendered in a table cell. Use [MarkoutIgnore],
 3. Transform the data using one of the 4 strategies (see nested-lists-guide.md)
 
 **Example Fix:**
+
 ```csharp
 // Option 1: Pivot transformation (recommended for dependencies)
 var matrix = groups

--- a/docs/markout-view-system-design.md
+++ b/docs/markout-view-system-design.md
@@ -102,6 +102,7 @@ We use indices rather than names because:
 4. **Discoverable** - Run once, count the sections
 
 The mapping is documented in help text and `llms.txt`:
+
 ```
 1=Summary  2=Projects  3=Errors  4=Warnings  5=ErrorTypes
 ```
@@ -174,6 +175,7 @@ Filtering advantages:
 ### Adding a New Section
 
 1. Create the section renderer:
+
 ```csharp
 private string NewSection()
 {
@@ -190,9 +192,9 @@ private string NewSection()
 }
 ```
 
-2. Add to appropriate verbosity levels in `GetSectionsForVerbosity()`
+1. Add to appropriate verbosity levels in `GetSectionsForVerbosity()`
 
-3. Update the section index documentation
+2. Update the section index documentation
 
 ### Adding a New Verbosity Level
 

--- a/docs/nested-lists-guide.md
+++ b/docs/nested-lists-guide.md
@@ -46,6 +46,7 @@ or transform the data.
 ```
 
 This error prevents your code from producing useless `ToString()` output like:
+
 ```markdown
 | North America | USD | System.Collections.Generic.List`1[Product] |
 ```
@@ -63,6 +64,7 @@ Choose the strategy that best answers your reader's question about our product c
 **Reader Question:** "Is the Laptop cheaper in Europe or North America?"
 
 **Transform your data:**
+
 ```csharp
 // Instead of List<Region> with nested List<Product>
 // Create a matrix where products are rows, regions are columns
@@ -86,6 +88,7 @@ string FormatPrice(IGrouping<string, ...> group, string region)
 ```
 
 **Result:**
+
 ```markdown
 ## Product Prices by Region
 
@@ -107,6 +110,7 @@ string FormatPrice(IGrouping<string, ...> group, string region)
 **Reader Question:** "What can I buy in Europe?" or "Show me the Asia catalog"
 
 **Structure your type:**
+
 ```csharp
 [MdfSerializable(TitleProperty = nameof(StoreName))]
 public class CatalogWithSections
@@ -133,6 +137,7 @@ public class Product
 ```
 
 **Result:**
+
 ```markdown
 # Global Electronics Store
 
@@ -170,6 +175,7 @@ public class Product
 **Reader Question:** "Quick scan - what's available where?"
 
 **Structure your type:**
+
 ```csharp
 [MdfSerializable(TitleProperty = nameof(StoreName))]
 public class CatalogWithLists
@@ -188,6 +194,7 @@ public class CatalogWithLists
 ```
 
 **Result:**
+
 ```markdown
 # Global Electronics Store
 
@@ -219,6 +226,7 @@ public class CatalogWithLists
 **Reader Question:** "Give me one searchable/sortable table of everything"
 
 **Transform your data:**
+
 ```csharp
 // Flatten into a single list where region becomes a column
 var flatProducts = catalog.Regions
@@ -234,6 +242,7 @@ var flatProducts = catalog.Regions
 ```
 
 **Result:**
+
 ```markdown
 ## Global Product Inventory
 
@@ -270,6 +279,7 @@ var flatProducts = catalog.Regions
 The same principles apply to any nested structure:
 
 ### NuGet Dependencies (dotnet-inspector)
+
 **Original:** `List<DependencyGroup>` with nested `List<Dependency>`
 - **Pivot:** Package × Framework version matrix (compare versions across frameworks) ✓ Best choice
 - **Multiple Tables:** Dependencies per framework (complete package info per framework)
@@ -279,6 +289,7 @@ The same principles apply to any nested structure:
 **See Example:** `tests/MarkdownData.Tests/NestedStructureTests.cs` - `Serialize_PackageWithDependencyGroups_CreatesTables()`
 
 ### Build Configurations
+
 **Original:** `List<BuildConfig>` with nested `List<Project>`
 - **Pivot:** Project × Config status matrix (see what built where)
 - **Multiple Tables:** Projects per config (detailed build results) ✓ Best choice
@@ -288,6 +299,7 @@ The same principles apply to any nested structure:
 **See Example:** `tests/MarkdownData.Tests/BuildResultsTests.cs` - `Serialize_BuildResult_GroupsByConfiguration()`
 
 ### Feature Tiers
+
 **Original:** `List<Tier>` with nested `List<Feature>`
 - **Pivot:** Feature × Tier availability matrix (which tiers have what features)
 - **Multiple Tables:** Features per tier (complete feature details)
@@ -315,6 +327,7 @@ public class Region
 ```
 
 **Result:**
+
 ```markdown
 ## Regions
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -102,7 +102,7 @@ Frameworks:
 ```
 
 - Key followed by colon with **no value on the same line**
-- Array items on subsequent lines, each prefixed with `- `
+- Array items on subsequent lines, each prefixed with `-`
 - Items are left-aligned (no indentation)
 - Empty array: key line with no items following
 

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,0 +1,332 @@
+#!/usr/bin/env dotnet run
+#:package Markout@0.1.6
+// CanCon. It's the law!
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Markout;
+
+// Load data from JSON files (relative to the source file location)
+var basePath = Path.GetDirectoryName(Path.GetFullPath("CanadianContent.cs")) ?? ".";
+var actorsJson = await File.ReadAllTextAsync(Path.Combine(basePath, "actors.json"));
+var showsJson = await File.ReadAllTextAsync(Path.Combine(basePath, "shows.json"));
+
+var actors = JsonSerializer.Deserialize(actorsJson, CanConJsonContext.Default.ListActor)!;
+var shows = JsonSerializer.Deserialize(showsJson, CanConJsonContext.Default.ListShow)!;
+
+// Parse command-line query
+var query = args.Length > 0 ? string.Join(" ", args).ToLowerInvariant() : "";
+
+if (query is "-h" or "--help" or "help")
+{
+    Console.WriteLine("""
+        Canadian Content Database - CanCon. It's the law!
+
+        Usage: dotnet run CanadianContent.cs [query]
+
+        Queries:
+          (no args)     Show all actors and shows
+          ryan          Actors named Ryan (Gosling, Reynolds)
+          rachel        Actors named Rachel (McAdams, Skarsten)
+          gosling       Ryan Gosling's filmography
+          reynolds      Ryan Reynolds' filmography
+          expanse       The Expanse with Canadian cast
+          schitt        Schitt's Creek with Canadian cast
+          toronto       Shows filmed in Toronto
+          vancouver     Shows filmed in Vancouver
+
+        Examples:
+          dotnet run CanadianContent.cs
+          dotnet run CanadianContent.cs ryan
+          dotnet run CanadianContent.cs toronto
+        """);
+    return;
+}
+
+if (string.IsNullOrEmpty(query))
+{
+    // Show all actors and shows
+    var overview = new CanConOverview
+    {
+        Title = "Canadian Content Database",
+        Actors = actors.Select(a => new ActorRow
+        {
+            Name = a.Name,
+            Birthplace = a.Birthplace,
+            BirthYear = a.BirthYear,
+            Citizenship = string.Join(", ", a.Citizenship)
+        }).ToList(),
+        Shows = shows.Select(s => new ShowRow
+        {
+            Title = s.Title,
+            Type = s.Type,
+            Years = s.Years,
+            FilmingLocation = s.Location
+        }).ToList()
+    };
+    MarkoutSerializer.Serialize(overview, Console.Out, CanConContext.Default);
+}
+else if (query.Contains("ryan") || query.Contains("rachel"))
+{
+    // Filter actors by first name
+    var nameFilter = query.Contains("ryan") ? "Ryan" : "Rachel";
+    var filtered = actors
+        .Where(a => a.Name.StartsWith(nameFilter, StringComparison.OrdinalIgnoreCase))
+        .ToList();
+
+    var view = new ActorSearchResult
+    {
+        Title = $"Actors Named {nameFilter}",
+        Results = filtered.Select(a => new ActorDetailRow
+        {
+            Name = a.Name,
+            Birthplace = a.Birthplace,
+            BirthYear = a.BirthYear,
+            Citizenship = string.Join(", ", a.Citizenship),
+            KnownFor = string.Join(", ", a.Shows.Take(3))
+        }).ToList()
+    };
+    MarkoutSerializer.Serialize(view, Console.Out, CanConContext.Default);
+}
+else if (query.Contains("expanse"))
+{
+    var show = shows.First(s => s.Title.Contains("Expanse", StringComparison.OrdinalIgnoreCase));
+    var castActors = actors.Where(a => show.CanadianActors.Contains(a.Name)).ToList();
+
+    var view = new ShowDetailView
+    {
+        Title = show.Title,
+        Type = show.Type,
+        Years = show.Years,
+        FilmingLocation = show.Location,
+        Cast = castActors.Select(a => new ActorRow
+        {
+            Name = a.Name,
+            Birthplace = a.Birthplace,
+            BirthYear = a.BirthYear,
+            Citizenship = string.Join(", ", a.Citizenship)
+        }).ToList()
+    };
+    MarkoutSerializer.Serialize(view, Console.Out, CanConContext.Default);
+}
+else if (query.Contains("schitt"))
+{
+    var show = shows.First(s => s.Title.Contains("Schitt", StringComparison.OrdinalIgnoreCase));
+    var castActors = actors.Where(a => show.CanadianActors.Contains(a.Name)).ToList();
+
+    var view = new ShowDetailView
+    {
+        Title = show.Title,
+        Type = show.Type,
+        Years = show.Years,
+        FilmingLocation = show.Location,
+        Cast = castActors.Select(a => new ActorRow
+        {
+            Name = a.Name,
+            Birthplace = a.Birthplace,
+            BirthYear = a.BirthYear,
+            Citizenship = string.Join(", ", a.Citizenship)
+        }).ToList()
+    };
+    MarkoutSerializer.Serialize(view, Console.Out, CanConContext.Default);
+}
+else if (query.Contains("toronto") || query.Contains("vancouver"))
+{
+    var city = query.Contains("toronto") ? "Toronto" : "Vancouver";
+    var filtered = shows.Where(s => s.Location.Contains(city, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    var view = new LocationSearchResult
+    {
+        Title = $"Shows Filmed in {city}",
+        Results = filtered.Select(s => new ShowRow
+        {
+            Title = s.Title,
+            Type = s.Type,
+            Years = s.Years,
+            FilmingLocation = s.Location
+        }).ToList()
+    };
+    MarkoutSerializer.Serialize(view, Console.Out, CanConContext.Default);
+}
+else if (query.Contains("gosling") || query.Contains("reynolds"))
+{
+    var lastName = query.Contains("gosling") ? "Gosling" : "Reynolds";
+    var actor = actors.First(a => a.Name.Contains(lastName, StringComparison.OrdinalIgnoreCase));
+    var actorShows = shows.Where(s => s.CanadianActors.Contains(actor.Name)).ToList();
+
+    var view = new ActorFilmography
+    {
+        Title = actor.Name,
+        Birthplace = actor.Birthplace,
+        BirthYear = actor.BirthYear,
+        Filmography = actorShows.Select(s => new ShowRow
+        {
+            Title = s.Title,
+            Type = s.Type,
+            Years = s.Years,
+            FilmingLocation = s.Location
+        }).ToList()
+    };
+    MarkoutSerializer.Serialize(view, Console.Out, CanConContext.Default);
+}
+else
+{
+    Console.WriteLine($"Unknown query: {query}");
+    Console.WriteLine("Try: ryan, rachel, gosling, reynolds, expanse, schitt, toronto, vancouver");
+}
+
+// --- JSON Models ---
+
+public class Actor
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("birthplace")]
+    public string Birthplace { get; set; } = "";
+
+    [JsonPropertyName("birthYear")]
+    public int BirthYear { get; set; }
+
+    [JsonPropertyName("citizenship")]
+    public List<string> Citizenship { get; set; } = new();
+
+    [JsonPropertyName("shows")]
+    public List<string> Shows { get; set; } = new();
+}
+
+public class Show
+{
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    [JsonPropertyName("years")]
+    public string Years { get; set; } = "";
+
+    [JsonPropertyName("location")]
+    public string Location { get; set; } = "";
+
+    [JsonPropertyName("canadianActors")]
+    public List<string> CanadianActors { get; set; } = new();
+}
+
+[JsonSerializable(typeof(List<Actor>))]
+[JsonSerializable(typeof(List<Show>))]
+internal partial class CanConJsonContext : JsonSerializerContext { }
+
+// --- Markout View Models ---
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class CanConOverview
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Actors")]
+    public List<ActorRow>? Actors { get; set; }
+
+    [MarkoutSection(Name = "Shows")]
+    public List<ShowRow>? Shows { get; set; }
+}
+
+[MarkoutSerializable]
+public class ActorRow
+{
+    public string Name { get; set; } = "";
+    public string Birthplace { get; set; } = "";
+
+    [MarkoutPropertyName("Born")]
+    public int BirthYear { get; set; }
+
+    public string Citizenship { get; set; } = "";
+}
+
+[MarkoutSerializable]
+public class ActorDetailRow
+{
+    public string Name { get; set; } = "";
+    public string Birthplace { get; set; } = "";
+
+    [MarkoutPropertyName("Born")]
+    public int BirthYear { get; set; }
+
+    public string Citizenship { get; set; } = "";
+
+    [MarkoutPropertyName("Known For")]
+    public string KnownFor { get; set; } = "";
+}
+
+[MarkoutSerializable]
+public class ShowRow
+{
+    public string Title { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string Years { get; set; } = "";
+
+    [MarkoutPropertyName("Filmed In")]
+    public string FilmingLocation { get; set; } = "";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ActorSearchResult
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Results")]
+    public List<ActorDetailRow>? Results { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class LocationSearchResult
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Results")]
+    public List<ShowRow>? Results { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ShowDetailView
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    public string Type { get; set; } = "";
+    public string Years { get; set; } = "";
+
+    [MarkoutPropertyName("Filmed In")]
+    public string FilmingLocation { get; set; } = "";
+
+    [MarkoutSection(Name = "Canadian Cast")]
+    public List<ActorRow>? Cast { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ActorFilmography
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    public string Birthplace { get; set; } = "";
+
+    [MarkoutPropertyName("Born")]
+    public int BirthYear { get; set; }
+
+    [MarkoutSection(Name = "Filmography")]
+    public List<ShowRow>? Filmography { get; set; }
+}
+
+[MarkoutContext(typeof(CanConOverview))]
+[MarkoutContext(typeof(ActorRow))]
+[MarkoutContext(typeof(ActorDetailRow))]
+[MarkoutContext(typeof(ShowRow))]
+[MarkoutContext(typeof(ActorSearchResult))]
+[MarkoutContext(typeof(LocationSearchResult))]
+[MarkoutContext(typeof(ShowDetailView))]
+[MarkoutContext(typeof(ActorFilmography))]
+public partial class CanConContext : MarkoutSerializerContext { }

--- a/samples/CanadianContent/actors.json
+++ b/samples/CanadianContent/actors.json
@@ -1,0 +1,170 @@
+[
+  {
+    "name": "Ryan Gosling",
+    "birthplace": "London, Ontario",
+    "birthYear": 1980,
+    "citizenship": ["Canadian", "American"],
+    "shows": ["The Notebook", "Drive", "Blade Runner 2049", "La La Land", "Barbie"]
+  },
+  {
+    "name": "Ryan Reynolds",
+    "birthplace": "Vancouver, British Columbia",
+    "birthYear": 1976,
+    "citizenship": ["Canadian", "American"],
+    "shows": ["Deadpool", "Free Guy", "The Proposal", "Detective Pikachu", "The Adam Project"]
+  },
+  {
+    "name": "Rachel McAdams",
+    "birthplace": "London, Ontario",
+    "birthYear": 1978,
+    "citizenship": ["Canadian"],
+    "shows": ["The Notebook", "Mean Girls", "Spotlight", "Doctor Strange", "Game Night"]
+  },
+  {
+    "name": "Rachel Skarsten",
+    "birthplace": "Toronto, Ontario",
+    "birthYear": 1985,
+    "citizenship": ["Canadian", "Norwegian"],
+    "shows": ["Lost Girl", "Batwoman", "Reign", "Birds of Prey"]
+  },
+  {
+    "name": "Keanu Reeves",
+    "birthplace": "Beirut, Lebanon",
+    "birthYear": 1964,
+    "citizenship": ["Canadian", "American", "British"],
+    "shows": ["The Matrix", "John Wick", "Speed", "Bill & Ted's Excellent Adventure", "Constantine"]
+  },
+  {
+    "name": "Carrie-Anne Moss",
+    "birthplace": "Burnaby, British Columbia",
+    "birthYear": 1967,
+    "citizenship": ["Canadian"],
+    "shows": ["The Matrix", "Memento", "Jessica Jones", "The Matrix Reloaded", "The Matrix Resurrections"]
+  },
+  {
+    "name": "Shohreh Aghdashloo",
+    "birthplace": "Tehran, Iran",
+    "birthYear": 1952,
+    "citizenship": ["Canadian", "American", "Iranian"],
+    "shows": ["The Expanse", "House of Sand and Fog", "X-Men: The Last Stand", "Star Trek Beyond"]
+  },
+  {
+    "name": "Cara Gee",
+    "birthplace": "Calgary, Alberta",
+    "birthYear": 1983,
+    "citizenship": ["Canadian"],
+    "shows": ["The Expanse", "Strange Empire", "Tribal"]
+  },
+  {
+    "name": "Shawn Doyle",
+    "birthplace": "Wabush, Newfoundland",
+    "birthYear": 1968,
+    "citizenship": ["Canadian"],
+    "shows": ["The Expanse", "Big Love", "Fargo", "Hannibal"]
+  },
+  {
+    "name": "Elias Toufexis",
+    "birthplace": "Montreal, Quebec",
+    "birthYear": 1975,
+    "citizenship": ["Canadian", "American"],
+    "shows": ["The Expanse", "Deus Ex: Human Revolution", "Smallville", "The Strain"]
+  },
+  {
+    "name": "Kathleen Robertson",
+    "birthplace": "Hamilton, Ontario",
+    "birthYear": 1973,
+    "citizenship": ["Canadian"],
+    "shows": ["The Expanse", "Beverly Hills, 90210", "Murder in the First", "Boss"]
+  },
+  {
+    "name": "Frankie Adams",
+    "birthplace": "Savai'i, Samoa",
+    "birthYear": 1994,
+    "citizenship": ["New Zealand", "Samoan"],
+    "shows": ["The Expanse", "Shortland Street", "Mortal Engines"]
+  },
+  {
+    "name": "Athena Karkanis",
+    "birthplace": "Lethbridge, Alberta",
+    "birthYear": 1981,
+    "citizenship": ["Canadian"],
+    "shows": ["The Expanse", "Manifest", "Low Winter Sun", "The Border"]
+  },
+  {
+    "name": "Andrew Rotilio",
+    "birthplace": "Toronto, Ontario",
+    "birthYear": 1983,
+    "citizenship": ["Canadian"],
+    "shows": ["The Expanse", "Designated Survivor", "Nikita"]
+  },
+  {
+    "name": "Sandrine Holt",
+    "birthplace": "London, England",
+    "birthYear": 1972,
+    "citizenship": ["Canadian", "British"],
+    "shows": ["The Expanse", "House of Cards", "Homeland", "Underworld Awakening"]
+  },
+  {
+    "name": "Eugene Levy",
+    "birthplace": "Hamilton, Ontario",
+    "birthYear": 1946,
+    "citizenship": ["Canadian"],
+    "shows": ["Schitt's Creek", "American Pie", "Best in Show", "A Mighty Wind", "SCTV"]
+  },
+  {
+    "name": "Dan Levy",
+    "birthplace": "Toronto, Ontario",
+    "birthYear": 1983,
+    "citizenship": ["Canadian"],
+    "shows": ["Schitt's Creek", "Happiest Season", "The Great Canadian Baking Show"]
+  },
+  {
+    "name": "Catherine O'Hara",
+    "birthplace": "Toronto, Ontario",
+    "birthYear": 1954,
+    "citizenship": ["Canadian", "American"],
+    "shows": ["Schitt's Creek", "Home Alone", "Beetlejuice", "Best in Show", "SCTV"]
+  },
+  {
+    "name": "Annie Murphy",
+    "birthplace": "Ottawa, Ontario",
+    "birthYear": 1986,
+    "citizenship": ["Canadian"],
+    "shows": ["Schitt's Creek", "Kevin Can F**k Himself", "Russian Doll"]
+  },
+  {
+    "name": "Emily Hampshire",
+    "birthplace": "Montreal, Quebec",
+    "birthYear": 1981,
+    "citizenship": ["Canadian"],
+    "shows": ["Schitt's Creek", "12 Monkeys", "Station Eleven"]
+  },
+  {
+    "name": "Mackenzie Davis",
+    "birthplace": "Vancouver, British Columbia",
+    "birthYear": 1987,
+    "citizenship": ["Canadian"],
+    "shows": ["Station Eleven", "Halt and Catch Fire", "Blade Runner 2049", "Terminator: Dark Fate", "The Martian"]
+  },
+  {
+    "name": "Tatiana Maslany",
+    "birthplace": "Regina, Saskatchewan",
+    "birthYear": 1985,
+    "citizenship": ["Canadian"],
+    "shows": ["Orphan Black", "She-Hulk", "Station Eleven", "Perry Mason"]
+  },
+  {
+    "name": "Sandra Oh",
+    "birthplace": "Nepean, Ontario",
+    "birthYear": 1971,
+    "citizenship": ["Canadian", "American"],
+    "shows": ["Grey's Anatomy", "Killing Eve", "Sideways", "The Chair", "Under the Tuscan Sun"]
+  },
+  {
+    "name": "Elliot Page",
+    "birthplace": "Halifax, Nova Scotia",
+    "birthYear": 1987,
+    "citizenship": ["Canadian"],
+    "shows": ["Juno", "Inception", "The Umbrella Academy", "X-Men: Days of Future Past", "Whip It"]
+  }
+]

--- a/samples/CanadianContent/shows.json
+++ b/samples/CanadianContent/shows.json
@@ -1,0 +1,107 @@
+[
+  {
+    "title": "Schitt's Creek",
+    "type": "TV Series",
+    "years": "2015-2020",
+    "location": "Filmed in Ontario",
+    "canadianActors": ["Eugene Levy", "Dan Levy", "Catherine O'Hara", "Annie Murphy", "Emily Hampshire"]
+  },
+  {
+    "title": "The Expanse",
+    "type": "TV Series",
+    "years": "2015-2022",
+    "location": "Filmed in Toronto",
+    "canadianActors": ["Shohreh Aghdashloo", "Cara Gee", "Shawn Doyle", "Elias Toufexis", "Kathleen Robertson", "Frankie Adams", "Athena Karkanis", "Andrew Rotilio", "Sandrine Holt"]
+  },
+  {
+    "title": "Station Eleven",
+    "type": "TV Miniseries",
+    "years": "2021-2022",
+    "location": "Filmed in Toronto",
+    "canadianActors": ["Mackenzie Davis", "Emily Hampshire", "Tatiana Maslany"]
+  },
+  {
+    "title": "The Matrix",
+    "type": "Movie",
+    "years": "1999",
+    "location": "Filmed in Sydney",
+    "canadianActors": ["Keanu Reeves", "Carrie-Anne Moss"]
+  },
+  {
+    "title": "The Notebook",
+    "type": "Movie",
+    "years": "2004",
+    "location": "Filmed in South Carolina",
+    "canadianActors": ["Ryan Gosling", "Rachel McAdams"]
+  },
+  {
+    "title": "Blade Runner 2049",
+    "type": "Movie",
+    "years": "2017",
+    "location": "Filmed in Budapest",
+    "canadianActors": ["Ryan Gosling", "Mackenzie Davis"]
+  },
+  {
+    "title": "Deadpool",
+    "type": "Movie",
+    "years": "2016",
+    "location": "Filmed in Vancouver",
+    "canadianActors": ["Ryan Reynolds"]
+  },
+  {
+    "title": "Barbie",
+    "type": "Movie",
+    "years": "2023",
+    "location": "Filmed in London",
+    "canadianActors": ["Ryan Gosling"]
+  },
+  {
+    "title": "Lost Girl",
+    "type": "TV Series",
+    "years": "2010-2016",
+    "location": "Filmed in Toronto",
+    "canadianActors": ["Rachel Skarsten"]
+  },
+  {
+    "title": "Orphan Black",
+    "type": "TV Series",
+    "years": "2013-2017",
+    "location": "Filmed in Toronto",
+    "canadianActors": ["Tatiana Maslany"]
+  },
+  {
+    "title": "The Umbrella Academy",
+    "type": "TV Series",
+    "years": "2019-2023",
+    "location": "Filmed in Toronto",
+    "canadianActors": ["Elliot Page"]
+  },
+  {
+    "title": "Grey's Anatomy",
+    "type": "TV Series",
+    "years": "2005-present",
+    "location": "Filmed in Los Angeles",
+    "canadianActors": ["Sandra Oh"]
+  },
+  {
+    "title": "Killing Eve",
+    "type": "TV Series",
+    "years": "2018-2022",
+    "location": "Filmed in London",
+    "canadianActors": ["Sandra Oh"]
+  },
+  {
+    "title": "Juno",
+    "type": "Movie",
+    "years": "2007",
+    "location": "Filmed in Vancouver",
+    "canadianActors": ["Elliot Page"]
+  },
+  {
+    "title": "Batwoman",
+    "type": "TV Series",
+    "years": "2019-2022",
+    "location": "Filmed in Vancouver",
+    "canadianActors": ["Rachel Skarsten"]
+  }
+]


### PR DESCRIPTION
## Summary

Adds a new file-based app sample showcasing Canadian actors and shows, updates README with real examples from samples, and improves CI workflow.

### CanadianContent Sample

A queryable database of Canadian actors and shows. CanCon—it's the law! 🍁

```bash
dotnet run CanadianContent.cs --help
dotnet run CanadianContent.cs           # Show all actors and shows
dotnet run CanadianContent.cs ryan      # Actors named Ryan
dotnet run CanadianContent.cs expanse   # The Expanse with Canadian cast
dotnet run CanadianContent.cs toronto   # Shows filmed in Toronto
```

**Content:**
- 22 actors with citizenship data (multiple citizenships supported)
- 15 shows/movies with filming locations
- Cast from The Expanse, Schitt's Creek, The Matrix, Station Eleven, and more

### README Updates

- All code examples now reference actual samples (CanadianContent, DotNetReleases)
- New "Data Shape vs Data Results" section explaining the pivot table approach
- Added Samples section listing all sample directories

### CI Improvements

- Path filtering via `dorny/paths-filter` - skips build when only docs change
- Dedicated markdownlint job for markdown files
- Environment variables for cleaner dotnet output