### PR TITLE
Add FieldLayout enum for scalar field formatting

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.1.6
+#:package Markout@0.1.7
 // CanCon. It's the law!
 
 using System.Text.Json;

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -156,9 +156,10 @@ else if (query.Contains("gosling") || query.Contains("reynolds"))
 
     var view = new ActorFilmography
     {
-        Title = actor.Name,
+        Name = actor.Name,
         Birthplace = actor.Birthplace,
         BirthYear = actor.BirthYear,
+        Citizenship = string.Join(", ", actor.Citizenship),
         Filmography = actorShows.Select(s => new ShowRow
         {
             Title = s.Title,
@@ -306,16 +307,13 @@ public class ShowDetailView
     public List<ActorRow>? Cast { get; set; }
 }
 
-[MarkoutSerializable(TitleProperty = nameof(Title))]
+[MarkoutSerializable(TitleProperty = nameof(Name))]
 public class ActorFilmography
 {
-    [MarkoutIgnore]
-    public string Title { get; set; } = "";
-
+    public string Name { get; set; } = "";
     public string Birthplace { get; set; } = "";
-
-    [MarkoutPropertyName("Born")]
     public int BirthYear { get; set; }
+    public string Citizenship { get; set; } = "";
 
     [MarkoutSection(Name = "Filmography")]
     public List<ShowRow>? Filmography { get; set; }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -73,7 +73,7 @@ internal static class SerializerEmitter
             }
         }
 
-        EmitPropertySerializations(sb, type.Properties, "value", 2, 2, 0, type.RenderScalars);
+        EmitPropertySerializations(sb, type.Properties, "value", 2, 2, 0, type.RenderScalars, type.FieldLayout);
 
         sb.AppendLine("    }");
         sb.AppendLine("}");
@@ -301,9 +301,14 @@ internal static class SerializerEmitter
         int indentLevel,
         int baseHeadingLevel = 2,
         int nestingDepth = 0,
-        bool renderScalars = true)
+        bool renderScalars = true,
+        int fieldLayout = 0)
     {
         var indent = new string(' ', indentLevel * 4);
+
+        // Separate scalars from non-scalars for field layout handling
+        var scalarProps = new List<PropertyMetadata>();
+        var nonScalarProps = new List<PropertyMetadata>();
 
         foreach (var prop in properties)
         {
@@ -311,13 +316,25 @@ internal static class SerializerEmitter
                 continue;
 
             // Skip non-section properties if RenderScalars is false
-            // Only render sections and field collections when RenderScalars is false
             if (!renderScalars && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
                 continue;
 
+            if (IsScalarKind(prop.Kind) && !prop.IsSection)
+                scalarProps.Add(prop);
+            else
+                nonScalarProps.Add(prop);
+        }
+
+        // Emit scalars based on layout
+        if (renderScalars && scalarProps.Count > 0)
+        {
+            EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout);
+        }
+
+        // Emit non-scalar properties (sections, arrays, etc.)
+        foreach (var prop in nonScalarProps)
+        {
             var propAccess = $"{valueExpr}.{prop.Name}";
-            // For sections: use the larger of baseHeadingLevel or the explicit SectionLevel
-            // This ensures nested sections don't go "up" in heading hierarchy
             var effectiveSectionLevel = prop.IsSection 
                 ? System.Math.Max(prop.SectionLevel, baseHeadingLevel) 
                 : baseHeadingLevel;
@@ -377,37 +394,9 @@ internal static class SerializerEmitter
                 continue;
             }
 
+            // Non-scalar property handling
             switch (prop.Kind)
             {
-                case PropertyKind.String:
-                    sb.AppendLine($"{indent}if ({propAccess} != null)");
-                    sb.AppendLine($"{indent}    writer.WriteField(\"{EscapeString(prop.MdfName)}\", {propAccess});");
-                    break;
-
-                case PropertyKind.Boolean:
-                    if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
-                    {
-                        // Custom bool format
-                        sb.AppendLine($"{indent}writer.WriteField(\"{EscapeString(prop.MdfName)}\", {propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
-                    }
-                    else
-                    {
-                        sb.AppendLine($"{indent}writer.WriteField(\"{EscapeString(prop.MdfName)}\", {propAccess});");
-                    }
-                    break;
-
-                case PropertyKind.Int32:
-                case PropertyKind.Int64:
-                case PropertyKind.Double:
-                case PropertyKind.Decimal:
-                    sb.AppendLine($"{indent}writer.WriteField(\"{EscapeString(prop.MdfName)}\", {propAccess});");
-                    break;
-
-                case PropertyKind.DateTime:
-                case PropertyKind.DateTimeOffset:
-                    sb.AppendLine($"{indent}writer.WriteField(\"{EscapeString(prop.MdfName)}\", {propAccess});");
-                    break;
-
                 case PropertyKind.StringArray:
                     sb.AppendLine($"{indent}if ({propAccess} != null)");
                     sb.AppendLine($"{indent}    writer.WriteArray(\"{EscapeString(prop.MdfName)}\", {propAccess});");
@@ -443,18 +432,147 @@ internal static class SerializerEmitter
                         sb.AppendLine($"{indent}if ({propAccess} != null)");
                         sb.AppendLine($"{indent}{{");
                         sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.MdfName)}\");");
-                        EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth);
+                        EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth, true, fieldLayout);
                         sb.AppendLine($"{indent}}}");
                     }
                     break;
-
-                case PropertyKind.Other:
-                    // Try to call ToString() for unknown types
-                    sb.AppendLine($"{indent}if ({propAccess} != null)");
-                    sb.AppendLine($"{indent}    writer.WriteField(\"{EscapeString(prop.MdfName)}\", {propAccess}.ToString());");
-                    break;
             }
         }
+    }
+
+    private static void EmitScalarsWithLayout(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        int fieldLayout)
+    {
+        var indent = new string(' ', indentLevel * 4);
+
+        // FieldLayout: 0 = OneLine, 1 = LineBreaks, 2 = LineBreaksDoubleSpace, 3 = List
+        switch (fieldLayout)
+        {
+            case 0: // OneLine - emit as WriteCompactFields with inline MarkoutField array
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel);
+                break;
+
+            case 1: // LineBreaks
+                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: false);
+                break;
+
+            case 2: // LineBreaksDoubleSpace
+                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: true);
+                break;
+
+            case 3: // List
+                EmitListScalars(sb, scalarProps, valueExpr, indentLevel);
+                break;
+
+            default:
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel);
+                break;
+        }
+    }
+
+    private static void EmitOneLineScalars(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel)
+    {
+        var indent = new string(' ', indentLevel * 4);
+
+        // Build inline MarkoutField array
+        var fields = new List<string>();
+        foreach (var prop in scalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+            var valueStr = GetScalarValueExpression(prop, propAccess);
+            fields.Add($"new global::Markout.MarkoutField(\"{EscapeString(prop.MdfName)}\", {valueStr})");
+        }
+
+        sb.AppendLine($"{indent}writer.WriteCompactFields(new global::Markout.MarkoutField[] {{ {string.Join(", ", fields)} }});");
+    }
+
+    private static void EmitLineBreaksScalars(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        bool doubleSpace)
+    {
+        var indent = new string(' ', indentLevel * 4);
+        var methodName = doubleSpace ? "WriteField" : "WriteFieldNoBreak";
+
+        foreach (var prop in scalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+            
+            if (prop.Kind == PropertyKind.String)
+            {
+                sb.AppendLine($"{indent}if ({propAccess} != null)");
+                sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+            }
+            else if (prop.Kind == PropertyKind.Boolean)
+            {
+                if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+                {
+                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+                }
+            }
+            else
+            {
+                sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+            }
+        }
+    }
+
+    private static void EmitListScalars(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel)
+    {
+        var indent = new string(' ', indentLevel * 4);
+
+        foreach (var prop in scalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+            var valueStr = GetScalarValueExpression(prop, propAccess);
+            
+            if (prop.Kind == PropertyKind.String)
+            {
+                sb.AppendLine($"{indent}if ({propAccess} != null)");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.MdfName)}: {{{propAccess}}}\");");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}writer.WriteListItem($\"{EscapeString(prop.MdfName)}: {{{valueStr}}}\");");
+            }
+        }
+    }
+
+    private static string GetScalarValueExpression(PropertyMetadata prop, string propAccess)
+    {
+        if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+        {
+            return $"{propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\"";
+        }
+
+        return prop.Kind switch
+        {
+            PropertyKind.Boolean => $"{propAccess} ? \"yes\" : \"no\"",
+            PropertyKind.String => $"{propAccess} ?? \"\"",
+            PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                => $"{propAccess}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.DateTime or PropertyKind.DateTimeOffset
+                => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+            _ => $"{propAccess}?.ToString() ?? \"\""
+        };
     }
 
     private static void EmitTableSerialization(

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -35,6 +35,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public string? TitleContextProperty { get; }
     public string? DescriptionProperty { get; }
     public bool RenderScalars { get; }
+    public int FieldLayout { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
 
     public TypeMetadata(
@@ -47,6 +48,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         string? titleContextProperty = null,
         string? descriptionProperty = null,
         bool renderScalars = true,
+        int fieldLayout = 0,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
         Namespace = @namespace;
@@ -58,6 +60,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         TitleContextProperty = titleContextProperty;
         DescriptionProperty = descriptionProperty;
         RenderScalars = renderScalars;
+        FieldLayout = fieldLayout;
         Diagnostics = diagnostics ?? Array.Empty<DiagnosticInfo>();
     }
 

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -39,6 +39,7 @@ internal static class TypeParser
         string? titleContextProperty = null;
         string? descriptionProperty = null;
         bool renderScalars = true;
+        int fieldLayout = 0; // OneLine
         foreach (var named in serializableAttr.NamedArguments)
         {
             if (named.Key == "TitleProperty" && named.Value.Value is string tp)
@@ -49,9 +50,11 @@ internal static class TypeParser
                 descriptionProperty = dp;
             else if (named.Key == "RenderScalars" && named.Value.Value is bool rs)
                 renderScalars = rs;
+            else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
+                fieldLayout = fl;
         }
 
-        return ParseTypeSymbol(typeSymbol, context.SemanticModel.Compilation, null, titleProperty, titleContextProperty, descriptionProperty, renderScalars);
+        return ParseTypeSymbol(typeSymbol, context.SemanticModel.Compilation, null, titleProperty, titleContextProperty, descriptionProperty, renderScalars, fieldLayout);
     }
 
     public static ContextMetadata? ParseContext(
@@ -98,10 +101,11 @@ internal static class TypeParser
         string? titleProperty = null,
         string? titleContextProperty = null,
         string? descriptionProperty = null,
-        bool? renderScalars = null)
+        bool? renderScalars = null,
+        int? fieldLayout = null)
     {
         // If titleProperty/descriptionProperty not passed, try to get them from the type's [MarkoutSerializable] attribute
-        if (titleProperty == null || titleContextProperty == null || descriptionProperty == null || renderScalars == null)
+        if (titleProperty == null || titleContextProperty == null || descriptionProperty == null || renderScalars == null || fieldLayout == null)
         {
             var serializableAttr = typeSymbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutSerializableAttribute);
@@ -117,12 +121,16 @@ internal static class TypeParser
                         descriptionProperty ??= dp;
                     else if (named.Key == "RenderScalars" && named.Value.Value is bool rs)
                         renderScalars ??= rs;
+                    else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
+                        fieldLayout ??= fl;
                 }
             }
         }
 
         // Default to true if not specified
         renderScalars ??= true;
+        // Default to OneLine (0)
+        fieldLayout ??= 0;
 
         // Check if this type is used in a List<T> (table context)
         bool isInTableContext = IsUsedInList(typeSymbol, compilation);
@@ -160,6 +168,7 @@ internal static class TypeParser
             titleContextProperty,
             descriptionProperty,
             renderScalars.Value,
+            fieldLayout.Value,
             diagnostics);
     }
 

--- a/src/Markout/Attributes/MarkoutSerializableAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSerializableAttribute.cs
@@ -32,4 +32,10 @@ public sealed class MarkoutSerializableAttribute : Attribute
     /// properties are rendered. Default is true.
     /// </summary>
     public bool RenderScalars { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the layout for scalar fields.
+    /// Default is OneLine (pipe-separated on a single line).
+    /// </summary>
+    public FieldLayout FieldLayout { get; set; } = FieldLayout.OneLine;
 }

--- a/src/Markout/FieldLayout.cs
+++ b/src/Markout/FieldLayout.cs
@@ -1,0 +1,32 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies how scalar fields are rendered in the output.
+/// </summary>
+public enum FieldLayout
+{
+    /// <summary>
+    /// Fields on a single line, separated by pipes.
+    /// Example: Birthplace: London | Born: 1980 | Citizenship: Canadian
+    /// </summary>
+    OneLine,
+
+    /// <summary>
+    /// Each field on its own line, no trailing spaces.
+    /// </summary>
+    LineBreaks,
+
+    /// <summary>
+    /// Each field on its own line with trailing double-space for markdown soft breaks.
+    /// Example: Birthplace: London··
+    ///          Born: 1980··
+    /// </summary>
+    LineBreaksDoubleSpace,
+
+    /// <summary>
+    /// Fields as a bullet list.
+    /// Example: - Birthplace: London
+    ///          - Born: 1980
+    /// </summary>
+    List
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.1.6</Version>
+    <Version>0.1.7</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -326,6 +326,95 @@ public sealed class MarkoutWriter
     }
 
     /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, string? value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value ?? string.Empty);
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, bool value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value ? "yes" : "no");
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, int value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value.ToString(CultureInfo.InvariantCulture));
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, long value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value.ToString(CultureInfo.InvariantCulture));
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, decimal value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value.ToString(CultureInfo.InvariantCulture));
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a single bullet list item.
+    /// </summary>
+    public void WriteListItem(string text)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        _writer.Write("- ");
+        _writer.WriteLine(text);
+        _hasContent = true;
+    }
+
+    /// <summary>
     /// Writes multiple key-value fields on a single line, separated by pipes.
     /// Useful for compact summary lines with essential metadata.
     /// </summary>


### PR DESCRIPTION
## Summary

Adds a new `FieldLayout` enum to control how scalar fields are rendered in the output.

### New FieldLayout options

| Layout | Output |
|--------|--------|
| **OneLine** (new default) | `Name: X \| Born: 1980 \| Citizenship: Canadian` |
| **LineBreaks** | One field per line, no trailing spaces |
| **LineBreaksDoubleSpace** | One field per line with `  ` (old default) |
| **List** | `- Name: X`<br>`- Born: 1980` |

### Usage

```csharp
// Uses default (OneLine)
[MarkoutSerializable(TitleProperty = nameof(Name))]
public class ActorFilmography
{
    public string Name { get; set; }
    public string Birthplace { get; set; }
    public int BirthYear { get; set; }
    public string Citizenship { get; set; }
}

// Or explicitly specify layout
[MarkoutSerializable(FieldLayout = FieldLayout.List)]
public class MyType { ... }
```

### Breaking change

Default field layout changed from `LineBreaksDoubleSpace` to `OneLine`.

### Other changes

- Adds `WriteFieldNoBreak()` methods for LineBreaks layout
- Adds `WriteListItem()` method for List layout
- Simplifies CanadianContent sample to use plain properties
- Bumps version to 0.1.7