### PR TITLE
Code review improvements: safety, generator, modernization

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.1.7
+#:package Markout@0.2.0
 // CanCon. It's the law!
 
 using System.Text.Json;

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.1.6
+#:package Markout@0.2.0
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.1.8
+#:package Markout@0.2.0
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/Serialization/SectionFiltering.cs
+++ b/samples/Serialization/SectionFiltering.cs
@@ -13,20 +13,20 @@ public static class SectionFiltering
     public static void IncludeSpecificSections()
     {
         #region IncludeSpecificSections
-        var writer = new MarkoutWriter
+        var writer = new MarkoutWriter(new MarkoutWriterOptions
         {
             // Only include sections 1 and 3 (H2 boundaries)
             IncludeSections = new HashSet<int> { 1, 3 }
-        };
+        });
 
         writer.WriteHeading(1, "Product Details");
-        
+
         writer.WriteHeading(2, "Overview");        // Section 1 - included
         writer.WriteField("Name", "Widget Pro");
-        
+
         writer.WriteHeading(2, "Specifications");  // Section 2 - excluded
         writer.WriteField("Weight", "1.5 kg");
-        
+
         writer.WriteHeading(2, "Reviews");         // Section 3 - included
         writer.WriteField("Rating", "4.5 stars");
 
@@ -35,11 +35,11 @@ public static class SectionFiltering
         //
         // ## Overview
         //
-        // Name: Widget Pro  
+        // Name: Widget Pro
         //
         // ## Reviews
         //
-        // Rating: 4.5 stars  
+        // Rating: 4.5 stars
         #endregion
     }
 
@@ -49,20 +49,20 @@ public static class SectionFiltering
     public static void ExcludeSpecificSections()
     {
         #region ExcludeSpecificSections
-        var writer = new MarkoutWriter
+        var writer = new MarkoutWriter(new MarkoutWriterOptions
         {
             // Exclude section 2 (Specifications)
             ExcludeSections = new HashSet<int> { 2 }
-        };
+        });
 
         writer.WriteHeading(1, "Product Details");
-        
+
         writer.WriteHeading(2, "Overview");        // Section 1 - included
         writer.WriteField("Name", "Widget Pro");
-        
+
         writer.WriteHeading(2, "Specifications");  // Section 2 - excluded
         writer.WriteField("Weight", "1.5 kg");
-        
+
         writer.WriteHeading(2, "Reviews");         // Section 3 - included
         writer.WriteField("Rating", "4.5 stars");
 
@@ -76,9 +76,14 @@ public static class SectionFiltering
     public static void FilterViaContext()
     {
         #region FilterViaContext
-        var context = SampleContext.Default;
-        context.ExcludeSections = new HashSet<int> { 2 };  // Skip section 2
-        context.BoldFieldNames = true;                      // Enable bold field names
+        var context = new SampleContext
+        {
+            Options = new MarkoutWriterOptions
+            {
+                ExcludeSections = new HashSet<int> { 2 },  // Skip section 2
+                BoldFieldNames = true                       // Enable bold field names
+            }
+        };
 
         ProductView product = new ProductView
         {
@@ -91,9 +96,9 @@ public static class SectionFiltering
         string markdown = MarkoutSerializer.Serialize(product, context);
         // # Widget Pro
         //
-        // **Category:** Electronics  
-        // **Price:** 99.99  
-        // **InStock:** yes  
+        // **Category:** Electronics
+        // **Price:** 99.99
+        // **InStock:** yes
         #endregion
 
         Console.WriteLine(markdown);

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -32,8 +32,11 @@ internal static class SerializerEmitter
         sb.AppendLine();
         sb.AppendLine($"    public override void Serialize(global::Markout.MarkoutWriter writer, {type.FullTypeName} value)");
         sb.AppendLine("    {");
-        sb.AppendLine("        if (value == null) return;");
-        sb.AppendLine();
+        if (!type.IsValueType)
+        {
+            sb.AppendLine("        if (value == null) return;");
+            sb.AppendLine();
+        }
 
         // Emit title (H1) if TitleProperty is set
         if (!string.IsNullOrEmpty(type.TitleProperty))
@@ -180,7 +183,7 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}new()");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    Name = \"{prop.Name}\",");
-            sb.AppendLine($"{indent}    DisplayName = \"{EscapeString(prop.MdfName)}\",");
+            sb.AppendLine($"{indent}    DisplayName = \"{EscapeString(prop.DisplayName)}\",");
             sb.AppendLine($"{indent}    TypeName = \"{EscapeString(GetSimpleTypeName(prop.TypeName))}\",");
             sb.AppendLine($"{indent}    Rendering = \"{EscapeString(rendering)}\",");
             
@@ -215,7 +218,7 @@ internal static class SerializerEmitter
             
             // In table context, only scalars work
             if (IsScalarKind(prop.Kind))
-                return "Column" + (prop.Name != prop.MdfName ? $" \"{prop.MdfName}\"" : "");
+                return "Column" + (prop.Name != prop.DisplayName ? $" \"{prop.DisplayName}\"" : "");
             
             // Unsupported patterns are skipped
             if (prop.IsUnsupportedInTable)
@@ -230,7 +233,7 @@ internal static class SerializerEmitter
         // Document context - [MarkoutIgnoreInTable] has no effect here
         if (prop.IsSection)
         {
-            var sectionName = prop.SectionName ?? prop.MdfName;
+            var sectionName = prop.SectionName ?? prop.DisplayName;
             if (prop.Kind == PropertyKind.FieldCollection)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (field table)";
             if (prop.Kind == PropertyKind.ComplexArray)
@@ -305,7 +308,7 @@ internal static class SerializerEmitter
         int baseHeadingLevel = 2,
         int nestingDepth = 0,
         bool renderScalars = true,
-        int fieldLayout = 0)
+        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine)
     {
         var indent = new string(' ', indentLevel * 4);
 
@@ -344,7 +347,7 @@ internal static class SerializerEmitter
 
             if (prop.IsSection)
             {
-                var sectionName = prop.SectionName ?? prop.MdfName;
+                var sectionName = prop.SectionName ?? prop.DisplayName;
 
                 if (prop.Kind == PropertyKind.FieldCollection)
                 {
@@ -411,7 +414,7 @@ internal static class SerializerEmitter
             {
                 case PropertyKind.StringArray:
                     sb.AppendLine($"{indent}if ({propAccess} != null)");
-                    sb.AppendLine($"{indent}    writer.WriteArray(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+                    sb.AppendLine($"{indent}    writer.WriteArray(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
                     break;
 
                 case PropertyKind.FieldCollection:
@@ -431,7 +434,7 @@ internal static class SerializerEmitter
                     {
                         sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Any())");
                         sb.AppendLine($"{indent}{{");
-                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.MdfName)}\");");
+                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.DisplayName)}\");");
                         if (prop.ElementHasNestedContent)
                         {
                             EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, baseHeadingLevel, nestingDepth);
@@ -449,7 +452,7 @@ internal static class SerializerEmitter
                     {
                         sb.AppendLine($"{indent}if ({propAccess} != null)");
                         sb.AppendLine($"{indent}{{");
-                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.MdfName)}\");");
+                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.DisplayName)}\");");
                         EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth, true, fieldLayout);
                         sb.AppendLine($"{indent}}}");
                     }
@@ -463,26 +466,23 @@ internal static class SerializerEmitter
         List<PropertyMetadata> scalarProps,
         string valueExpr,
         int indentLevel,
-        int fieldLayout)
+        FieldLayoutKind fieldLayout)
     {
-        var indent = new string(' ', indentLevel * 4);
-
-        // FieldLayout: 0 = OneLine, 1 = LineBreaks, 2 = LineBreaksDoubleSpace, 3 = List
         switch (fieldLayout)
         {
-            case 0: // OneLine - emit as WriteCompactFields with inline MarkoutField array
+            case FieldLayoutKind.OneLine:
                 EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel);
                 break;
 
-            case 1: // LineBreaks
+            case FieldLayoutKind.LineBreaks:
                 EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: false);
                 break;
 
-            case 2: // LineBreaksDoubleSpace
+            case FieldLayoutKind.LineBreaksDoubleSpace:
                 EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: true);
                 break;
 
-            case 3: // List
+            case FieldLayoutKind.List:
                 EmitListScalars(sb, scalarProps, valueExpr, indentLevel);
                 break;
 
@@ -506,7 +506,7 @@ internal static class SerializerEmitter
         {
             var propAccess = $"{valueExpr}.{prop.Name}";
             var valueStr = GetScalarValueExpression(prop, propAccess);
-            fields.Add($"new global::Markout.MarkoutField(\"{EscapeString(prop.MdfName)}\", {valueStr})");
+            fields.Add($"new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr})");
         }
 
         sb.AppendLine($"{indent}writer.WriteCompactFields(new global::Markout.MarkoutField[] {{ {string.Join(", ", fields)} }});");
@@ -529,22 +529,22 @@ internal static class SerializerEmitter
             if (prop.Kind == PropertyKind.String)
             {
                 sb.AppendLine($"{indent}if ({propAccess} != null)");
-                sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+                sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
             }
             else if (prop.Kind == PropertyKind.Boolean)
             {
                 if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
                 {
-                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
+                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
                 }
                 else
                 {
-                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
                 }
             }
             else
             {
-                sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.MdfName)}\", {propAccess});");
+                sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
             }
         }
     }
@@ -565,11 +565,11 @@ internal static class SerializerEmitter
             if (prop.Kind == PropertyKind.String)
             {
                 sb.AppendLine($"{indent}if ({propAccess} != null)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.MdfName)}: {{{propAccess}}}\");");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
             }
             else
             {
-                sb.AppendLine($"{indent}writer.WriteListItem($\"{EscapeString(prop.MdfName)}: {{{valueStr}}}\");");
+                sb.AppendLine($"{indent}writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
         }
     }
@@ -608,7 +608,7 @@ internal static class SerializerEmitter
         var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
 
         // Build header array
-        var headers = string.Join(", ", visibleProps.Select(p => $"\"{EscapeString(p.MdfName)}\""));
+        var headers = string.Join(", ", visibleProps.Select(p => $"\"{EscapeString(p.DisplayName)}\""));
         sb.AppendLine($"{indent}writer.WriteTableStart({headers});");
 
         sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -35,7 +35,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public string? TitleContextProperty { get; }
     public string? DescriptionProperty { get; }
     public bool RenderScalars { get; }
-    public int FieldLayout { get; }
+    public FieldLayoutKind FieldLayout { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
 
     public TypeMetadata(
@@ -48,7 +48,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         string? titleContextProperty = null,
         string? descriptionProperty = null,
         bool renderScalars = true,
-        int fieldLayout = 0,
+        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
         Namespace = @namespace;
@@ -81,7 +81,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
 internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
 {
     public string Name { get; }
-    public string MdfName { get; }
+    public string DisplayName { get; }
     public string TypeName { get; }
     public PropertyKind Kind { get; }
     public bool IsIgnored { get; }
@@ -116,7 +116,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? boolFalseValue = null)
     {
         Name = name;
-        MdfName = mdfName;
+        DisplayName = mdfName;
         TypeName = typeName;
         Kind = kind;
         IsIgnored = isIgnored;
@@ -148,6 +148,18 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             return (Name?.GetHashCode() ?? 0) * 397 ^ (TypeName?.GetHashCode() ?? 0);
         }
     }
+}
+
+/// <summary>
+/// How scalar fields are laid out in generated code.
+/// Values mirror the runtime Markout.FieldLayout enum.
+/// </summary>
+internal enum FieldLayoutKind
+{
+    OneLine = 0,
+    LineBreaks = 1,
+    LineBreaksDoubleSpace = 2,
+    List = 3
 }
 
 /// <summary>

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -39,7 +39,7 @@ internal static class TypeParser
         string? titleContextProperty = null;
         string? descriptionProperty = null;
         bool renderScalars = true;
-        int fieldLayout = 0; // OneLine
+        var fieldLayout = FieldLayoutKind.OneLine;
         foreach (var named in serializableAttr.NamedArguments)
         {
             if (named.Key == "TitleProperty" && named.Value.Value is string tp)
@@ -51,7 +51,7 @@ internal static class TypeParser
             else if (named.Key == "RenderScalars" && named.Value.Value is bool rs)
                 renderScalars = rs;
             else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
-                fieldLayout = fl;
+                fieldLayout = (FieldLayoutKind)fl;
         }
 
         return ParseTypeSymbol(typeSymbol, context.SemanticModel.Compilation, null, titleProperty, titleContextProperty, descriptionProperty, renderScalars, fieldLayout);
@@ -102,7 +102,7 @@ internal static class TypeParser
         string? titleContextProperty = null,
         string? descriptionProperty = null,
         bool? renderScalars = null,
-        int? fieldLayout = null)
+        FieldLayoutKind? fieldLayout = null)
     {
         // If titleProperty/descriptionProperty not passed, try to get them from the type's [MarkoutSerializable] attribute
         if (titleProperty == null || titleContextProperty == null || descriptionProperty == null || renderScalars == null || fieldLayout == null)
@@ -122,18 +122,15 @@ internal static class TypeParser
                     else if (named.Key == "RenderScalars" && named.Value.Value is bool rs)
                         renderScalars ??= rs;
                     else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
-                        fieldLayout ??= fl;
+                        fieldLayout ??= (FieldLayoutKind)fl;
                 }
             }
         }
 
         // Default to true if not specified
         renderScalars ??= true;
-        // Default to OneLine (0)
-        fieldLayout ??= 0;
-
-        // Check if this type is used in a List<T> (table context)
-        bool isInTableContext = IsUsedInList(typeSymbol, compilation);
+        // Default to OneLine
+        fieldLayout ??= FieldLayoutKind.OneLine;
 
         var properties = new List<PropertyMetadata>();
         var diagnostics = new List<DiagnosticInfo>();
@@ -149,7 +146,7 @@ internal static class TypeParser
             if (prop.GetMethod == null)
                 continue;
 
-            var propMeta = ParseProperty(prop, compilation, isInTableContext, diagnostics);
+            var propMeta = ParseProperty(prop, compilation, diagnostics);
             if (propMeta != null)
                 properties.Add(propMeta);
         }
@@ -188,9 +185,8 @@ internal static class TypeParser
     }
 
     private static PropertyMetadata? ParseProperty(
-        IPropertySymbol prop, 
+        IPropertySymbol prop,
         Compilation compilation,
-        bool isInTableContext,
         List<DiagnosticInfo> diagnostics)
     {
         var isIgnored = HasAttribute(prop, MarkoutIgnoreAttribute);
@@ -215,13 +211,13 @@ internal static class TypeParser
             }
         }
 
-        var mdfName = prop.Name;
+        var displayName = prop.Name;
         var nameAttr = prop.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutPropertyNameAttribute);
         if (nameAttr?.ConstructorArguments.Length > 0 &&
             nameAttr.ConstructorArguments[0].Value is string customName)
         {
-            mdfName = customName;
+            displayName = customName;
         }
 
         // Parse [MarkoutBoolFormat] attribute
@@ -237,7 +233,7 @@ internal static class TypeParser
                 boolFalseValue = fv;
         }
 
-        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty) = DeterminePropertyKind(prop.Type, compilation, diagnostics);
+        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty) = DeterminePropertyKind(prop.Type, compilation, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
 
         // Determine if property is unsupported in table context
         bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind);
@@ -256,7 +252,7 @@ internal static class TypeParser
 
         return new PropertyMetadata(
             prop.Name,
-            mdfName,
+            displayName,
             prop.Type.ToDisplayString(),
             kind,
             isIgnored,
@@ -274,7 +270,7 @@ internal static class TypeParser
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty)
-        DeterminePropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null)
+        DeterminePropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
         var typeName = type.ToDisplayString();
 
@@ -295,12 +291,12 @@ internal static class TypeParser
             SpecialType.System_Int64 => (PropertyKind.Int64, null, null, false, null),
             SpecialType.System_Double => (PropertyKind.Double, null, null, false, null),
             SpecialType.System_Decimal => (PropertyKind.Decimal, null, null, false, null),
-            _ => DetermineComplexPropertyKind(type, compilation, diagnostics)
+            _ => DetermineComplexPropertyKind(type, compilation, diagnostics, propertyName, propertyLocation)
         };
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty)
-        DetermineComplexPropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null)
+        DetermineComplexPropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
         var typeName = type.ToDisplayString();
 
@@ -322,7 +318,7 @@ internal static class TypeParser
             if (elementType.SpecialType == SpecialType.System_String)
                 return (PropertyKind.StringArray, null, null, false, null);
 
-            var elementProps = GetTypeProperties(elementType, compilation, true, diagnostics);
+            var elementProps = GetTypeProperties(elementType, compilation, diagnostics);
             var hasNested = HasNestedContent(elementProps);
             var titleProp = GetTitleProperty(elementType);
             return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp);
@@ -331,6 +327,22 @@ internal static class TypeParser
         // Check for IEnumerable<T> / List<T> / etc.
         if (type is INamedTypeSymbol namedType)
         {
+            // Detect Dictionary<TKey, TValue> before IEnumerable<T> since dictionaries implement IEnumerable<KeyValuePair>
+            var isDictionary = namedType.AllInterfaces.Any(i =>
+                i.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IDictionary<TKey, TValue>");
+
+            if (isDictionary)
+            {
+                if (diagnostics != null && propertyName != null)
+                {
+                    diagnostics.Add(new DiagnosticInfo(
+                        DiagnosticDescriptors.DictionaryProperty,
+                        propertyLocation,
+                        propertyName));
+                }
+                return (PropertyKind.Other, null, null, false, null);
+            }
+
             var enumerableInterface = namedType.AllInterfaces
                 .FirstOrDefault(i => i.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>");
 
@@ -379,7 +391,7 @@ internal static class TypeParser
                     if (elementType.SpecialType == SpecialType.System_String)
                         return (PropertyKind.StringArray, null, null, false, null);
 
-                    var elementProps = GetTypeProperties(elementType, compilation, true, diagnostics);
+                    var elementProps = GetTypeProperties(elementType, compilation, diagnostics);
                     var hasNested = HasNestedContent(elementProps);
                     var titleProp = GetTitleProperty(elementType);
                     return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp);
@@ -390,7 +402,7 @@ internal static class TypeParser
         // Nested object
         if (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct)
         {
-            var props = GetTypeProperties(type, compilation, false, diagnostics);
+            var props = GetTypeProperties(type, compilation, diagnostics);
             if (props.Count > 0)
                 return (PropertyKind.NestedObject, null, props, false, null);
         }
@@ -425,9 +437,8 @@ internal static class TypeParser
     }
 
     private static IReadOnlyList<PropertyMetadata> GetTypeProperties(
-        ITypeSymbol type, 
+        ITypeSymbol type,
         Compilation compilation,
-        bool isInTableContext = false,
         List<DiagnosticInfo>? diagnostics = null)
     {
         var properties = new List<PropertyMetadata>();
@@ -447,72 +458,12 @@ internal static class TypeParser
             if (prop.GetMethod == null)
                 continue;
 
-            var propMeta = ParseProperty(prop, compilation, isInTableContext, diagnostics);
+            var propMeta = ParseProperty(prop, compilation, diagnostics);
             if (propMeta != null)
                 properties.Add(propMeta);
         }
 
         return properties;
-    }
-
-    private static bool IsUsedInList(INamedTypeSymbol type, Compilation compilation)
-    {
-        // Search through all syntax trees to find property declarations
-        foreach (var syntaxTree in compilation.SyntaxTrees)
-        {
-            var semanticModel = compilation.GetSemanticModel(syntaxTree);
-            var root = syntaxTree.GetRoot();
-            
-            foreach (var node in root.DescendantNodes())
-            {
-                if (node is PropertyDeclarationSyntax propDecl)
-                {
-                    var propSymbol = semanticModel.GetDeclaredSymbol(propDecl) as IPropertySymbol;
-                    if (propSymbol != null && IsGenericListOf(propSymbol.Type, type))
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        
-        return false;
-    }
-
-    private static bool IsGenericListOf(ITypeSymbol propertyType, INamedTypeSymbol targetType)
-    {
-        if (propertyType is not INamedTypeSymbol namedType)
-            return false;
-
-        // Check if it's a generic type
-        if (!namedType.IsGenericType && namedType.TypeArguments.Length == 0)
-            return false;
-
-        // Check direct type arguments (List<TargetType>, IEnumerable<TargetType>, etc.)
-        if (namedType.TypeArguments.Length > 0)
-        {
-            var firstArg = namedType.TypeArguments[0];
-            if (SymbolEqualityComparer.Default.Equals(firstArg, targetType))
-                return true;
-        }
-
-        // Check through all interfaces for IEnumerable<TargetType>
-        foreach (var iface in namedType.AllInterfaces)
-        {
-            if (iface.TypeArguments.Length > 0 &&
-                SymbolEqualityComparer.Default.Equals(iface.TypeArguments[0], targetType))
-            {
-                var ifaceTypeName = iface.OriginalDefinition.ToDisplayString();
-                if (ifaceTypeName == "System.Collections.Generic.IEnumerable<T>" ||
-                    ifaceTypeName == "System.Collections.Generic.ICollection<T>" ||
-                    ifaceTypeName == "System.Collections.Generic.IList<T>")
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     private static bool IsScalarKind(PropertyKind kind)

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.1.8</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutSchemaInfo.cs
+++ b/src/Markout/MarkoutSchemaInfo.cs
@@ -13,12 +13,12 @@ public sealed class MarkoutSchemaInfo
     /// <summary>
     /// Schema when rendered as a document root.
     /// </summary>
-    public IReadOnlyList<MarkoutPropertySchema> AsDocument { get; init; } = Array.Empty<MarkoutPropertySchema>();
+    public IReadOnlyList<MarkoutPropertySchema> AsDocument { get; init; } = [];
     
     /// <summary>
     /// Schema when rendered as a table row (inside List&lt;T&gt;).
     /// </summary>
-    public IReadOnlyList<MarkoutPropertySchema> AsTableItem { get; init; } = Array.Empty<MarkoutPropertySchema>();
+    public IReadOnlyList<MarkoutPropertySchema> AsTableItem { get; init; } = [];
     
     /// <summary>
     /// Formats the schema as a tree structure for display.
@@ -97,5 +97,5 @@ public sealed class MarkoutPropertySchema
     /// <summary>
     /// Child properties (for nested objects or list elements).
     /// </summary>
-    public IReadOnlyList<MarkoutPropertySchema> Children { get; init; } = Array.Empty<MarkoutPropertySchema>();
+    public IReadOnlyList<MarkoutPropertySchema> Children { get; init; } = [];
 }

--- a/src/Markout/MarkoutSerializerContext.cs
+++ b/src/Markout/MarkoutSerializerContext.cs
@@ -14,29 +14,9 @@ namespace Markout;
 public abstract class MarkoutSerializerContext
 {
     /// <summary>
-    /// Gets or sets whether field names should be rendered in bold.
-    /// When true, field names are wrapped in ** for markdown bold formatting.
+    /// Gets or sets the writer options for controlling output formatting.
     /// </summary>
-    public bool BoldFieldNames { get; set; }
-
-    /// <summary>
-    /// Gets or sets the sections to include (1-based, H2 boundaries).
-    /// If set, only these sections are written. If null, all sections are included.
-    /// </summary>
-    public HashSet<int>? IncludeSections { get; set; }
-
-    /// <summary>
-    /// Gets or sets the sections to exclude (1-based, H2 boundaries).
-    /// These sections are skipped even if in IncludeSections.
-    /// </summary>
-    public HashSet<int>? ExcludeSections { get; set; }
-
-    /// <summary>
-    /// Gets or sets whether to include the description paragraph.
-    /// When false, the description (from DescriptionProperty) is suppressed.
-    /// Default is true.
-    /// </summary>
-    public bool IncludeDescription { get; set; } = true;
+    public MarkoutWriterOptions Options { get; set; } = new();
 
     /// <summary>
     /// Gets the type info for the specified type, or null if not registered.
@@ -60,7 +40,7 @@ public abstract class MarkoutSerializerContext
     /// <returns>The Markdown string representation.</returns>
     public string Serialize<T>(T value)
     {
-        return Serialize(value, BuildOptions());
+        return Serialize(value, Options);
     }
 
     /// <summary>
@@ -93,7 +73,7 @@ public abstract class MarkoutSerializerContext
     /// <param name="output">The TextWriter to write to.</param>
     public void Serialize<T>(T value, TextWriter output)
     {
-        Serialize(value, output, BuildOptions());
+        Serialize(value, output, Options);
     }
 
     /// <summary>
@@ -116,16 +96,5 @@ public abstract class MarkoutSerializerContext
         var writer = new MarkoutWriter(output, options);
         typeInfo.Serialize(writer, value);
         writer.Flush();
-    }
-
-    private MarkoutWriterOptions BuildOptions()
-    {
-        return new MarkoutWriterOptions
-        {
-            BoldFieldNames = BoldFieldNames,
-            IncludeSections = IncludeSections,
-            ExcludeSections = ExcludeSections,
-            IncludeDescription = IncludeDescription
-        };
     }
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -15,6 +15,8 @@ namespace Markout;
 /// <seealso href="../../samples/Serialization/SectionFiltering.cs">Section filtering examples</seealso>
 public sealed class MarkoutWriter
 {
+    private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
+
     private readonly TextWriter _writer;
     private readonly MarkoutWriterOptions _options;
     private bool _needsBlankLine;
@@ -70,54 +72,29 @@ public sealed class MarkoutWriter
     }
 
     /// <summary>
-    /// Gets or sets whether field names should be rendered in bold.
-    /// When true, field names are wrapped in ** for markdown bold formatting.
+    /// Gets whether field names should be rendered in bold.
     /// </summary>
-    public bool BoldFieldNames
-    {
-        get => _options.BoldFieldNames;
-        set => _options.BoldFieldNames = value;
-    }
+    public bool BoldFieldNames => _options.BoldFieldNames;
 
     /// <summary>
-    /// Gets or sets the sections to include (1-based, H2 boundaries).
-    /// If set, only these sections are written. If null, all sections are included.
+    /// Gets the sections to include (1-based, H2 boundaries).
     /// </summary>
-    public HashSet<int>? IncludeSections
-    {
-        get => _options.IncludeSections;
-        set => _options.IncludeSections = value;
-    }
+    public HashSet<int>? IncludeSections => _options.IncludeSections;
 
     /// <summary>
-    /// Gets or sets the sections to exclude (1-based, H2 boundaries).
-    /// These sections are skipped even if in IncludeSections.
+    /// Gets the sections to exclude (1-based, H2 boundaries).
     /// </summary>
-    public HashSet<int>? ExcludeSections
-    {
-        get => _options.ExcludeSections;
-        set => _options.ExcludeSections = value;
-    }
+    public HashSet<int>? ExcludeSections => _options.ExcludeSections;
 
     /// <summary>
-    /// Gets or sets whether to include the description paragraph.
-    /// When false, the description is suppressed. Default is true.
+    /// Gets whether to include the description paragraph.
     /// </summary>
-    public bool IncludeDescription
-    {
-        get => _options.IncludeDescription;
-        set => _options.IncludeDescription = value;
-    }
+    public bool IncludeDescription => _options.IncludeDescription;
 
     /// <summary>
-    /// Gets or sets whether to include icons in tree nodes.
-    /// When false, only the label is rendered. Default is true.
+    /// Gets whether to include icons in tree nodes.
     /// </summary>
-    public bool IncludeIcons
-    {
-        get => _options.IncludeIcons;
-        set => _options.IncludeIcons = value;
-    }
+    public bool IncludeIcons => _options.IncludeIcons;
 
     /// <summary>
     /// Flushes any buffered output to the underlying stream.
@@ -129,9 +106,9 @@ public sealed class MarkoutWriter
         // Content before first H2 (section 0) is always included
         if (_currentSection == 0)
             return true;
-        if (IncludeSections?.Count > 0 && !IncludeSections.Contains(_currentSection))
+        if (_options.IncludeSections?.Count > 0 && !_options.IncludeSections.Contains(_currentSection))
             return false;
-        if (ExcludeSections?.Contains(_currentSection) == true)
+        if (_options.ExcludeSections?.Contains(_currentSection) == true)
             return false;
         return true;
     }
@@ -188,7 +165,7 @@ public sealed class MarkoutWriter
             _writer.WriteLine();
         }
 
-        _writer.Write(new string('#', level));
+        _writer.Write(HeadingPrefixes[level]);
         _writer.Write(' ');
         _writer.Write(text);
 
@@ -447,6 +424,51 @@ public sealed class MarkoutWriter
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         _writer.WriteLine(value.ToString(CultureInfo.InvariantCulture));
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, double value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value.ToString(CultureInfo.InvariantCulture));
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, DateTime value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value.ToString("O", CultureInfo.InvariantCulture));
+        _hasContent = true;
+    }
+
+    /// <summary>
+    /// Writes a key-value field without trailing spaces (no markdown soft break).
+    /// Use for LineBreaks layout where each field is on its own line.
+    /// </summary>
+    public void WriteFieldNoBreak(string key, DateTimeOffset value)
+    {
+        if (_sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+        WriteFieldName(key);
+        _writer.WriteLine(value.ToString("O", CultureInfo.InvariantCulture));
         _hasContent = true;
     }
 
@@ -723,7 +745,7 @@ public sealed class MarkoutWriter
     {
         if (nodes == null || _sectionExcluded) return;
         
-        var nodeList = nodes.ToList();
+        var nodeList = nodes as IList<TreeNode> ?? [.. nodes];
         for (int i = 0; i < nodeList.Count; i++)
         {
             var isLast = i == nodeList.Count - 1;

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -5,33 +5,104 @@ namespace Markout;
 /// </summary>
 public class MarkoutWriterOptions
 {
+    private bool _isReadOnly;
+    private bool _includeIcons = true;
+    private bool _includeDescription = true;
+    private bool _boldFieldNames;
+    private HashSet<int>? _includeSections;
+    private HashSet<int>? _excludeSections;
+
     /// <summary>
-    /// Gets the default options instance.
+    /// Gets the default options instance. This instance is read-only.
     /// </summary>
-    public static MarkoutWriterOptions Default { get; } = new();
+    public static MarkoutWriterOptions Default { get; } = CreateDefaultOptions();
+
+    private static MarkoutWriterOptions CreateDefaultOptions()
+    {
+        var options = new MarkoutWriterOptions();
+        options.MakeReadOnly();
+        return options;
+    }
 
     /// <summary>
     /// Whether to include icons in tree nodes. Default is true.
     /// </summary>
-    public bool IncludeIcons { get; set; } = true;
+    public bool IncludeIcons
+    {
+        get => _includeIcons;
+        set
+        {
+            ThrowIfReadOnly();
+            _includeIcons = value;
+        }
+    }
 
     /// <summary>
     /// Whether to include the description paragraph (from DescriptionProperty). Default is true.
     /// </summary>
-    public bool IncludeDescription { get; set; } = true;
+    public bool IncludeDescription
+    {
+        get => _includeDescription;
+        set
+        {
+            ThrowIfReadOnly();
+            _includeDescription = value;
+        }
+    }
 
     /// <summary>
     /// Whether to render field names in bold. Default is false.
     /// </summary>
-    public bool BoldFieldNames { get; set; }
+    public bool BoldFieldNames
+    {
+        get => _boldFieldNames;
+        set
+        {
+            ThrowIfReadOnly();
+            _boldFieldNames = value;
+        }
+    }
 
     /// <summary>
     /// If set, only sections with these indices (1-based) are rendered.
     /// </summary>
-    public HashSet<int>? IncludeSections { get; set; }
+    public HashSet<int>? IncludeSections
+    {
+        get => _includeSections;
+        set
+        {
+            ThrowIfReadOnly();
+            _includeSections = value;
+        }
+    }
 
     /// <summary>
     /// If set, sections with these indices (1-based) are excluded from output.
     /// </summary>
-    public HashSet<int>? ExcludeSections { get; set; }
+    public HashSet<int>? ExcludeSections
+    {
+        get => _excludeSections;
+        set
+        {
+            ThrowIfReadOnly();
+            _excludeSections = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether this instance is read-only.
+    /// </summary>
+    public bool IsReadOnly => _isReadOnly;
+
+    /// <summary>
+    /// Marks this instance as read-only. After calling this method, any attempt to set
+    /// a property will throw <see cref="InvalidOperationException"/>.
+    /// </summary>
+    public void MakeReadOnly() => _isReadOnly = true;
+
+    private void ThrowIfReadOnly()
+    {
+        if (_isReadOnly)
+            throw new InvalidOperationException("This MarkoutWriterOptions instance is read-only.");
+    }
 }

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -174,8 +174,7 @@ public class MarkoutWriterTests
     [Fact]
     public void IncludeSections_FiltersToSpecifiedSections()
     {
-        var writer = new MarkoutWriter();
-        writer.IncludeSections = new HashSet<int> { 1 };
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = new HashSet<int> { 1 } });
 
         writer.WriteHeading(1, "Title");
         writer.WriteParagraph("Intro");
@@ -202,8 +201,7 @@ public class MarkoutWriterTests
     [Fact]
     public void ExcludeSections_SkipsSpecifiedSections()
     {
-        var writer = new MarkoutWriter();
-        writer.ExcludeSections = new HashSet<int> { 2 };
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { ExcludeSections = new HashSet<int> { 2 } });
 
         writer.WriteHeading(1, "Title");
         writer.WriteHeading(2, "First");    // Section 1 - included
@@ -231,8 +229,7 @@ public class MarkoutWriterTests
     [Fact]
     public void SectionFiltering_ContentBeforeFirstH2_AlwaysIncluded()
     {
-        var writer = new MarkoutWriter();
-        writer.IncludeSections = new HashSet<int> { 2 };
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = new HashSet<int> { 2 } });
 
         writer.WriteHeading(1, "Title");
         writer.WriteParagraph("This is before any H2");
@@ -257,8 +254,7 @@ public class MarkoutWriterTests
     [Fact]
     public void SectionFiltering_TableSpanningExcludedSection_NotWritten()
     {
-        var writer = new MarkoutWriter();
-        writer.ExcludeSections = new HashSet<int> { 1 };
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { ExcludeSections = new HashSet<int> { 1 } });
 
         writer.WriteHeading(1, "Title");
         writer.WriteHeading(2, "Data");     // Section 1 - excluded
@@ -438,6 +434,35 @@ public class MarkoutWriterTests
     }
 
     [Fact]
+    public void WriteFieldNoBreak_Double_WritesNumber()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteFieldNoBreak("Score", 9.5);
+
+        Assert.Equal("Score: 9.5\n", writer.ToString());
+    }
+
+    [Fact]
+    public void WriteFieldNoBreak_DateTime_WritesIso8601()
+    {
+        var writer = new MarkoutWriter();
+        var date = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        writer.WriteFieldNoBreak("Created", date);
+
+        Assert.StartsWith("Created: 2024-06-15T12:00:00", writer.ToString());
+    }
+
+    [Fact]
+    public void WriteFieldNoBreak_DateTimeOffset_WritesIso8601()
+    {
+        var writer = new MarkoutWriter();
+        var date = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        writer.WriteFieldNoBreak("Modified", date);
+
+        Assert.StartsWith("Modified: 2024-06-15T12:00:00", writer.ToString());
+    }
+
+    [Fact]
     public void MarkoutWriterOptions_Default_HasExpectedValues()
     {
         var options = new MarkoutWriterOptions();
@@ -447,5 +472,25 @@ public class MarkoutWriterTests
         Assert.False(options.BoldFieldNames);
         Assert.Null(options.IncludeSections);
         Assert.Null(options.ExcludeSections);
+    }
+
+    [Fact]
+    public void MarkoutWriterOptions_Default_IsReadOnly()
+    {
+        Assert.True(MarkoutWriterOptions.Default.IsReadOnly);
+        Assert.Throws<InvalidOperationException>(() => MarkoutWriterOptions.Default.BoldFieldNames = true);
+    }
+
+    [Fact]
+    public void MarkoutWriterOptions_MakeReadOnly_PreventsModification()
+    {
+        var options = new MarkoutWriterOptions { BoldFieldNames = true };
+        options.MakeReadOnly();
+
+        Assert.Throws<InvalidOperationException>(() => options.BoldFieldNames = false);
+        Assert.Throws<InvalidOperationException>(() => options.IncludeIcons = false);
+        Assert.Throws<InvalidOperationException>(() => options.IncludeDescription = false);
+        Assert.Throws<InvalidOperationException>(() => options.IncludeSections = new HashSet<int> { 1 });
+        Assert.Throws<InvalidOperationException>(() => options.ExcludeSections = new HashSet<int> { 2 });
     }
 }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -157,7 +157,7 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext { IncludeSections = new HashSet<int> { 1 } };
+        var context = new SectionTestContext { Options = new MarkoutWriterOptions { IncludeSections = new HashSet<int> { 1 } } };
         var mdf = context.Serialize(package);
 
         // Section 1 (Dependencies) should be included
@@ -186,7 +186,7 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext { ExcludeSections = new HashSet<int> { 1 } };
+        var context = new SectionTestContext { Options = new MarkoutWriterOptions { ExcludeSections = new HashSet<int> { 1 } } };
         var mdf = context.Serialize(package);
 
         // Section 1 (Dependencies) should be excluded
@@ -418,6 +418,22 @@ public class FileExplorer
 [MarkoutContext(typeof(FileExplorer))]
 [MarkoutContext(typeof(RenderScalarsWarningTest))]
 public partial class TreeTestContext : MarkoutSerializerContext
+{
+}
+
+// Test type that intentionally triggers MARKOUT003 error for dictionary properties
+// This verifies the analyzer correctly detects Dictionary<TKey, TValue> usage
+#pragma warning disable MARKOUT003, MARKOUT001
+[MarkoutSerializable]
+public class DictionaryWarningTest
+{
+    public string Name { get; set; } = "";
+    public Dictionary<string, string> Tags { get; set; } = new();
+}
+#pragma warning restore MARKOUT003, MARKOUT001
+
+[MarkoutContext(typeof(DictionaryWarningTest))]
+public partial class DictionaryTestContext : MarkoutSerializerContext
 {
 }
 


### PR DESCRIPTION
## Summary

- **Safety:** Add missing `WriteFieldNoBreak` overloads (double/DateTime/DateTimeOffset), freeze pattern for `MarkoutWriterOptions`, eliminate dual options surface (context uses `Options` property, writer properties get-only), skip null check for value types in generated code
- **Source generator:** Remove O(N*M) `IsUsedInList` scan, replace magic int with `FieldLayoutKind` enum, rename `MdfName` → `DisplayName`, wire up MARKOUT003 dictionary detection
- **Modernization:** Static heading prefix lookup, avoid unnecessary `ToList()` in `WriteTree`, collection expressions in `MarkoutSchemaInfo`
- **Version bump** to 0.2.0

## Breaking changes

- `MarkoutSerializerContext` no longer has `BoldFieldNames`, `IncludeSections`, `ExcludeSections`, `IncludeDescription` properties — use `Options = new() { ... }` instead
- `MarkoutWriter` forwarding properties (`BoldFieldNames`, `IncludeSections`, etc.) are now get-only — configure via constructor options
- `MarkoutWriterOptions.Default` is now read-only (throws `InvalidOperationException` on mutation)

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` — 107 tests pass (5 new)
- [x] `dotnet pack -c Release` — package builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)