### PR TITLE
API improvements: name-based sections, generic WriteField, optional attribute

### DIFF
--- a/samples/Serialization/SectionFiltering.cs
+++ b/samples/Serialization/SectionFiltering.cs
@@ -15,19 +15,19 @@ public static class SectionFiltering
         #region IncludeSpecificSections
         var writer = new MarkoutWriter(new MarkoutWriterOptions
         {
-            // Only include sections 1 and 3 (H2 boundaries)
-            IncludeSections = new HashSet<int> { 1, 3 }
+            // Only include sections matching these heading names
+            IncludeSections = ["Overview", "Reviews"]
         });
 
         writer.WriteHeading(1, "Product Details");
 
-        writer.WriteHeading(2, "Overview");        // Section 1 - included
+        writer.WriteHeading(2, "Overview");        // included
         writer.WriteField("Name", "Widget Pro");
 
-        writer.WriteHeading(2, "Specifications");  // Section 2 - excluded
+        writer.WriteHeading(2, "Specifications");  // excluded
         writer.WriteField("Weight", "1.5 kg");
 
-        writer.WriteHeading(2, "Reviews");         // Section 3 - included
+        writer.WriteHeading(2, "Reviews");         // included
         writer.WriteField("Rating", "4.5 stars");
 
         Console.WriteLine(writer.ToString());
@@ -51,19 +51,19 @@ public static class SectionFiltering
         #region ExcludeSpecificSections
         var writer = new MarkoutWriter(new MarkoutWriterOptions
         {
-            // Exclude section 2 (Specifications)
-            ExcludeSections = new HashSet<int> { 2 }
+            // Exclude the Specifications section
+            ExcludeSections = ["Specifications"]
         });
 
         writer.WriteHeading(1, "Product Details");
 
-        writer.WriteHeading(2, "Overview");        // Section 1 - included
+        writer.WriteHeading(2, "Overview");        // included
         writer.WriteField("Name", "Widget Pro");
 
-        writer.WriteHeading(2, "Specifications");  // Section 2 - excluded
+        writer.WriteHeading(2, "Specifications");  // excluded
         writer.WriteField("Weight", "1.5 kg");
 
-        writer.WriteHeading(2, "Reviews");         // Section 3 - included
+        writer.WriteHeading(2, "Reviews");         // included
         writer.WriteField("Rating", "4.5 stars");
 
         Console.WriteLine(writer.ToString());
@@ -80,7 +80,7 @@ public static class SectionFiltering
         {
             Options = new MarkoutWriterOptions
             {
-                ExcludeSections = new HashSet<int> { 2 },  // Skip section 2
+                ExcludeSections = ["Specifications"],  // Skip Specifications section
                 BoldFieldNames = true                       // Enable bold field names
             }
         };

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -99,7 +99,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
 
     public PropertyMetadata(
         string name,
-        string mdfName,
+        string displayName,
         string typeName,
         PropertyKind kind,
         bool isIgnored = false,
@@ -116,7 +116,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? boolFalseValue = null)
     {
         Name = name;
-        DisplayName = mdfName;
+        DisplayName = displayName;
         TypeName = typeName;
         Kind = kind;
         IsIgnored = isIgnored;

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -7,7 +7,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Markout.SourceGeneration.Parser;
 
 /// <summary>
-/// Parses types marked with [MarkoutSerializable] and contexts marked with [MarkoutContext].
+/// Parses types and contexts marked with [MarkoutContext].
+/// Types do not require [MarkoutSerializable] — it is optional for customizing behavior.
 /// </summary>
 internal static class TypeParser
 {
@@ -18,44 +19,6 @@ internal static class TypeParser
     private const string MarkoutIgnoreInTableAttribute = "Markout.MarkoutIgnoreInTableAttribute";
     private const string MarkoutSectionAttribute = "Markout.MarkoutSectionAttribute";
     private const string MarkoutBoolFormatAttribute = "Markout.MarkoutBoolFormatAttribute";
-
-    public static TypeMetadata? ParseSerializableType(
-        GeneratorSyntaxContext context,
-        CancellationToken cancellationToken)
-    {
-        var typeDecl = (TypeDeclarationSyntax)context.Node;
-        var symbol = context.SemanticModel.GetDeclaredSymbol(typeDecl, cancellationToken);
-
-        if (symbol is not INamedTypeSymbol typeSymbol)
-            return null;
-
-        var serializableAttr = typeSymbol.GetAttributes()
-            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutSerializableAttribute);
-
-        if (serializableAttr == null)
-            return null;
-
-        string? titleProperty = null;
-        string? titleContextProperty = null;
-        string? descriptionProperty = null;
-        bool renderScalars = true;
-        var fieldLayout = FieldLayoutKind.OneLine;
-        foreach (var named in serializableAttr.NamedArguments)
-        {
-            if (named.Key == "TitleProperty" && named.Value.Value is string tp)
-                titleProperty = tp;
-            else if (named.Key == "TitleContextProperty" && named.Value.Value is string tcp)
-                titleContextProperty = tcp;
-            else if (named.Key == "DescriptionProperty" && named.Value.Value is string dp)
-                descriptionProperty = dp;
-            else if (named.Key == "RenderScalars" && named.Value.Value is bool rs)
-                renderScalars = rs;
-            else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
-                fieldLayout = (FieldLayoutKind)fl;
-        }
-
-        return ParseTypeSymbol(typeSymbol, context.SemanticModel.Compilation, null, titleProperty, titleContextProperty, descriptionProperty, renderScalars, fieldLayout);
-    }
 
     public static ContextMetadata? ParseContext(
         GeneratorSyntaxContext context,

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -22,7 +22,7 @@ public sealed class MarkoutWriter
     private bool _needsBlankLine;
     private bool _hasContent;
     private bool _inTable;
-    private int _currentSection;
+    private string? _currentSectionName;
     private bool _sectionExcluded;
 
     /// <summary>
@@ -51,8 +51,12 @@ public sealed class MarkoutWriter
     /// <summary>
     /// Creates a writer that writes to the specified TextWriter with the specified options.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if both IncludeSections and ExcludeSections are set.</exception>
     public MarkoutWriter(TextWriter writer, MarkoutWriterOptions options)
     {
+        if (options.IncludeSections != null && options.ExcludeSections != null)
+            throw new InvalidOperationException("Cannot set both IncludeSections and ExcludeSections. Use one or the other.");
+
         _writer = writer;
         _options = options;
     }
@@ -77,14 +81,14 @@ public sealed class MarkoutWriter
     public bool BoldFieldNames => _options.BoldFieldNames;
 
     /// <summary>
-    /// Gets the sections to include (1-based, H2 boundaries).
+    /// Gets the sections to include (by heading name).
     /// </summary>
-    public HashSet<int>? IncludeSections => _options.IncludeSections;
+    public HashSet<string>? IncludeSections => _options.IncludeSections;
 
     /// <summary>
-    /// Gets the sections to exclude (1-based, H2 boundaries).
+    /// Gets the sections to exclude (by heading name).
     /// </summary>
-    public HashSet<int>? ExcludeSections => _options.ExcludeSections;
+    public HashSet<string>? ExcludeSections => _options.ExcludeSections;
 
     /// <summary>
     /// Gets whether to include the description paragraph.
@@ -103,18 +107,20 @@ public sealed class MarkoutWriter
 
     private bool IsSectionIncluded()
     {
-        // Content before first H2 (section 0) is always included
-        if (_currentSection == 0)
+        // Content before first H2 (no section name) is always included
+        if (_currentSectionName == null)
             return true;
-        if (_options.IncludeSections?.Count > 0 && !_options.IncludeSections.Contains(_currentSection))
+        if (_options.IncludeSections != null && !_options.IncludeSections.Contains(_currentSectionName))
             return false;
-        if (_options.ExcludeSections?.Contains(_currentSection) == true)
+        if (_options.ExcludeSections?.Contains(_currentSectionName) == true)
             return false;
         return true;
     }
 
-    private void WriteFormattedValue<T>(T value, ReadOnlySpan<char> format = default) where T : ISpanFormattable
+    private void WriteFormattedValue<T>(T value) where T : ISpanFormattable
     {
+        // Use ISO 8601 round-trip format for date/time types
+        ReadOnlySpan<char> format = value is DateTime or DateTimeOffset ? "O" : default;
         Span<char> buffer = stackalloc char[64];
         if (value.TryFormat(buffer, out int charsWritten, format, CultureInfo.InvariantCulture))
             _writer.Write(buffer[..charsWritten]);
@@ -161,7 +167,7 @@ public sealed class MarkoutWriter
         // H2 starts a new section
         if (level == 2)
         {
-            _currentSection++;
+            _currentSectionName = text;
             _sectionExcluded = !IsSectionIncluded();
         }
 
@@ -266,10 +272,10 @@ public sealed class MarkoutWriter
     }
 
     /// <summary>
-    /// Writes a key-value field with an integer value.
+    /// Writes a key-value field with a formattable value (int, long, double, decimal, DateTime, DateTimeOffset, etc.).
     /// Uses trailing spaces for markdown hard line break.
     /// </summary>
-    public void WriteField(string key, int value)
+    public void WriteField<T>(string key, T value) where T : ISpanFormattable
     {
         if (_sectionExcluded)
             return;
@@ -277,86 +283,6 @@ public sealed class MarkoutWriter
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         WriteFormattedValue(value);
-        _writer.WriteLine("  "); // Two trailing spaces for markdown hard line break
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field with a long value.
-    /// Uses trailing spaces for markdown hard line break.
-    /// </summary>
-    public void WriteField(string key, long value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value);
-        _writer.WriteLine("  "); // Two trailing spaces for markdown hard line break
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field with a double value.
-    /// Uses trailing spaces for markdown hard line break.
-    /// </summary>
-    public void WriteField(string key, double value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value);
-        _writer.WriteLine("  "); // Two trailing spaces for markdown hard line break
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field with a decimal value.
-    /// Uses trailing spaces for markdown hard line break.
-    /// </summary>
-    public void WriteField(string key, decimal value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value);
-        _writer.WriteLine("  "); // Two trailing spaces for markdown hard line break
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field with a DateTime value (ISO 8601 format).
-    /// Uses trailing spaces for markdown hard line break.
-    /// </summary>
-    public void WriteField(string key, DateTime value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value, "O");
-        _writer.WriteLine("  "); // Two trailing spaces for markdown hard line break
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field with a DateTimeOffset value (ISO 8601 format).
-    /// Uses trailing spaces for markdown hard line break.
-    /// </summary>
-    public void WriteField(string key, DateTimeOffset value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value, "O");
         _writer.WriteLine("  "); // Two trailing spaces for markdown hard line break
         _hasContent = true;
     }
@@ -395,7 +321,7 @@ public sealed class MarkoutWriter
     /// Writes a key-value field without trailing spaces (no markdown soft break).
     /// Use for LineBreaks layout where each field is on its own line.
     /// </summary>
-    public void WriteFieldNoBreak(string key, int value)
+    public void WriteFieldNoBreak<T>(string key, T value) where T : ISpanFormattable
     {
         if (_sectionExcluded)
             return;
@@ -403,86 +329,6 @@ public sealed class MarkoutWriter
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         WriteFormattedValue(value);
-        _writer.WriteLine();
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field without trailing spaces (no markdown soft break).
-    /// Use for LineBreaks layout where each field is on its own line.
-    /// </summary>
-    public void WriteFieldNoBreak(string key, long value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value);
-        _writer.WriteLine();
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field without trailing spaces (no markdown soft break).
-    /// Use for LineBreaks layout where each field is on its own line.
-    /// </summary>
-    public void WriteFieldNoBreak(string key, decimal value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value);
-        _writer.WriteLine();
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field without trailing spaces (no markdown soft break).
-    /// Use for LineBreaks layout where each field is on its own line.
-    /// </summary>
-    public void WriteFieldNoBreak(string key, double value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value);
-        _writer.WriteLine();
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field without trailing spaces (no markdown soft break).
-    /// Use for LineBreaks layout where each field is on its own line.
-    /// </summary>
-    public void WriteFieldNoBreak(string key, DateTime value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value, "O");
-        _writer.WriteLine();
-        _hasContent = true;
-    }
-
-    /// <summary>
-    /// Writes a key-value field without trailing spaces (no markdown soft break).
-    /// Use for LineBreaks layout where each field is on its own line.
-    /// </summary>
-    public void WriteFieldNoBreak(string key, DateTimeOffset value)
-    {
-        if (_sectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteFieldName(key);
-        WriteFormattedValue(value, "O");
         _writer.WriteLine();
         _hasContent = true;
     }

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -9,8 +9,8 @@ public class MarkoutWriterOptions
     private bool _includeIcons = true;
     private bool _includeDescription = true;
     private bool _boldFieldNames;
-    private HashSet<int>? _includeSections;
-    private HashSet<int>? _excludeSections;
+    private HashSet<string>? _includeSections;
+    private HashSet<string>? _excludeSections;
 
     /// <summary>
     /// Gets the default options instance. This instance is read-only.
@@ -64,9 +64,10 @@ public class MarkoutWriterOptions
     }
 
     /// <summary>
-    /// If set, only sections with these indices (1-based) are rendered.
+    /// If set, only sections whose heading text matches are rendered.
+    /// An empty set means no named sections are included (preamble only).
     /// </summary>
-    public HashSet<int>? IncludeSections
+    public HashSet<string>? IncludeSections
     {
         get => _includeSections;
         set
@@ -77,9 +78,9 @@ public class MarkoutWriterOptions
     }
 
     /// <summary>
-    /// If set, sections with these indices (1-based) are excluded from output.
+    /// If set, sections whose heading text matches are excluded from output.
     /// </summary>
-    public HashSet<int>? ExcludeSections
+    public HashSet<string>? ExcludeSections
     {
         get => _excludeSections;
         set

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -174,15 +174,15 @@ public class MarkoutWriterTests
     [Fact]
     public void IncludeSections_FiltersToSpecifiedSections()
     {
-        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = new HashSet<int> { 1 } });
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = ["First"] });
 
         writer.WriteHeading(1, "Title");
         writer.WriteParagraph("Intro");
-        writer.WriteHeading(2, "First");    // Section 1 - included
+        writer.WriteHeading(2, "First");    // included
         writer.WriteField("A", "1");
-        writer.WriteHeading(2, "Second");   // Section 2 - excluded
+        writer.WriteHeading(2, "Second");   // excluded
         writer.WriteField("B", "2");
-        writer.WriteHeading(2, "Third");    // Section 3 - excluded
+        writer.WriteHeading(2, "Third");    // excluded
         writer.WriteField("C", "3");
 
         var expected = """
@@ -201,14 +201,14 @@ public class MarkoutWriterTests
     [Fact]
     public void ExcludeSections_SkipsSpecifiedSections()
     {
-        var writer = new MarkoutWriter(new MarkoutWriterOptions { ExcludeSections = new HashSet<int> { 2 } });
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { ExcludeSections = ["Second"] });
 
         writer.WriteHeading(1, "Title");
-        writer.WriteHeading(2, "First");    // Section 1 - included
+        writer.WriteHeading(2, "First");    // included
         writer.WriteField("A", "1");
-        writer.WriteHeading(2, "Second");   // Section 2 - excluded
+        writer.WriteHeading(2, "Second");   // excluded
         writer.WriteField("B", "2");
-        writer.WriteHeading(2, "Third");    // Section 3 - included
+        writer.WriteHeading(2, "Third");    // included
         writer.WriteField("C", "3");
 
         var expected = """
@@ -229,13 +229,13 @@ public class MarkoutWriterTests
     [Fact]
     public void SectionFiltering_ContentBeforeFirstH2_AlwaysIncluded()
     {
-        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = new HashSet<int> { 2 } });
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = ["Second"] });
 
         writer.WriteHeading(1, "Title");
         writer.WriteParagraph("This is before any H2");
-        writer.WriteHeading(2, "First");    // Section 1 - excluded
+        writer.WriteHeading(2, "First");    // excluded
         writer.WriteField("A", "1");
-        writer.WriteHeading(2, "Second");   // Section 2 - included
+        writer.WriteHeading(2, "Second");   // included
         writer.WriteField("B", "2");
 
         var expected = """
@@ -254,14 +254,14 @@ public class MarkoutWriterTests
     [Fact]
     public void SectionFiltering_TableSpanningExcludedSection_NotWritten()
     {
-        var writer = new MarkoutWriter(new MarkoutWriterOptions { ExcludeSections = new HashSet<int> { 1 } });
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { ExcludeSections = ["Data"] });
 
         writer.WriteHeading(1, "Title");
-        writer.WriteHeading(2, "Data");     // Section 1 - excluded
+        writer.WriteHeading(2, "Data");     // excluded
         writer.WriteTableStart("Name", "Value");
         writer.WriteTableRow("Foo", "Bar");
         writer.WriteTableEnd();
-        writer.WriteHeading(2, "Other");    // Section 2 - included
+        writer.WriteHeading(2, "Other");    // included
         writer.WriteField("X", "Y");
 
         var expected = """
@@ -490,7 +490,38 @@ public class MarkoutWriterTests
         Assert.Throws<InvalidOperationException>(() => options.BoldFieldNames = false);
         Assert.Throws<InvalidOperationException>(() => options.IncludeIcons = false);
         Assert.Throws<InvalidOperationException>(() => options.IncludeDescription = false);
-        Assert.Throws<InvalidOperationException>(() => options.IncludeSections = new HashSet<int> { 1 });
-        Assert.Throws<InvalidOperationException>(() => options.ExcludeSections = new HashSet<int> { 2 });
+        Assert.Throws<InvalidOperationException>(() => options.IncludeSections = ["First"]);
+        Assert.Throws<InvalidOperationException>(() => options.ExcludeSections = ["Second"]);
+    }
+
+    [Fact]
+    public void MarkoutWriter_BothIncludeAndExclude_ThrowsInvalidOperation()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            IncludeSections = ["First"],
+            ExcludeSections = ["Second"]
+        };
+
+        Assert.Throws<InvalidOperationException>(() => new MarkoutWriter(options));
+    }
+
+    [Fact]
+    public void IncludeSections_EmptySet_IncludesPreambleOnly()
+    {
+        var writer = new MarkoutWriter(new MarkoutWriterOptions { IncludeSections = [] });
+
+        writer.WriteHeading(1, "Title");
+        writer.WriteParagraph("Preamble text");
+        writer.WriteHeading(2, "First");
+        writer.WriteField("A", "1");
+
+        var expected = """
+            # Title
+
+            Preamble text
+
+            """;
+        Assert.Equal(expected, writer.ToString());
     }
 }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -157,14 +157,14 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext { Options = new MarkoutWriterOptions { IncludeSections = new HashSet<int> { 1 } } };
+        var context = new SectionTestContext { Options = new MarkoutWriterOptions { IncludeSections = ["Dependencies"] } };
         var mdf = context.Serialize(package);
 
-        // Section 1 (Dependencies) should be included
+        // Dependencies section should be included
         Assert.Contains("## Dependencies", mdf);
         Assert.Contains("Dep1", mdf);
 
-        // Section 2 (Assemblies) should be excluded
+        // Assemblies section should be excluded
         Assert.DoesNotContain("## Assemblies", mdf);
         Assert.DoesNotContain("Test.dll", mdf);
     }
@@ -186,14 +186,14 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext { Options = new MarkoutWriterOptions { ExcludeSections = new HashSet<int> { 1 } } };
+        var context = new SectionTestContext { Options = new MarkoutWriterOptions { ExcludeSections = ["Dependencies"] } };
         var mdf = context.Serialize(package);
 
-        // Section 1 (Dependencies) should be excluded
+        // Dependencies section should be excluded
         Assert.DoesNotContain("## Dependencies", mdf);
         Assert.DoesNotContain("Dep1", mdf);
 
-        // Section 2 (Assemblies) should be included
+        // Assemblies section should be included
         Assert.Contains("## Assemblies", mdf);
         Assert.Contains("Test.dll", mdf);
     }


### PR DESCRIPTION
## Summary

- **Section filtering by name**: `IncludeSections`/`ExcludeSections` now use `HashSet<string>` keyed by H2 heading text instead of `HashSet<int>` indices. Empty set means preamble only. Throws if both are set simultaneously.
- **Collapse WriteField overloads**: 12 type-specific overloads replaced with 2 generic `ISpanFormattable` methods (16 → 6 total). DateTime/DateTimeOffset auto-format as ISO 8601.
- **Make `[MarkoutSerializable]` optional**: types registered via `[MarkoutContext]` work without the attribute. Only needed for customizing TitleProperty, FieldLayout, etc.
- **Internal naming**: renamed `mdfName` → `displayName` in PropertyMetadata constructor.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings
- [x] `dotnet test -c Release` — 109 tests pass (107 existing + 2 new)
- [x] dotnet-inspect builds with ProjectReference and all 324 tests pass
- [x] End-to-end: `dotnet-inspect package Markout` output verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)