### PR TITLE
Bump version to 0.2.1 and add Serialization sample to CI

### DIFF
--- a/Markout.sln
+++ b/Markout.sln
@@ -13,6 +13,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Markout.Demo", "src\Markout.Demo\Markout.Demo.csproj", "{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5D20AA90-6969-D8BD-9DCD-8634F4692FDA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialization", "samples\Serialization\Serialization.csproj", "{2FBCC45A-444A-444D-96D4-475718EA2A1E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,11 +75,24 @@ Global
 		{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4}.Release|x64.Build.0 = Release|Any CPU
 		{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4}.Release|x86.ActiveCfg = Release|Any CPU
 		{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4}.Release|x86.Build.0 = Release|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Debug|x86.Build.0 = Debug|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x64.Build.0 = Release|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{2FBCC45A-444A-444D-96D4-475718EA2A1E} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 EndGlobal

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.2.0
+#:package Markout@0.2.1
 // CanCon. It's the law!
 
 using System.Text.Json;

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.2.0
+#:package Markout@0.2.1
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.2.0
+#:package Markout@0.2.1
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/Serialization/Serialization.csproj
+++ b/samples/Serialization/Serialization.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="true" />
+  </ItemGroup>
+</Project>

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">


### PR DESCRIPTION
## Summary

- Bump package version to 0.2.1
- Add `samples/Serialization/Serialization.csproj` to the solution so the three loose sample files (BasicUsage, WriterUsage, SectionFiltering) are compiled in CI, catching breakages early
- Bump file-based app `#:package` references from `Markout@0.2.0` to `@0.2.1`

## Test plan

- [ ] `dotnet build -c Release` succeeds with 0 warnings (includes new Serialization project)
- [ ] `dotnet test -c Release` — all 109 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)