### PR TITLE
Safety, correctness, and ergonomics fixes

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -76,7 +76,17 @@ internal static class SerializerEmitter
             }
         }
 
-        EmitPropertySerializations(sb, type.Properties, "value", 2, 2, 0, type.RenderScalars, type.FieldLayout);
+        var propsToRender = type.Properties;
+        if (type.TitleProperty != null || type.TitleContextProperty != null || type.DescriptionProperty != null)
+        {
+            var skip = new HashSet<string>();
+            if (type.TitleProperty != null) skip.Add(type.TitleProperty);
+            if (type.TitleContextProperty != null) skip.Add(type.TitleContextProperty);
+            if (type.DescriptionProperty != null) skip.Add(type.DescriptionProperty);
+            propsToRender = type.Properties.Where(p => !skip.Contains(p.Name)).ToList();
+        }
+
+        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.RenderScalars, type.FieldLayout);
 
         sb.AppendLine("    }");
         sb.AppendLine("}");
@@ -360,7 +370,7 @@ internal static class SerializerEmitter
                 }
                 else if (prop.Kind == PropertyKind.ComplexArray && prop.ElementProperties != null)
                 {
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                    sb.AppendLine($"{indent}if ({GetCollectionCountCheck(prop, propAccess)})");
                     sb.AppendLine($"{indent}{{");
                     sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
                     
@@ -378,7 +388,7 @@ internal static class SerializerEmitter
                 }
                 else if (prop.Kind == PropertyKind.StringArray)
                 {
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Any())");
+                    sb.AppendLine($"{indent}if ({GetCollectionCountCheck(prop, propAccess)})");
                     sb.AppendLine($"{indent}{{");
                     sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
                     sb.AppendLine($"{indent}    writer.WriteArray({propAccess});");
@@ -432,7 +442,7 @@ internal static class SerializerEmitter
                 case PropertyKind.ComplexArray:
                     if (prop.ElementProperties != null && prop.ElementProperties.Count > 0)
                     {
-                        sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                        sb.AppendLine($"{indent}if ({GetCollectionCountCheck(prop, propAccess)})");
                         sb.AppendLine($"{indent}{{");
                         sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.DisplayName)}\");");
                         if (prop.ElementHasNestedContent)
@@ -499,17 +509,43 @@ internal static class SerializerEmitter
         int indentLevel)
     {
         var indent = new string(' ', indentLevel * 4);
+        bool hasNullable = scalarProps.Any(p => p.IsNullableValueType);
 
-        // Build inline MarkoutField array
-        var fields = new List<string>();
-        foreach (var prop in scalarProps)
+        if (hasNullable)
         {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-            var valueStr = GetScalarValueExpression(prop, propAccess);
-            fields.Add($"new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr})");
+            // Use List<MarkoutField> builder pattern when any scalar is nullable
+            sb.AppendLine($"{indent}var __fields = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+            foreach (var prop in scalarProps)
+            {
+                var propAccess = $"{valueExpr}.{prop.Name}";
+                if (prop.IsNullableValueType)
+                {
+                    var valueStr = GetScalarValueExpression(prop, propAccess, nullable: true);
+                    sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                    sb.AppendLine($"{indent}    __fields.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+                else
+                {
+                    var valueStr = GetScalarValueExpression(prop, propAccess);
+                    sb.AppendLine($"{indent}__fields.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+            }
+            sb.AppendLine($"{indent}if (__fields.Count > 0)");
+            sb.AppendLine($"{indent}    writer.WriteCompactFields(__fields);");
         }
+        else
+        {
+            // Build inline MarkoutField array
+            var fields = new List<string>();
+            foreach (var prop in scalarProps)
+            {
+                var propAccess = $"{valueExpr}.{prop.Name}";
+                var valueStr = GetScalarValueExpression(prop, propAccess);
+                fields.Add($"new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr})");
+            }
 
-        sb.AppendLine($"{indent}writer.WriteCompactFields({string.Join(", ", fields)});");
+            sb.AppendLine($"{indent}writer.WriteCompactFields({string.Join(", ", fields)});");
+        }
     }
 
     private static void EmitLineBreaksScalars(
@@ -525,8 +561,27 @@ internal static class SerializerEmitter
         foreach (var prop in scalarProps)
         {
             var propAccess = $"{valueExpr}.{prop.Name}";
-            
-            if (prop.Kind == PropertyKind.String)
+
+            if (prop.IsNullableValueType)
+            {
+                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                if (prop.Kind == PropertyKind.Boolean)
+                {
+                    if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+                    {
+                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                    }
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                }
+            }
+            else if (prop.Kind == PropertyKind.String)
             {
                 sb.AppendLine($"{indent}if ({propAccess} != null)");
                 sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
@@ -560,35 +615,43 @@ internal static class SerializerEmitter
         foreach (var prop in scalarProps)
         {
             var propAccess = $"{valueExpr}.{prop.Name}";
-            var valueStr = GetScalarValueExpression(prop, propAccess);
-            
-            if (prop.Kind == PropertyKind.String)
+
+            if (prop.IsNullableValueType)
+            {
+                var valueStr = GetScalarValueExpression(prop, propAccess, nullable: true);
+                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+            }
+            else if (prop.Kind == PropertyKind.String)
             {
                 sb.AppendLine($"{indent}if ({propAccess} != null)");
                 sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
             }
             else
             {
+                var valueStr = GetScalarValueExpression(prop, propAccess);
                 sb.AppendLine($"{indent}writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
         }
     }
 
-    private static string GetScalarValueExpression(PropertyMetadata prop, string propAccess)
+    private static string GetScalarValueExpression(PropertyMetadata prop, string propAccess, bool nullable = false)
     {
+        var access = nullable ? $"{propAccess}.Value" : propAccess;
+
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
         {
-            return $"{propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\"";
+            return $"({access} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\")";
         }
 
         return prop.Kind switch
         {
-            PropertyKind.Boolean => $"{propAccess} ? \"yes\" : \"no\"",
+            PropertyKind.Boolean => $"({access} ? \"yes\" : \"no\")",
             PropertyKind.String => $"{propAccess} ?? \"\"",
             PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
-                => $"{propAccess}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
+                => $"{access}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset
-                => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+                => $"{access}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
     }
@@ -685,6 +748,12 @@ internal static class SerializerEmitter
     {
         var propAccess = $"{itemExpr}.{prop.Name}";
 
+        if (prop.IsNullableValueType)
+        {
+            var valueExpr = GetScalarValueExpression(prop, propAccess, nullable: true);
+            return $"{propAccess}.HasValue ? {valueExpr} : \"\"";
+        }
+
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
         {
             return $"{propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\"";
@@ -700,6 +769,12 @@ internal static class SerializerEmitter
                 => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
+    }
+
+    private static string GetCollectionCountCheck(PropertyMetadata prop, string propAccess)
+    {
+        var countProp = prop.IsArray ? "Length" : "Count";
+        return $"{propAccess} != null && {propAccess}.{countProp} > 0";
     }
 
     private static string EscapeString(string s)

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -96,6 +96,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? ElementTitleProperty { get; }
     public string? BoolTrueValue { get; }
     public string? BoolFalseValue { get; }
+    public bool IsNullableValueType { get; }
+    public bool IsArray { get; }
 
     public PropertyMetadata(
         string name,
@@ -113,7 +115,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         bool elementHasNestedContent = false,
         string? elementTitleProperty = null,
         string? boolTrueValue = null,
-        string? boolFalseValue = null)
+        string? boolFalseValue = null,
+        bool isNullableValueType = false,
+        bool isArray = false)
     {
         Name = name;
         DisplayName = displayName;
@@ -131,6 +135,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         ElementTitleProperty = elementTitleProperty;
         BoolTrueValue = boolTrueValue;
         BoolFalseValue = boolFalseValue;
+        IsNullableValueType = isNullableValueType;
+        IsArray = isArray;
     }
 
     public bool Equals(PropertyMetadata? other)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -196,7 +196,15 @@ internal static class TypeParser
                 boolFalseValue = fv;
         }
 
-        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty) = DeterminePropertyKind(prop.Type, compilation, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
+        // Detect nullable value types before determining property kind
+        bool isNullableValueType = false;
+        if (prop.Type is INamedTypeSymbol nullableCheck &&
+            nullableCheck.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            isNullableValueType = true;
+        }
+
+        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, isArray) = DeterminePropertyKind(prop.Type, compilation, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
 
         // Determine if property is unsupported in table context
         bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind);
@@ -229,10 +237,12 @@ internal static class TypeParser
             hasNestedContent,
             elementTitleProperty,
             boolTrueValue,
-            boolFalseValue);
+            boolFalseValue,
+            isNullableValueType,
+            isArray);
     }
 
-    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty)
+    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)
         DeterminePropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
         var typeName = type.ToDisplayString();
@@ -248,43 +258,43 @@ internal static class TypeParser
         // Primitives
         return type.SpecialType switch
         {
-            SpecialType.System_String => (PropertyKind.String, null, null, false, null),
-            SpecialType.System_Boolean => (PropertyKind.Boolean, null, null, false, null),
-            SpecialType.System_Int32 => (PropertyKind.Int32, null, null, false, null),
-            SpecialType.System_Int64 => (PropertyKind.Int64, null, null, false, null),
-            SpecialType.System_Double => (PropertyKind.Double, null, null, false, null),
-            SpecialType.System_Decimal => (PropertyKind.Decimal, null, null, false, null),
+            SpecialType.System_String => (PropertyKind.String, null, null, false, null, false),
+            SpecialType.System_Boolean => (PropertyKind.Boolean, null, null, false, null, false),
+            SpecialType.System_Int32 => (PropertyKind.Int32, null, null, false, null, false),
+            SpecialType.System_Int64 => (PropertyKind.Int64, null, null, false, null, false),
+            SpecialType.System_Double => (PropertyKind.Double, null, null, false, null, false),
+            SpecialType.System_Decimal => (PropertyKind.Decimal, null, null, false, null, false),
             _ => DetermineComplexPropertyKind(type, compilation, diagnostics, propertyName, propertyLocation)
         };
     }
 
-    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty)
+    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)
         DetermineComplexPropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
         var typeName = type.ToDisplayString();
 
         // DateTime types
         if (typeName == "System.DateTime")
-            return (PropertyKind.DateTime, null, null, false, null);
+            return (PropertyKind.DateTime, null, null, false, null, false);
         if (typeName == "System.DateTimeOffset")
-            return (PropertyKind.DateTimeOffset, null, null, false, null);
+            return (PropertyKind.DateTimeOffset, null, null, false, null, false);
 
         // Check for arrays
         if (type is IArrayTypeSymbol arrayType)
         {
             var elementType = arrayType.ElementType;
-            
+
             // Check for MarkoutField[] - renders as compact line or field table
             if (elementType.ToDisplayString() == "Markout.MarkoutField")
-                return (PropertyKind.FieldCollection, null, null, false, null);
-            
+                return (PropertyKind.FieldCollection, null, null, false, null, true);
+
             if (elementType.SpecialType == SpecialType.System_String)
-                return (PropertyKind.StringArray, null, null, false, null);
+                return (PropertyKind.StringArray, null, null, false, null, true);
 
             var elementProps = GetTypeProperties(elementType, compilation, diagnostics);
             var hasNested = HasNestedContent(elementProps);
             var titleProp = GetTitleProperty(elementType);
-            return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp);
+            return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp, true);
         }
 
         // Check for IEnumerable<T> / List<T> / etc.
@@ -303,7 +313,7 @@ internal static class TypeParser
                         propertyLocation,
                         propertyName));
                 }
-                return (PropertyKind.Other, null, null, false, null);
+                return (PropertyKind.Other, null, null, false, null, false);
             }
 
             var enumerableInterface = namedType.AllInterfaces
@@ -335,7 +345,7 @@ internal static class TypeParser
                             typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>" ||
                             typeDisplayString == "System.Collections.Generic.IList<T>")
                         {
-                            return (PropertyKind.FieldCollection, null, null, false, null);
+                            return (PropertyKind.FieldCollection, null, null, false, null, false);
                         }
                         // IEnumerable<MarkoutField> without materialization is not supported
                         // User should use List<MarkoutField> or IReadOnlyList<MarkoutField>
@@ -347,17 +357,17 @@ internal static class TypeParser
                         var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
                         if (typeDisplayString == "System.Collections.Generic.List<T>")
                         {
-                            return (PropertyKind.Tree, null, null, false, null);
+                            return (PropertyKind.Tree, null, null, false, null, false);
                         }
                     }
 
                     if (elementType.SpecialType == SpecialType.System_String)
-                        return (PropertyKind.StringArray, null, null, false, null);
+                        return (PropertyKind.StringArray, null, null, false, null, false);
 
                     var elementProps = GetTypeProperties(elementType, compilation, diagnostics);
                     var hasNested = HasNestedContent(elementProps);
                     var titleProp = GetTitleProperty(elementType);
-                    return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp);
+                    return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp, false);
                 }
             }
         }
@@ -367,10 +377,10 @@ internal static class TypeParser
         {
             var props = GetTypeProperties(type, compilation, diagnostics);
             if (props.Count > 0)
-                return (PropertyKind.NestedObject, null, props, false, null);
+                return (PropertyKind.NestedObject, null, props, false, null, false);
         }
 
-        return (PropertyKind.Other, null, null, false, null);
+        return (PropertyKind.Other, null, null, false, null, false);
     }
 
     private static bool HasNestedContent(IReadOnlyList<PropertyMetadata>? props)

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -680,7 +680,7 @@ public sealed class MarkoutWriter
     public override string ToString()
     {
         if (_writer is StringWriter sw)
-            return sw.ToString();
+            return sw.ToString().TrimEnd();
         return base.ToString() ?? "";
     }
 

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -11,7 +11,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteHeading(1, "Package");
 
-        Assert.Equal("# Package\n", writer.ToString());
+        Assert.Equal("# Package", writer.ToString());
     }
 
     [Fact]
@@ -20,7 +20,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteHeading(2, "Dependencies");
 
-        Assert.Equal("## Dependencies\n", writer.ToString());
+        Assert.Equal("## Dependencies", writer.ToString());
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteHeading(2, "Dependencies", "net6.0");
 
-        Assert.Equal("## Dependencies (net6.0)\n", writer.ToString());
+        Assert.Equal("## Dependencies (net6.0)", writer.ToString());
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class MarkoutWriterTests
         writer.WriteField("Name", "Newtonsoft.Json");
 
         // Note: WriteField adds two trailing spaces for markdown hard line break
-        Assert.Equal("Name: Newtonsoft.Json  \n", writer.ToString());
+        Assert.Equal("Name: Newtonsoft.Json", writer.ToString());
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteField("Signed", true);
 
-        Assert.Equal("Signed: yes  \n", writer.ToString());
+        Assert.Equal("Signed: yes", writer.ToString());
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteField("Signed", false);
 
-        Assert.Equal("Signed: no  \n", writer.ToString());
+        Assert.Equal("Signed: no", writer.ToString());
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteField("Count", 42);
 
-        Assert.Equal("Count: 42  \n", writer.ToString());
+        Assert.Equal("Count: 42", writer.ToString());
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteField("Version", 3.14);
 
-        Assert.Equal("Version: 3.14  \n", writer.ToString());
+        Assert.Equal("Version: 3.14", writer.ToString());
     }
 
     [Fact]
@@ -89,7 +89,6 @@ public class MarkoutWriterTests
             - netstandard2.0
             - net6.0
             - net8.0
-
             """;
         Assert.Equal(expected, writer.ToString());
     }
@@ -100,7 +99,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteArray("Frameworks", Array.Empty<string>());
 
-        Assert.Equal("Frameworks:\n", writer.ToString());
+        Assert.Equal("Frameworks:", writer.ToString());
     }
 
     [Fact]
@@ -117,7 +116,6 @@ public class MarkoutWriterTests
             | ---- | ---- | ------ |
             | Foo.dll | AnyCPU | yes |
             | Bar.dll | x64 | no |
-
             """;
         Assert.Equal(expected, writer.ToString());
     }
@@ -132,7 +130,6 @@ public class MarkoutWriterTests
         var expected = """
             Microsoft.CSharp                4.7.0
             System.Memory                   4.5.5
-
             """;
         Assert.Equal(expected, writer.ToString());
     }
@@ -147,17 +144,7 @@ public class MarkoutWriterTests
         writer.WriteHeading(2, "Dependencies");
         writer.WriteField("Count", 5);
 
-        var expected = """
-            # Package
-
-            Name: Test  
-            Version: 1.0.0  
-
-            ## Dependencies
-
-            Count: 5  
-
-            """;
+        var expected = "# Package\n\nName: Test  \nVersion: 1.0.0  \n\n## Dependencies\n\nCount: 5";
         Assert.Equal(expected, writer.ToString());
     }
 
@@ -185,16 +172,7 @@ public class MarkoutWriterTests
         writer.WriteHeading(2, "Third");    // excluded
         writer.WriteField("C", "3");
 
-        var expected = """
-            # Title
-
-            Intro
-
-            ## First
-
-            A: 1  
-
-            """;
+        var expected = "# Title\n\nIntro\n\n## First\n\nA: 1";
         Assert.Equal(expected, writer.ToString());
     }
 
@@ -211,18 +189,7 @@ public class MarkoutWriterTests
         writer.WriteHeading(2, "Third");    // included
         writer.WriteField("C", "3");
 
-        var expected = """
-            # Title
-
-            ## First
-
-            A: 1  
-
-            ## Third
-
-            C: 3  
-
-            """;
+        var expected = "# Title\n\n## First\n\nA: 1  \n\n## Third\n\nC: 3";
         Assert.Equal(expected, writer.ToString());
     }
 
@@ -238,16 +205,7 @@ public class MarkoutWriterTests
         writer.WriteHeading(2, "Second");   // included
         writer.WriteField("B", "2");
 
-        var expected = """
-            # Title
-
-            This is before any H2
-
-            ## Second
-
-            B: 2  
-
-            """;
+        var expected = "# Title\n\nThis is before any H2\n\n## Second\n\nB: 2";
         Assert.Equal(expected, writer.ToString());
     }
 
@@ -264,14 +222,7 @@ public class MarkoutWriterTests
         writer.WriteHeading(2, "Other");    // included
         writer.WriteField("X", "Y");
 
-        var expected = """
-            # Title
-
-            ## Other
-
-            X: Y  
-
-            """;
+        var expected = "# Title\n\n## Other\n\nX: Y";
         Assert.Equal(expected, writer.ToString());
     }
 
@@ -281,7 +232,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteCompactFields(new MarkoutField("Type", "Library"));
 
-        Assert.Equal("Type: Library\n", writer.ToString());
+        Assert.Equal("Type: Library", writer.ToString());
     }
 
     [Fact]
@@ -293,7 +244,7 @@ public class MarkoutWriterTests
             new MarkoutField("TFM", "net8.0"),
             new MarkoutField("Updated", "2026-01-15"));
 
-        Assert.Equal("Type: Library | TFM: net8.0 | Updated: 2026-01-15\n", writer.ToString());
+        Assert.Equal("Type: Library | TFM: net8.0 | Updated: 2026-01-15", writer.ToString());
     }
 
     [Fact]
@@ -313,7 +264,7 @@ public class MarkoutWriterTests
             new MarkoutField("Status", null),
             new MarkoutField("Count", "5"));
 
-        Assert.Equal("Status:  | Count: 5\n", writer.ToString());
+        Assert.Equal("Status:  | Count: 5", writer.ToString());
     }
 
     [Fact]
@@ -325,12 +276,7 @@ public class MarkoutWriterTests
             new MarkoutField("Type", "Library"),
             new MarkoutField("TFM", "net8.0"));
 
-        var expected = """
-            # Package 1.0.0
-
-            Type: Library | TFM: net8.0
-
-            """;
+        var expected = "# Package 1.0.0\n\nType: Library | TFM: net8.0";
         Assert.Equal(expected, writer.ToString());
     }
 
@@ -439,7 +385,7 @@ public class MarkoutWriterTests
         var writer = new MarkoutWriter();
         writer.WriteFieldNoBreak("Score", 9.5);
 
-        Assert.Equal("Score: 9.5\n", writer.ToString());
+        Assert.Equal("Score: 9.5", writer.ToString());
     }
 
     [Fact]
@@ -516,12 +462,7 @@ public class MarkoutWriterTests
         writer.WriteHeading(2, "First");
         writer.WriteField("A", "1");
 
-        var expected = """
-            # Title
-
-            Preamble text
-
-            """;
+        var expected = "# Title\n\nPreamble text";
         Assert.Equal(expected, writer.ToString());
     }
 }

--- a/tests/Markout.Tests/NullableAndTitleTests.cs
+++ b/tests/Markout.Tests/NullableAndTitleTests.cs
@@ -1,0 +1,332 @@
+using Markout;
+using Xunit;
+
+namespace Markout.Tests;
+
+// --- Nullable value type test models ---
+
+[MarkoutSerializable]
+public class NullableScalarsOneLine
+{
+    public string? Label { get; set; }
+    public int? Count { get; set; }
+    public bool? Active { get; set; }
+    public DateTimeOffset? Modified { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class NullableScalarsLineBreaks
+{
+    public string? Label { get; set; }
+    public int? Count { get; set; }
+    public bool? Active { get; set; }
+    public double? Score { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaksDoubleSpace)]
+public class NullableScalarsDoubleSpace
+{
+    public string? Label { get; set; }
+    public int? Count { get; set; }
+    public bool? Active { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.List)]
+public class NullableScalarsList
+{
+    public string? Label { get; set; }
+    public int? Count { get; set; }
+    public bool? Active { get; set; }
+}
+
+[MarkoutSerializable]
+public class NullableInTableRow
+{
+    public string? Name { get; set; }
+    public int? Priority { get; set; }
+    public bool? Completed { get; set; }
+}
+
+[MarkoutSerializable]
+public class NullableTableContainer
+{
+    public string? Title { get; set; }
+    [MarkoutSection(Name = "Items")]
+    public List<NullableInTableRow>? Items { get; set; }
+}
+
+// --- Title dedup test models ---
+
+[MarkoutSerializable(TitleProperty = nameof(Name), RenderScalars = true)]
+public class TitleDedupRecord
+{
+    public string Name { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public int Count { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Summary), RenderScalars = true)]
+public class TitleAndDescDedupRecord
+{
+    public string Name { get; set; } = "";
+    public string? Summary { get; set; }
+    public string Kind { get; set; } = "";
+    public int Count { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), TitleContextProperty = nameof(Version), RenderScalars = true)]
+public class TitleContextDedupRecord
+{
+    public string Name { get; set; } = "";
+    public string Version { get; set; } = "";
+    public string Kind { get; set; } = "";
+}
+
+// --- Contexts ---
+
+[MarkoutContext(typeof(NullableScalarsOneLine))]
+[MarkoutContext(typeof(NullableScalarsLineBreaks))]
+[MarkoutContext(typeof(NullableScalarsDoubleSpace))]
+[MarkoutContext(typeof(NullableScalarsList))]
+[MarkoutContext(typeof(NullableTableContainer))]
+[MarkoutContext(typeof(TitleDedupRecord))]
+[MarkoutContext(typeof(TitleAndDescDedupRecord))]
+[MarkoutContext(typeof(TitleContextDedupRecord))]
+public partial class NullableAndTitleTestContext : MarkoutSerializerContext
+{
+}
+
+public class NullableAndTitleTests
+{
+    // --- Nullable: OneLine layout ---
+
+    [Fact]
+    public void Nullable_OneLine_AllSet_RendersAll()
+    {
+        var record = new NullableScalarsOneLine
+        {
+            Label = "Test",
+            Count = 42,
+            Active = true,
+            Modified = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("Label: Test", mdf);
+        Assert.Contains("Count: 42", mdf);
+        Assert.Contains("Active: yes", mdf);
+        Assert.Contains("Modified: 2024-06-15T12:00:00", mdf);
+    }
+
+    [Fact]
+    public void Nullable_OneLine_NullsSkipped()
+    {
+        var record = new NullableScalarsOneLine
+        {
+            Label = "Test",
+            Count = null,
+            Active = null,
+            Modified = null
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("Label: Test", mdf);
+        Assert.DoesNotContain("Count:", mdf);
+        Assert.DoesNotContain("Active:", mdf);
+        Assert.DoesNotContain("Modified:", mdf);
+    }
+
+    [Fact]
+    public void Nullable_OneLine_AllNullableNull_StringStillRendered()
+    {
+        var record = new NullableScalarsOneLine
+        {
+            Label = null,
+            Count = null,
+            Active = null,
+            Modified = null
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        // String fields still render (with empty value); nullable value types are skipped
+        Assert.Contains("Label:", mdf);
+        Assert.DoesNotContain("Count:", mdf);
+        Assert.DoesNotContain("Active:", mdf);
+        Assert.DoesNotContain("Modified:", mdf);
+    }
+
+    // --- Nullable: LineBreaks layout ---
+
+    [Fact]
+    public void Nullable_LineBreaks_AllSet_RendersAll()
+    {
+        var record = new NullableScalarsLineBreaks
+        {
+            Label = "Test",
+            Count = 10,
+            Active = false,
+            Score = 9.5
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("Label: Test", mdf);
+        Assert.Contains("Count: 10", mdf);
+        Assert.Contains("Active: no", mdf);
+        Assert.Contains("Score: 9.5", mdf);
+    }
+
+    [Fact]
+    public void Nullable_LineBreaks_NullsSkipped()
+    {
+        var record = new NullableScalarsLineBreaks
+        {
+            Label = "Test",
+            Count = null,
+            Active = null,
+            Score = null
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("Label: Test", mdf);
+        Assert.DoesNotContain("Count:", mdf);
+        Assert.DoesNotContain("Active:", mdf);
+        Assert.DoesNotContain("Score:", mdf);
+    }
+
+    // --- Nullable: LineBreaksDoubleSpace layout ---
+
+    [Fact]
+    public void Nullable_DoubleSpace_NullsSkipped()
+    {
+        var record = new NullableScalarsDoubleSpace
+        {
+            Label = "Test",
+            Count = null,
+            Active = true
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("Label: Test", mdf);
+        Assert.DoesNotContain("Count:", mdf);
+        Assert.Contains("Active: yes", mdf);
+    }
+
+    // --- Nullable: List layout ---
+
+    [Fact]
+    public void Nullable_List_NullsSkipped()
+    {
+        var record = new NullableScalarsList
+        {
+            Label = "Test",
+            Count = null,
+            Active = true
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("- Label: Test", mdf);
+        Assert.DoesNotContain("Count:", mdf);
+        Assert.Contains("- Active: yes", mdf);
+    }
+
+    // --- Nullable: Table cells ---
+
+    [Fact]
+    public void Nullable_InTable_NullRendersEmpty()
+    {
+        var container = new NullableTableContainer
+        {
+            Title = "My List",
+            Items = new List<NullableInTableRow>
+            {
+                new() { Name = "Item1", Priority = 1, Completed = true },
+                new() { Name = "Item2", Priority = null, Completed = null }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(container, NullableAndTitleTestContext.Default);
+
+        // Table should contain Item1 with values
+        Assert.Contains("| Item1 |", mdf);
+        Assert.Contains("| 1 |", mdf);
+        Assert.Contains("| yes |", mdf);
+        // Item2 should have empty cells for null values
+        Assert.Contains("| Item2 |", mdf);
+    }
+
+    // --- Title property deduplication ---
+
+    [Fact]
+    public void TitleProperty_NotDuplicatedAsScalar()
+    {
+        var record = new TitleDedupRecord
+        {
+            Name = "MyWidget",
+            Kind = "gadget",
+            Count = 3
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        // Title should appear as H1
+        Assert.Contains("# MyWidget", mdf);
+        // Name should NOT appear again as a scalar field
+        Assert.DoesNotContain("Name: MyWidget", mdf);
+        // Other scalars should still appear
+        Assert.Contains("Kind: gadget", mdf);
+        Assert.Contains("Count: 3", mdf);
+    }
+
+    [Fact]
+    public void DescriptionProperty_NotDuplicatedAsScalar()
+    {
+        var record = new TitleAndDescDedupRecord
+        {
+            Name = "MyWidget",
+            Summary = "A useful widget",
+            Kind = "gadget",
+            Count = 3
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        // Title should appear as H1
+        Assert.Contains("# MyWidget", mdf);
+        // Description should appear as paragraph
+        Assert.Contains("A useful widget", mdf);
+        // Neither Name nor Summary should appear as scalar fields
+        Assert.DoesNotContain("Name: MyWidget", mdf);
+        Assert.DoesNotContain("Summary: A useful widget", mdf);
+        // Other scalars should still appear
+        Assert.Contains("Kind: gadget", mdf);
+        Assert.Contains("Count: 3", mdf);
+    }
+
+    [Fact]
+    public void TitleContextProperty_NotDuplicatedAsScalar()
+    {
+        var record = new TitleContextDedupRecord
+        {
+            Name = "MyWidget",
+            Version = "2.0",
+            Kind = "gadget"
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        // Title with context should appear as H1
+        Assert.Contains("# MyWidget (2.0)", mdf);
+        // Neither Name nor Version should appear as scalar fields
+        Assert.DoesNotContain("Name: MyWidget", mdf);
+        Assert.DoesNotContain("Version: 2.0", mdf);
+        // Other scalars should still appear
+        Assert.Contains("Kind: gadget", mdf);
+    }
+}


### PR DESCRIPTION
## Summary

Four targeted fixes driven by consumer (`dotnet-inspect`) usage:

- **Nullable value type support** — generated code for `int?`, `bool?`, `DateTimeOffset?` etc. now compiles and correctly skips null values with `HasValue` guards across all four `FieldLayout` modes and table cells
- **Title/description dedup** — properties named in `TitleProperty`, `TitleContextProperty`, or `DescriptionProperty` are excluded from scalar rendering to prevent double output
- **Auto-trim `ToString()`** — `MarkoutWriter.ToString()` now calls `.TrimEnd()`, eliminating the `.TrimEnd()` call every consumer was doing
- **`.Any()` → count/length** — replaces LINQ `.Any()` with `.Length > 0` (arrays) or `.Count > 0` (lists) in generated collection null-checks, avoiding enumerator allocation

Also parenthesizes ternary expressions in generated string interpolations to prevent `:` format-specifier conflicts.

## Test plan

- [x] 120 tests pass (109 existing + 11 new)
- [x] Zero build warnings
- [x] `dotnet-inspect` builds and passes 324 tests against ProjectReference
- [ ] Verify `dotnet pack` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)