### PR TITLE
Ergonomics improvements: null-skipping, format attribute, section constants

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,17 @@ jobs:
 
       - name: Publish to NuGet
         run: |
-          dotnet nuget push packages/*.nupkg \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
-            --source https://api.nuget.org/v3/index.json \
-            --skip-duplicate
+          for pkg in packages/*.nupkg; do
+            name=$(basename "$pkg")
+            case "$name" in
+              Markout.[0-9]*)
+                dotnet nuget push "$pkg" \
+                  --api-key ${{ secrets.NUGET_API_KEY }} \
+                  --source https://api.nuget.org/v3/index.json \
+                  --skip-duplicate
+                ;;
+              *)
+                echo "Skipping sample package: $name"
+                ;;
+            esac
+          done

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -159,6 +159,12 @@ internal static class SerializerEmitter
             EmitSchemaProperty(sb, type);
         }
 
+        // Section name constants for each type that has sections
+        foreach (var type in context.Types)
+        {
+            EmitSectionConstants(sb, type);
+        }
+
         sb.AppendLine("}");
 
         return sb.ToString();
@@ -214,6 +220,60 @@ internal static class SerializerEmitter
             
             sb.AppendLine($"{indent}}},");
         }
+    }
+
+    private static void EmitSectionConstants(StringBuilder sb, TypeMetadata type)
+    {
+        var sectionProps = type.Properties
+            .Where(p => p.IsSection && !p.IsIgnored)
+            .ToList();
+
+        if (sectionProps.Count == 0)
+            return;
+
+        sb.AppendLine($"    public static class {type.TypeName}Sections");
+        sb.AppendLine("    {");
+
+        var usedNames = new HashSet<string>();
+        foreach (var prop in sectionProps)
+        {
+            var sectionName = prop.SectionName ?? prop.DisplayName;
+            var constName = NormalizeSectionName(sectionName);
+
+            // Ensure uniqueness by appending a suffix if needed
+            var uniqueName = constName;
+            var suffix = 2;
+            while (!usedNames.Add(uniqueName))
+            {
+                uniqueName = constName + suffix;
+                suffix++;
+            }
+
+            sb.AppendLine($"        public const string {uniqueName} = \"{EscapeString(sectionName)}\";");
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine();
+    }
+
+    private static string NormalizeSectionName(string name)
+    {
+        // Replace non-alphanumeric characters with spaces, then PascalCase join
+        var cleaned = new StringBuilder(name.Length);
+        foreach (var ch in name)
+        {
+            cleaned.Append(char.IsLetterOrDigit(ch) ? ch : ' ');
+        }
+
+        var parts = cleaned.ToString().Split(new[] { ' ' }, System.StringSplitOptions.RemoveEmptyEntries);
+        var result = new StringBuilder();
+        foreach (var part in parts)
+        {
+            result.Append(char.ToUpperInvariant(part[0]));
+            if (part.Length > 1)
+                result.Append(part.Substring(1));
+        }
+        return result.ToString();
     }
 
     private static string GetRenderingDescription(PropertyMetadata prop, bool inTableContext)
@@ -344,7 +404,7 @@ internal static class SerializerEmitter
         // Emit scalars based on layout
         if (renderScalars && scalarProps.Count > 0)
         {
-            EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout);
+            EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout, nestingDepth);
         }
 
         // Emit non-scalar properties (sections, arrays, etc.)
@@ -408,7 +468,7 @@ internal static class SerializerEmitter
                     sb.AppendLine($"{indent}if ({propAccess} != null)");
                     sb.AppendLine($"{indent}{{");
                     sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                    EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth);
+                    EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1);
                     sb.AppendLine($"{indent}}}");
                 }
                 else
@@ -463,7 +523,7 @@ internal static class SerializerEmitter
                         sb.AppendLine($"{indent}if ({propAccess} != null)");
                         sb.AppendLine($"{indent}{{");
                         sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.DisplayName)}\");");
-                        EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth, true, fieldLayout);
+                        EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth + 1, true, fieldLayout);
                         sb.AppendLine($"{indent}}}");
                     }
                     break;
@@ -476,12 +536,13 @@ internal static class SerializerEmitter
         List<PropertyMetadata> scalarProps,
         string valueExpr,
         int indentLevel,
-        FieldLayoutKind fieldLayout)
+        FieldLayoutKind fieldLayout,
+        int nestingDepth = 0)
     {
         switch (fieldLayout)
         {
             case FieldLayoutKind.OneLine:
-                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel);
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
                 break;
 
             case FieldLayoutKind.LineBreaks:
@@ -497,7 +558,7 @@ internal static class SerializerEmitter
                 break;
 
             default:
-                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel);
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
                 break;
         }
     }
@@ -506,15 +567,17 @@ internal static class SerializerEmitter
         StringBuilder sb,
         List<PropertyMetadata> scalarProps,
         string valueExpr,
-        int indentLevel)
+        int indentLevel,
+        int nestingDepth = 0)
     {
         var indent = new string(' ', indentLevel * 4);
-        bool hasNullable = scalarProps.Any(p => p.IsNullableValueType);
+        bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String);
+        var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
-        if (hasNullable)
+        if (useBuilder)
         {
-            // Use List<MarkoutField> builder pattern when any scalar is nullable
-            sb.AppendLine($"{indent}var __fields = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+            // Use List<MarkoutField> builder pattern when any scalar is nullable or string (to skip nulls/empties)
+            sb.AppendLine($"{indent}var {fieldsVar} = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
             foreach (var prop in scalarProps)
             {
                 var propAccess = $"{valueExpr}.{prop.Name}";
@@ -522,20 +585,25 @@ internal static class SerializerEmitter
                 {
                     var valueStr = GetScalarValueExpression(prop, propAccess, nullable: true);
                     sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
-                    sb.AppendLine($"{indent}    __fields.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+                else if (prop.Kind == PropertyKind.String)
+                {
+                    sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({propAccess}))");
+                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {propAccess}));");
                 }
                 else
                 {
                     var valueStr = GetScalarValueExpression(prop, propAccess);
-                    sb.AppendLine($"{indent}__fields.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
             }
-            sb.AppendLine($"{indent}if (__fields.Count > 0)");
-            sb.AppendLine($"{indent}    writer.WriteCompactFields(__fields);");
+            sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
+            sb.AppendLine($"{indent}    writer.WriteCompactFields({fieldsVar});");
         }
         else
         {
-            // Build inline MarkoutField array
+            // Build inline MarkoutField array (no nullable/string scalars)
             var fields = new List<string>();
             foreach (var prop in scalarProps)
             {
@@ -576,6 +644,10 @@ internal static class SerializerEmitter
                         sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
                     }
                 }
+                else if (prop.CustomFormat != null)
+                {
+                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
+                }
                 else
                 {
                     sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
@@ -596,6 +668,10 @@ internal static class SerializerEmitter
                 {
                     sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
                 }
+            }
+            else if (prop.CustomFormat != null)
+            {
+                sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
             }
             else
             {
@@ -642,6 +718,16 @@ internal static class SerializerEmitter
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
         {
             return $"({access} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\")";
+        }
+
+        // Custom format overrides default formatting for formattable types
+        if (prop.CustomFormat != null)
+        {
+            if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
+            {
+                return $"{access}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+            }
         }
 
         return prop.Kind switch
@@ -757,6 +843,16 @@ internal static class SerializerEmitter
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
         {
             return $"{propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\"";
+        }
+
+        // Custom format overrides default formatting for formattable types
+        if (prop.CustomFormat != null)
+        {
+            if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
+            {
+                return $"{propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+            }
         }
 
         return prop.Kind switch

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -98,6 +98,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? BoolFalseValue { get; }
     public bool IsNullableValueType { get; }
     public bool IsArray { get; }
+    public string? CustomFormat { get; }
 
     public PropertyMetadata(
         string name,
@@ -117,7 +118,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? boolTrueValue = null,
         string? boolFalseValue = null,
         bool isNullableValueType = false,
-        bool isArray = false)
+        bool isArray = false,
+        string? customFormat = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -137,6 +139,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         BoolFalseValue = boolFalseValue;
         IsNullableValueType = isNullableValueType;
         IsArray = isArray;
+        CustomFormat = customFormat;
     }
 
     public bool Equals(PropertyMetadata? other)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -19,6 +19,7 @@ internal static class TypeParser
     private const string MarkoutIgnoreInTableAttribute = "Markout.MarkoutIgnoreInTableAttribute";
     private const string MarkoutSectionAttribute = "Markout.MarkoutSectionAttribute";
     private const string MarkoutBoolFormatAttribute = "Markout.MarkoutBoolFormatAttribute";
+    private const string MarkoutFormatAttribute = "Markout.MarkoutFormatAttribute";
 
     public static ContextMetadata? ParseContext(
         GeneratorSyntaxContext context,
@@ -196,6 +197,16 @@ internal static class TypeParser
                 boolFalseValue = fv;
         }
 
+        // Parse [MarkoutFormat] attribute
+        string? customFormat = null;
+        var formatAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutFormatAttribute);
+        if (formatAttr?.ConstructorArguments.Length > 0 &&
+            formatAttr.ConstructorArguments[0].Value is string fmt)
+        {
+            customFormat = fmt;
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -239,7 +250,8 @@ internal static class TypeParser
             boolTrueValue,
             boolFalseValue,
             isNullableValueType,
-            isArray);
+            isArray,
+            customFormat);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)

--- a/src/Markout/Attributes/MarkoutFormatAttribute.cs
+++ b/src/Markout/Attributes/MarkoutFormatAttribute.cs
@@ -1,0 +1,20 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies a custom format string for rendering an <see cref="ISpanFormattable"/> property
+/// (e.g., DateTime, DateTimeOffset, numeric types).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutFormatAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the format string to use when rendering the value.
+    /// </summary>
+    public string Format { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified format string.
+    /// </summary>
+    /// <param name="format">A standard or custom format string (e.g., "yyyy-MM-dd", "N0", "P1").</param>
+    public MarkoutFormatAttribute(string format) => Format = format;
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/FormatAttributeTests.cs
+++ b/tests/Markout.Tests/FormatAttributeTests.cs
@@ -1,0 +1,236 @@
+using Markout;
+using Xunit;
+
+namespace Markout.Tests;
+
+// --- Test models ---
+
+[MarkoutSerializable]
+public class DateFormatOneLine
+{
+    public string? Name { get; set; }
+    [MarkoutFormat("yyyy-MM-dd")]
+    public DateTimeOffset Published { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class DateFormatLineBreaks
+{
+    public string? Name { get; set; }
+    [MarkoutFormat("yyyy-MM-dd")]
+    public DateTimeOffset Published { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.List)]
+public class DateFormatList
+{
+    public string? Name { get; set; }
+    [MarkoutFormat("yyyy-MM-dd")]
+    public DateTimeOffset Published { get; set; }
+}
+
+[MarkoutSerializable]
+public class NumericFormatOneLine
+{
+    public string? Label { get; set; }
+    [MarkoutFormat("N0")]
+    public int Size { get; set; }
+    [MarkoutFormat("P1")]
+    public double Rate { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class NumericFormatLineBreaks
+{
+    public string? Label { get; set; }
+    [MarkoutFormat("N0")]
+    public int Size { get; set; }
+}
+
+[MarkoutSerializable]
+public class NullableDateFormatOneLine
+{
+    public string? Name { get; set; }
+    [MarkoutFormat("yyyy-MM-dd")]
+    public DateTimeOffset? Published { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class NullableDateFormatLineBreaks
+{
+    public string? Name { get; set; }
+    [MarkoutFormat("yyyy-MM-dd")]
+    public DateTimeOffset? Published { get; set; }
+}
+
+[MarkoutSerializable]
+public class DateFormatTableRow
+{
+    public string? Name { get; set; }
+    [MarkoutFormat("yyyy-MM-dd")]
+    public DateTimeOffset Published { get; set; }
+}
+
+[MarkoutSerializable]
+public class DateFormatTableContainer
+{
+    [MarkoutSection(Name = "Items")]
+    public List<DateFormatTableRow>? Items { get; set; }
+}
+
+// --- Context ---
+
+[MarkoutContext(typeof(DateFormatOneLine))]
+[MarkoutContext(typeof(DateFormatLineBreaks))]
+[MarkoutContext(typeof(DateFormatList))]
+[MarkoutContext(typeof(NumericFormatOneLine))]
+[MarkoutContext(typeof(NumericFormatLineBreaks))]
+[MarkoutContext(typeof(NullableDateFormatOneLine))]
+[MarkoutContext(typeof(NullableDateFormatLineBreaks))]
+[MarkoutContext(typeof(DateFormatTableContainer))]
+public partial class FormatAttributeTestContext : MarkoutSerializerContext
+{
+}
+
+public class FormatAttributeTests
+{
+    [Fact]
+    public void DateFormat_OneLine_UsesCustomFormat()
+    {
+        var record = new DateFormatOneLine
+        {
+            Name = "Package",
+            Published = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Published: 2024-06-15", mdf);
+        // Should NOT contain the full ISO format
+        Assert.DoesNotContain("T12:00:00", mdf);
+    }
+
+    [Fact]
+    public void DateFormat_LineBreaks_UsesCustomFormat()
+    {
+        var record = new DateFormatLineBreaks
+        {
+            Name = "Package",
+            Published = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Published: 2024-06-15", mdf);
+        Assert.DoesNotContain("T12:00:00", mdf);
+    }
+
+    [Fact]
+    public void DateFormat_List_UsesCustomFormat()
+    {
+        var record = new DateFormatList
+        {
+            Name = "Package",
+            Published = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Published: 2024-06-15", mdf);
+        Assert.DoesNotContain("T12:00:00", mdf);
+    }
+
+    [Fact]
+    public void NumericFormat_OneLine_UsesCustomFormat()
+    {
+        var record = new NumericFormatOneLine
+        {
+            Label = "Widget",
+            Size = 1234567,
+            Rate = 0.856
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Size: 1,234,567", mdf);
+        Assert.Contains("Rate: 85.6", mdf);
+    }
+
+    [Fact]
+    public void NumericFormat_LineBreaks_UsesCustomFormat()
+    {
+        var record = new NumericFormatLineBreaks
+        {
+            Label = "Widget",
+            Size = 1234567
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Size: 1,234,567", mdf);
+    }
+
+    [Fact]
+    public void NullableDateFormat_OneLine_SetValue_UsesCustomFormat()
+    {
+        var record = new NullableDateFormatOneLine
+        {
+            Name = "Package",
+            Published = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Published: 2024-03-01", mdf);
+        Assert.DoesNotContain("T00:00:00", mdf);
+    }
+
+    [Fact]
+    public void NullableDateFormat_OneLine_NullValue_Skipped()
+    {
+        var record = new NullableDateFormatOneLine
+        {
+            Name = "Package",
+            Published = null
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Name: Package", mdf);
+        Assert.DoesNotContain("Published:", mdf);
+    }
+
+    [Fact]
+    public void NullableDateFormat_LineBreaks_SetValue_UsesCustomFormat()
+    {
+        var record = new NullableDateFormatLineBreaks
+        {
+            Name = "Package",
+            Published = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, FormatAttributeTestContext.Default);
+
+        Assert.Contains("Published: 2024-03-01", mdf);
+    }
+
+    [Fact]
+    public void DateFormat_InTable_UsesCustomFormat()
+    {
+        var container = new DateFormatTableContainer
+        {
+            Items = new List<DateFormatTableRow>
+            {
+                new() { Name = "Pkg1", Published = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero) },
+                new() { Name = "Pkg2", Published = new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero) }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(container, FormatAttributeTestContext.Default);
+
+        Assert.Contains("2024-06-15", mdf);
+        Assert.Contains("2023-01-01", mdf);
+        // Should NOT contain full ISO format
+        Assert.DoesNotContain("T12:00:00", mdf);
+    }
+}

--- a/tests/Markout.Tests/NullableAndTitleTests.cs
+++ b/tests/Markout.Tests/NullableAndTitleTests.cs
@@ -55,6 +55,16 @@ public class NullableTableContainer
     public List<NullableInTableRow>? Items { get; set; }
 }
 
+// --- String null-skipping test model (OneLine, strings only) ---
+
+[MarkoutSerializable]
+public class StringOnlyOneLine
+{
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public int Count { get; set; }
+}
+
 // --- Title dedup test models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Name), RenderScalars = true)]
@@ -89,6 +99,7 @@ public class TitleContextDedupRecord
 [MarkoutContext(typeof(NullableScalarsDoubleSpace))]
 [MarkoutContext(typeof(NullableScalarsList))]
 [MarkoutContext(typeof(NullableTableContainer))]
+[MarkoutContext(typeof(StringOnlyOneLine))]
 [MarkoutContext(typeof(TitleDedupRecord))]
 [MarkoutContext(typeof(TitleAndDescDedupRecord))]
 [MarkoutContext(typeof(TitleContextDedupRecord))]
@@ -139,7 +150,7 @@ public class NullableAndTitleTests
     }
 
     [Fact]
-    public void Nullable_OneLine_AllNullableNull_StringStillRendered()
+    public void Nullable_OneLine_AllNull_AllSkipped()
     {
         var record = new NullableScalarsOneLine
         {
@@ -151,8 +162,8 @@ public class NullableAndTitleTests
 
         var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
 
-        // String fields still render (with empty value); nullable value types are skipped
-        Assert.Contains("Label:", mdf);
+        // Null strings and nullable value types are all skipped
+        Assert.DoesNotContain("Label:", mdf);
         Assert.DoesNotContain("Count:", mdf);
         Assert.DoesNotContain("Active:", mdf);
         Assert.DoesNotContain("Modified:", mdf);
@@ -328,5 +339,39 @@ public class NullableAndTitleTests
         Assert.DoesNotContain("Version: 2.0", mdf);
         // Other scalars should still appear
         Assert.Contains("Kind: gadget", mdf);
+    }
+
+    // --- String null-skipping in OneLine mode ---
+
+    [Fact]
+    public void OneLine_NullString_Skipped()
+    {
+        var record = new StringOnlyOneLine { Name = null, Description = "hello", Count = 5 };
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.DoesNotContain("Name:", mdf);
+        Assert.Contains("Description: hello", mdf);
+        Assert.Contains("Count: 5", mdf);
+    }
+
+    [Fact]
+    public void OneLine_EmptyString_Skipped()
+    {
+        var record = new StringOnlyOneLine { Name = "", Description = "hello", Count = 5 };
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.DoesNotContain("Name:", mdf);
+        Assert.Contains("Description: hello", mdf);
+    }
+
+    [Fact]
+    public void OneLine_NonNullString_Rendered()
+    {
+        var record = new StringOnlyOneLine { Name = "Widget", Description = "A thing", Count = 1 };
+        var mdf = MarkoutSerializer.Serialize(record, NullableAndTitleTestContext.Default);
+
+        Assert.Contains("Name: Widget", mdf);
+        Assert.Contains("Description: A thing", mdf);
+        Assert.Contains("Count: 1", mdf);
     }
 }

--- a/tests/Markout.Tests/SectionConstantsTests.cs
+++ b/tests/Markout.Tests/SectionConstantsTests.cs
@@ -1,0 +1,91 @@
+using Markout;
+using Xunit;
+
+namespace Markout.Tests;
+
+// --- Test model with sections ---
+
+[MarkoutSerializable]
+public class SectionConstantsModel
+{
+    public string? Name { get; set; }
+
+    [MarkoutSection(Name = "Metadata")]
+    public List<MarkoutField>? Metadata { get; set; }
+
+    [MarkoutSection(Name = "Package Dependencies")]
+    public List<string>? PackageDependencies { get; set; }
+
+    [MarkoutSection(Name = "RID Packages")]
+    public List<string>? RidPackages { get; set; }
+}
+
+// --- Context ---
+
+[MarkoutContext(typeof(SectionConstantsModel))]
+public partial class SectionConstantsTestContext : MarkoutSerializerContext
+{
+}
+
+public class SectionConstantsTests
+{
+    [Fact]
+    public void SectionConstants_SimpleNameExists()
+    {
+        Assert.Equal("Metadata", SectionConstantsTestContext.SectionConstantsModelSections.Metadata);
+    }
+
+    [Fact]
+    public void SectionConstants_SpacedNameNormalized()
+    {
+        Assert.Equal("Package Dependencies", SectionConstantsTestContext.SectionConstantsModelSections.PackageDependencies);
+    }
+
+    [Fact]
+    public void SectionConstants_AcronymPreserved()
+    {
+        Assert.Equal("RID Packages", SectionConstantsTestContext.SectionConstantsModelSections.RIDPackages);
+    }
+
+    [Fact]
+    public void SectionConstants_UsableInIncludeSections()
+    {
+        var record = new SectionConstantsModel
+        {
+            Name = "Test",
+            Metadata = new List<MarkoutField> { new("Key", "Value") },
+            PackageDependencies = new List<string> { "Dep1" },
+            RidPackages = new List<string> { "RID1" }
+        };
+
+        var options = new MarkoutWriterOptions
+        {
+            IncludeSections = new HashSet<string>
+            {
+                SectionConstantsTestContext.SectionConstantsModelSections.Metadata
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(record, SectionConstantsTestContext.Default, options);
+
+        Assert.Contains("Metadata", mdf);
+        Assert.DoesNotContain("Package Dependencies", mdf);
+        Assert.DoesNotContain("RID Packages", mdf);
+    }
+
+    [Fact]
+    public void SectionConstants_ConstValuesMatchViaReflection()
+    {
+        var sectionsType = typeof(SectionConstantsTestContext).GetNestedType("SectionConstantsModelSections");
+        Assert.NotNull(sectionsType);
+
+        var fields = sectionsType!.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        Assert.Equal(3, fields.Length);
+
+        foreach (var field in fields)
+        {
+            Assert.True(field.IsLiteral, $"{field.Name} should be a const");
+            Assert.IsType<string>(field.GetRawConstantValue());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Null-skipping in OneLine mode**: Null/empty strings are now skipped instead of rendering as empty `"FieldName: "` fields, matching the behavior of LineBreaks/List modes. Eliminates the need for `RenderScalars = false` + manual `List<MarkoutField>` workarounds.
- **`[MarkoutFormat]` attribute**: Custom format strings for `ISpanFormattable` properties (DateTime, DateTimeOffset, numerics). E.g., `[MarkoutFormat("yyyy-MM-dd")]` on a `DateTimeOffset` property. Works across all layout modes and table cells.
- **Section name constants**: Source generator now emits a `{TypeName}Sections` static class with `const string` fields for each section, enabling type-safe `IncludeSections`/`ExcludeSections` instead of magic strings.
- **CI fix**: Release workflow now only pushes `Markout.X.Y.Z.nupkg`, skipping sample packages that cause 403 errors.
- **Version bump**: 0.2.2 → 0.2.3

## Test plan

- [x] `dotnet build -c Release` — zero warnings
- [x] `dotnet test -c Release` — 137 tests pass (17 new)
- [x] `dotnet pack -c Release` — produces `Markout.0.2.3.nupkg`
- [ ] Verify null string skipping in OneLine mode
- [ ] Verify `[MarkoutFormat]` across OneLine, LineBreaks, List, and table layouts
- [ ] Verify section constants are generated and usable with `IncludeSections`
- [ ] Verify release workflow only pushes main package

🤖 Generated with [Claude Code](https://claude.com/claude-code)