### PR TITLE
Update NuGet package references to latest versions

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.2.1
+#:package Markout@0.2.3
 // CanCon. It's the law!
 
 using System.Text.Json;

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.2.1
+#:package Markout@0.2.3
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.2.1
+#:package Markout@0.2.3
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Markout.SourceGeneration/Markout.SourceGeneration.csproj
+++ b/src/Markout.SourceGeneration/Markout.SourceGeneration.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updates all NuGet package references to their latest versions.

| Package | Old | New |
|---------|-----|-----|
| Microsoft.NET.Test.Sdk | 17.8.0 | 18.0.1 |
| xunit | 2.6.2 | 2.9.3 |
| xunit.runner.visualstudio | 2.5.4 | 2.5.6 |
| Microsoft.CodeAnalysis.Analyzers | 3.3.4 | 3.11.0 |
| Microsoft.CodeAnalysis.CSharp | 4.8.0 | 5.0.0 |
| Markout (samples `#:package`) | 0.2.1 | 0.2.3 |

Build and tests pass.