### PR TITLE
Bind and freeze options on context construction

### DIFF
--- a/samples/Serialization/SectionFiltering.cs
+++ b/samples/Serialization/SectionFiltering.cs
@@ -76,14 +76,11 @@ public static class SectionFiltering
     public static void FilterViaContext()
     {
         #region FilterViaContext
-        var context = new SampleContext
+        var context = new SampleContext(new MarkoutWriterOptions
         {
-            Options = new MarkoutWriterOptions
-            {
-                ExcludeSections = ["Specifications"],  // Skip Specifications section
-                BoldFieldNames = true                       // Enable bold field names
-            }
-        };
+            ExcludeSections = ["Specifications"],  // Skip Specifications section
+            BoldFieldNames = true                       // Enable bold field names
+        });
 
         ProductView product = new ProductView
         {

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -111,6 +111,11 @@ internal static class SerializerEmitter
         sb.AppendLine($"partial class {context.ClassName}");
         sb.AppendLine("{");
 
+        // Constructor accepting options
+        sb.AppendLine($"    public {context.ClassName}() {{ }}");
+        sb.AppendLine($"    public {context.ClassName}(global::Markout.MarkoutWriterOptions options) : base(options) {{ }}");
+        sb.AppendLine();
+
         // Static Default property
         sb.AppendLine($"    public static {context.ClassName} Default {{ get; }} = new();");
         sb.AppendLine();

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutSerializerContext.cs
+++ b/src/Markout/MarkoutSerializerContext.cs
@@ -13,10 +13,41 @@ namespace Markout;
 /// <seealso href="../../samples/Serialization/SectionFiltering.cs">Section filtering via context</seealso>
 public abstract class MarkoutSerializerContext
 {
+    private MarkoutWriterOptions _options;
+
     /// <summary>
-    /// Gets or sets the writer options for controlling output formatting.
+    /// Creates a new context with default writer options.
     /// </summary>
-    public MarkoutWriterOptions Options { get; set; } = new();
+    protected MarkoutSerializerContext() : this(new MarkoutWriterOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new context with the specified writer options.
+    /// The options instance cannot be mutated once it is bound to the context.
+    /// </summary>
+    /// <param name="options">The writer options to bind to this context.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="options"/> is already read-only.</exception>
+    protected MarkoutSerializerContext(MarkoutWriterOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.IsReadOnly)
+        {
+            throw new InvalidOperationException(
+                "Cannot bind a read-only MarkoutWriterOptions instance to a context. " +
+                "The options instance is made read-only when bound to a context.");
+        }
+
+        options.MakeReadOnly();
+        _options = options;
+    }
+
+    /// <summary>
+    /// Gets the writer options bound to this context. The options instance is read-only.
+    /// </summary>
+    public MarkoutWriterOptions Options => _options;
 
     /// <summary>
     /// Gets the type info for the specified type, or null if not registered.

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -157,7 +157,7 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext { Options = new MarkoutWriterOptions { IncludeSections = ["Dependencies"] } };
+        var context = new SectionTestContext(new MarkoutWriterOptions { IncludeSections = ["Dependencies"] });
         var mdf = context.Serialize(package);
 
         // Dependencies section should be included
@@ -186,7 +186,7 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext { Options = new MarkoutWriterOptions { ExcludeSections = ["Dependencies"] } };
+        var context = new SectionTestContext(new MarkoutWriterOptions { ExcludeSections = ["Dependencies"] });
         var mdf = context.Serialize(package);
 
         // Dependencies section should be excluded
@@ -322,6 +322,61 @@ public class SerializerTests
 
         // Output should be empty (no scalars rendered, no sections)
         Assert.Equal("", mdf.Trim());
+    }
+
+    [Fact]
+    public void Context_DefaultInstance_HasReadOnlyOptions()
+    {
+        var context = TestMarkoutContext.Default;
+
+        Assert.True(context.Options.IsReadOnly);
+    }
+
+    [Fact]
+    public void Context_ParameterlessConstructor_FreezesOptions()
+    {
+        var context = new TestMarkoutContext();
+
+        Assert.True(context.Options.IsReadOnly);
+    }
+
+    [Fact]
+    public void Context_WithOptions_BindsAndFreezesOptions()
+    {
+        var options = new MarkoutWriterOptions { BoldFieldNames = true };
+        var context = new TestMarkoutContext(options);
+
+        Assert.True(context.Options.IsReadOnly);
+        Assert.True(context.Options.BoldFieldNames);
+        Assert.Same(options, context.Options);
+    }
+
+    [Fact]
+    public void Context_WithOptions_OptionsCannotBeMutatedAfterBinding()
+    {
+        var options = new MarkoutWriterOptions { BoldFieldNames = true };
+        var context = new TestMarkoutContext(options);
+
+        Assert.Throws<InvalidOperationException>(() => options.BoldFieldNames = false);
+    }
+
+    [Fact]
+    public void Context_WithReadOnlyOptions_Throws()
+    {
+        var options = new MarkoutWriterOptions();
+        options.MakeReadOnly();
+
+        Assert.Throws<InvalidOperationException>(() => new TestMarkoutContext(options));
+    }
+
+    [Fact]
+    public void Context_OptionsPropertyHasNoSetter()
+    {
+        // Verify that Options is get-only (no set accessor)
+        var prop = typeof(MarkoutSerializerContext).GetProperty("Options");
+        Assert.NotNull(prop);
+        Assert.NotNull(prop!.GetMethod);
+        Assert.Null(prop.SetMethod);
     }
 }
 


### PR DESCRIPTION
## Summary

Follow the System.Text.Json pattern: `MarkoutWriterOptions` are now frozen (`MakeReadOnly`) when bound to a `MarkoutSerializerContext`, preventing accidental mutation of shared context instances — including the generated `Default` singleton.

## Motivation

The `MarkoutSerializerContext.Options` property was previously a mutable `get; set;`, meaning:

- `MyContext.Default.Options = new MarkoutWriterOptions { ... }` could mutate the global singleton
- Options could be swapped mid-flight from another thread
- No freezing occurred — unlike System.Text.Json, which freezes options on context binding

This matters for SDK integration scenarios where context instances may be shared across concurrent callers.

## Changes

**`MarkoutSerializerContext`**
- Replace mutable `Options { get; set; }` with a get-only property backed by a frozen instance
- Add `protected` constructors: parameterless (creates + freezes default options) and options-accepting (binds + freezes the given instance)
- Reject already-frozen options to prevent sharing a single options instance across multiple contexts

**Source generator (`SerializerEmitter`)**
- Emit `public` parameterless and options-accepting constructors on generated partial context classes, forwarding to the base constructors

**Tests**
- 6 new tests covering: Default instance has read-only options, parameterless constructor freezes, options-accepting constructor binds and freezes, mutation after binding throws, already-frozen options rejected, Options property has no setter

**Samples**
- Update `SectionFiltering.cs` to use constructor-based options binding

## Breaking change

`MarkoutSerializerContext.Options` no longer has a setter. Code that previously used:
```csharp
var context = new MyContext { Options = new MarkoutWriterOptions { ... } };
```
must change to:
```csharp
var context = new MyContext(new MarkoutWriterOptions { ... });
```

The `Serialize(value, options)` overload (passing options per-call) continues to work unchanged. Verified no breakage in dotnet-inspect.