### PR TITLE
Gate builds on markdownlint passing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
           globs: '**/*.md'
 
   build:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, markdownlint]
+    if: always() && needs.changes.outputs.code == 'true' && needs.markdownlint.result != 'failure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,8 +79,8 @@ jobs:
           path: artifacts/package/release/*.nupkg
 
   smoke-test:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, markdownlint]
+    if: always() && needs.changes.outputs.code == 'true' && needs.markdownlint.result != 'failure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Build and smoke-test jobs now depend on markdownlint, so markdown lint failures block builds to avoid wasting CI resources
- Uses `always()` + `!= 'failure'` so builds proceed when lint is skipped (no docs changed) or succeeds

Mirrors the same change made in dotnet-inspect (richlander/dotnet-inspect#14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)