### PR TITLE
Add enum support and [MarkoutJoin] attribute

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -331,6 +331,7 @@ internal static class SerializerEmitter
             PropertyKind.Int32 or PropertyKind.Int64 => "Field",
             PropertyKind.Double or PropertyKind.Decimal => "Field",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset => "Field (ISO 8601)",
+            PropertyKind.Enum => "Field (enum)",
             PropertyKind.StringArray => "Bullet list",
             PropertyKind.ComplexArray => prop.ElementHasNestedContent 
                 ? "Subsections" 
@@ -365,7 +366,8 @@ internal static class SerializerEmitter
             PropertyKind.Double or
             PropertyKind.Decimal or
             PropertyKind.DateTime or
-            PropertyKind.DateTimeOffset;
+            PropertyKind.DateTimeOffset or
+            PropertyKind.Enum;
     }
 
     private static string GetTypeInfoClassName(TypeMetadata type)
@@ -743,6 +745,7 @@ internal static class SerializerEmitter
                 => $"{access}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset
                 => $"{access}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.Enum => $"{access}.ToString()",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
     }
@@ -868,6 +871,7 @@ internal static class SerializerEmitter
                 => $"{propAccess}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset
                 => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.Enum => $"{propAccess}.ToString()",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
     }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -291,8 +291,8 @@ internal static class SerializerEmitter
             if (prop.IsIgnoredInTable)
                 return "Ignored";
             
-            // In table context, only scalars work
-            if (IsScalarKind(prop.Kind))
+            // In table context, only scalars (and joined arrays) work
+            if (IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null))
                 return "Column" + (prop.Name != prop.DisplayName ? $" \"{prop.DisplayName}\"" : "");
             
             // Unsupported patterns are skipped
@@ -332,7 +332,7 @@ internal static class SerializerEmitter
             PropertyKind.Double or PropertyKind.Decimal => "Field",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset => "Field (ISO 8601)",
             PropertyKind.Enum => "Field (enum)",
-            PropertyKind.StringArray => "Bullet list",
+            PropertyKind.StringArray => prop.JoinSeparator != null ? "Field (joined)" : "Bullet list",
             PropertyKind.ComplexArray => prop.ElementHasNestedContent 
                 ? "Subsections" 
                 : "Table",
@@ -402,7 +402,7 @@ internal static class SerializerEmitter
             if (!renderScalars && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
                 continue;
 
-            if (IsScalarKind(prop.Kind) && !prop.IsSection)
+            if ((IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)) && !prop.IsSection)
                 scalarProps.Add(prop);
             else
                 nonScalarProps.Add(prop);
@@ -578,7 +578,8 @@ internal static class SerializerEmitter
         int nestingDepth = 0)
     {
         var indent = new string(' ', indentLevel * 4);
-        bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String);
+        bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
+            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null));
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
         if (useBuilder)
@@ -598,6 +599,12 @@ internal static class SerializerEmitter
                 {
                     sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {propAccess}));");
+                }
+                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                {
+                    var countProp = prop.IsArray ? "Length" : "Count";
+                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {GetScalarValueExpression(prop, propAccess)}));");
                 }
                 else
                 {
@@ -665,6 +672,12 @@ internal static class SerializerEmitter
                 sb.AppendLine($"{indent}if ({propAccess} != null)");
                 sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
             }
+            else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+            {
+                var countProp = prop.IsArray ? "Length" : "Count";
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {GetScalarValueExpression(prop, propAccess)});");
+            }
             else if (prop.Kind == PropertyKind.Boolean)
             {
                 if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
@@ -710,6 +723,13 @@ internal static class SerializerEmitter
                 sb.AppendLine($"{indent}if ({propAccess} != null)");
                 sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
             }
+            else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+            {
+                var countProp = prop.IsArray ? "Length" : "Count";
+                var valueStr = GetScalarValueExpression(prop, propAccess);
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+            }
             else
             {
                 var valueStr = GetScalarValueExpression(prop, propAccess);
@@ -721,6 +741,12 @@ internal static class SerializerEmitter
     private static string GetScalarValueExpression(PropertyMetadata prop, string propAccess, bool nullable = false)
     {
         var access = nullable ? $"{propAccess}.Value" : propAccess;
+
+        // Joined string array: render as string.Join(separator, collection)
+        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+        {
+            return $"string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess})";
+        }
 
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
         {
@@ -846,6 +872,12 @@ internal static class SerializerEmitter
         {
             var valueExpr = GetScalarValueExpression(prop, propAccess, nullable: true);
             return $"{propAccess}.HasValue ? {valueExpr} : \"\"";
+        }
+
+        // Joined string array in table cell
+        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+        {
+            return $"{propAccess} != null ? string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess}) : \"\"";
         }
 
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -244,6 +244,7 @@ internal enum PropertyKind
     Decimal,
     DateTime,
     DateTimeOffset,
+    Enum,
     StringArray,
     ComplexArray,
     NestedObject,

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -128,6 +128,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public bool IsNullableValueType { get; }
     public bool IsArray { get; }
     public string? CustomFormat { get; }
+    public string? JoinSeparator { get; }
 
     public PropertyMetadata(
         string name,
@@ -148,7 +149,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? boolFalseValue = null,
         bool isNullableValueType = false,
         bool isArray = false,
-        string? customFormat = null)
+        string? customFormat = null,
+        string? joinSeparator = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -169,6 +171,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         IsNullableValueType = isNullableValueType;
         IsArray = isArray;
         CustomFormat = customFormat;
+        JoinSeparator = joinSeparator;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -193,6 +196,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                IsNullableValueType == other.IsNullableValueType &&
                IsArray == other.IsArray &&
                CustomFormat == other.CustomFormat &&
+               JoinSeparator == other.JoinSeparator &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -285,6 +285,10 @@ internal static class TypeParser
         if (typeName == "System.DateTimeOffset")
             return (PropertyKind.DateTimeOffset, null, null, false, null, false);
 
+        // Enum types
+        if (type.TypeKind == TypeKind.Enum)
+            return (PropertyKind.Enum, null, null, false, null, false);
+
         // Check for arrays
         if (type is IArrayTypeSymbol arrayType)
         {
@@ -455,7 +459,8 @@ internal static class TypeParser
             PropertyKind.Double or 
             PropertyKind.Decimal or 
             PropertyKind.DateTime or 
-            PropertyKind.DateTimeOffset;
+            PropertyKind.DateTimeOffset or
+            PropertyKind.Enum;
     }
 
     private static string GetKindDisplayName(PropertyKind kind)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -20,6 +20,7 @@ internal static class TypeParser
     private const string MarkoutSectionAttribute = "Markout.MarkoutSectionAttribute";
     private const string MarkoutBoolFormatAttribute = "Markout.MarkoutBoolFormatAttribute";
     private const string MarkoutFormatAttribute = "Markout.MarkoutFormatAttribute";
+    private const string MarkoutJoinAttribute = "Markout.MarkoutJoinAttribute";
 
     public static ContextMetadata? ParseContext(
         GeneratorAttributeSyntaxContext context,
@@ -201,6 +202,16 @@ internal static class TypeParser
             customFormat = fmt;
         }
 
+        // Parse [MarkoutJoin] attribute
+        string? joinSeparator = null;
+        var joinAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutJoinAttribute);
+        if (joinAttr?.ConstructorArguments.Length > 0 &&
+            joinAttr.ConstructorArguments[0].Value is string sep)
+        {
+            joinSeparator = sep;
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -212,7 +223,9 @@ internal static class TypeParser
         var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, isArray) = DeterminePropertyKind(prop.Type, compilation, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
 
         // Determine if property is unsupported in table context
-        bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind);
+        // Joined string arrays are treated as scalars, so they're fine in tables
+        bool isJoinedArray = kind == PropertyKind.StringArray && joinSeparator != null;
+        bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind) && !isJoinedArray;
 
         // Emit warning for unsupported properties without [MarkoutIgnoreInTable]
         if (isUnsupportedInTable && !isIgnoredInTable)
@@ -245,7 +258,8 @@ internal static class TypeParser
             boolFalseValue,
             isNullableValueType,
             isArray,
-            customFormat);
+            customFormat,
+            joinSeparator);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)

--- a/src/Markout/Attributes/MarkoutJoinAttribute.cs
+++ b/src/Markout/Attributes/MarkoutJoinAttribute.cs
@@ -1,0 +1,27 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies that a string collection property (e.g., <c>List&lt;string&gt;</c>, <c>string[]</c>)
+/// should be rendered as a single joined field instead of a bullet list.
+/// </summary>
+/// <example>
+///   <code>
+///   [MarkoutJoin(", ")]
+///   public List&lt;string&gt; Tags { get; set; }
+///   // Renders as: Tags: api, web, tools
+///   </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutJoinAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the separator used to join the collection values.
+    /// </summary>
+    public string Separator { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified separator.
+    /// </summary>
+    /// <param name="separator">The string used to join collection values (e.g., ", ", " | ", " · ").</param>
+    public MarkoutJoinAttribute(string separator) => Separator = separator;
+}

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -378,6 +378,35 @@ public class SerializerTests
         Assert.NotNull(prop!.GetMethod);
         Assert.Null(prop.SetMethod);
     }
+
+    [Fact]
+    public void Serialize_EnumProperty_RendersEnumName()
+    {
+        var task = new TaskItem { Name = "Build", Priority = Priority.High };
+        var mdf = MarkoutSerializer.Serialize(task, EnumTestContext.Default);
+
+        Assert.Contains("Priority: High", mdf);
+        Assert.Contains("Name: Build", mdf);
+    }
+
+    [Fact]
+    public void Serialize_NullableEnum_SuppressesWhenNull()
+    {
+        var task = new TaskItem { Name = "Build", Priority = Priority.Low, OptionalPriority = null };
+        var mdf = MarkoutSerializer.Serialize(task, EnumTestContext.Default);
+
+        Assert.Contains("Priority: Low", mdf);
+        Assert.DoesNotContain("OptionalPriority", mdf);
+    }
+
+    [Fact]
+    public void Serialize_NullableEnum_RendersWhenSet()
+    {
+        var task = new TaskItem { Name = "Build", Priority = Priority.Low, OptionalPriority = Priority.Critical };
+        var mdf = MarkoutSerializer.Serialize(task, EnumTestContext.Default);
+
+        Assert.Contains("Critical", mdf);
+    }
 }
 
 [MarkoutSerializable]
@@ -503,3 +532,19 @@ public class RenderScalarsWarningTest
     // No [MarkoutSection] or FieldCollection properties - output will be empty
 }
 #pragma warning restore MARKOUT004
+
+// Enum support types
+public enum Priority { Low, Medium, High, Critical }
+
+[MarkoutSerializable]
+public class TaskItem
+{
+    public string? Name { get; set; }
+    public Priority Priority { get; set; }
+    public Priority? OptionalPriority { get; set; }
+}
+
+[MarkoutContext(typeof(TaskItem))]
+public partial class EnumTestContext : MarkoutSerializerContext
+{
+}

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -407,6 +407,44 @@ public class SerializerTests
 
         Assert.Contains("Critical", mdf);
     }
+
+    [Fact]
+    public void Serialize_JoinedList_RendersAsJoinedField()
+    {
+        var project = new ProjectInfo
+        {
+            Name = "MyLib",
+            Tags = ["api", "web", "tools"],
+            Frameworks = ["net8.0", "net9.0"]
+        };
+        var mdf = MarkoutSerializer.Serialize(project, JoinTestContext.Default);
+
+        Assert.Contains("Tags: api, web, tools", mdf);
+        Assert.Contains("Frameworks: net8.0 | net9.0", mdf);
+        Assert.DoesNotContain("- api", mdf); // Should NOT be a bullet list
+    }
+
+    [Fact]
+    public void Serialize_JoinedList_SuppressesWhenNull()
+    {
+        var project = new ProjectInfo { Name = "MyLib", Tags = null, Frameworks = null };
+        var mdf = MarkoutSerializer.Serialize(project, JoinTestContext.Default);
+
+        Assert.Contains("Name: MyLib", mdf);
+        Assert.DoesNotContain("Tags", mdf);
+        Assert.DoesNotContain("Frameworks", mdf);
+    }
+
+    [Fact]
+    public void Serialize_JoinedList_SuppressesWhenEmpty()
+    {
+        var project = new ProjectInfo { Name = "MyLib", Tags = [], Frameworks = [] };
+        var mdf = MarkoutSerializer.Serialize(project, JoinTestContext.Default);
+
+        Assert.Contains("Name: MyLib", mdf);
+        Assert.DoesNotContain("Tags", mdf);
+        Assert.DoesNotContain("Frameworks", mdf);
+    }
 }
 
 [MarkoutSerializable]
@@ -546,5 +584,21 @@ public class TaskItem
 
 [MarkoutContext(typeof(TaskItem))]
 public partial class EnumTestContext : MarkoutSerializerContext
+{
+}
+
+// Collection joining types
+[MarkoutSerializable]
+public class ProjectInfo
+{
+    public string? Name { get; set; }
+    [MarkoutJoin(", ")]
+    public List<string>? Tags { get; set; }
+    [MarkoutJoin(" | ")]
+    public string[]? Frameworks { get; set; }
+}
+
+[MarkoutContext(typeof(ProjectInfo))]
+public partial class JoinTestContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

Phase 2 expressiveness improvements: enum support and collection joining. Validated against dotnet-inspect (324 tests pass).

### Investigation findings

Before implementing, I investigated the current state of all 4 planned features:

- **`[MarkoutFormat]`**: ✅ Already works across all layouts via `GetScalarValueExpression`. No changes needed.
- **Null/empty suppression**: ✅ Already works — nullable value types skip when no value, strings skip when null/empty in all 3 layout methods. No changes needed.
- **Enum support**: ❌ Not implemented — enums fell to `PropertyKind.Other` and didn't render.
- **`[MarkoutJoin]`**: ❌ Not implemented.

### Enum support

Enums are now first-class scalar types in the source generator:

- Added `PropertyKind.Enum` to type classification
- Detect via `TypeKind.Enum` in `DetermineComplexPropertyKind`
- Generate `.ToString()` for enum values
- Works in all contexts: fields, compact fields, tables, list layout
- Nullable enums (`Priority?`) correctly suppress when null, render when set
- Schema shows "Field (enum)"

### `[MarkoutJoin]` attribute

New attribute that renders string collections as a single joined field:

```csharp
[MarkoutJoin(", ")]
public List<string> Tags { get; set; }
// Renders as: Tags: api, web, tools  (instead of a bullet list)

[MarkoutJoin(" | ")]
public string[] Frameworks { get; set; }
// Renders as: Frameworks: net8.0 | net9.0
```

- Works with both `List<string>` and `string[]`
- Null/empty collections automatically suppressed
- Works in all layouts (OneLine, LineBreaks, LineBreaksDoubleSpace, List)
- Works in table cells (renders joined string in column)
- No MARKOUT001 diagnostic for joined arrays (they're scalar-like)
- Schema shows "Field (joined)"

### Tests

- 6 new tests (3 enum, 3 join), all passing
- Total: 149 tests (up from 143)

### Validation

- ✅ Markout: 149 tests pass
- ✅ dotnet-inspect (worktree with project reference): 324 tests pass
