### PR TITLE
Architecture improvements: rename, context tracking, symbol caching, context options

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Latest LTS: 10.0
 - **`[MarkoutSerializable]`** - Marks a type for serialization
   - `TitleProperty` - Property to use as H1 title
   - `DescriptionProperty` - Property to render as paragraph after title
-  - `RenderScalars` - When `false`, only sections and field collections render (default: `true`)
+  - `AutoFields` - When `false`, only sections and field collections render (default: `true`)
 - **`[MarkoutPropertyName("...")]`** - Custom property display name
 - **`[MarkoutIgnore]`** - Excludes a property from output
 - **`[MarkoutIgnoreInTable]`** - Excludes a property only in table context (silences MARKOUT001 warning)
@@ -214,7 +214,7 @@ Latest LTS: 10.0
 For dynamic metadata, use `List<MarkoutField>` properties:
 
 ```csharp
-[MarkoutSerializable(RenderScalars = false)]
+[MarkoutSerializable(AutoFields = false)]
 public class PackageInfo
 {
     public string Name { get; set; }

--- a/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
+++ b/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
@@ -49,16 +49,16 @@ internal static class DiagnosticDescriptors
                      "or if keys are known at design time, use separate scalar properties."
     );
 
-    public static readonly DiagnosticDescriptor RenderScalarsNoContent = new(
+    public static readonly DiagnosticDescriptor AutoFieldsNoContent = new(
         id: "MARKOUT004",
-        title: "RenderScalars=false with no sections",
-        messageFormat: "Type '{0}' has RenderScalars=false but no [MarkoutSection] or FieldCollection properties. " +
+        title: "AutoFields=false with no sections",
+        messageFormat: "Type '{0}' has AutoFields=false but no [MarkoutSection] or FieldCollection properties. " +
                        "Output will be empty or contain only the title.",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "When RenderScalars is false, only properties with [MarkoutSection] or FieldCollection types are rendered. " +
+        description: "When AutoFields is false, only properties with [MarkoutSection] or FieldCollection types are rendered. " +
                      "Without any such properties, the serialized output will be empty or contain only the title/description. " +
-                     "Either add [MarkoutSection] to collection properties, or remove RenderScalars=false."
+                     "Either add [MarkoutSection] to collection properties, or remove AutoFields=false."
     );
 }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -112,7 +112,23 @@ internal static class SerializerEmitter
         sb.AppendLine("{");
 
         // Constructor accepting options
-        sb.AppendLine($"    public {context.ClassName}() {{ }}");
+        if (context.BoldFieldNames != null || context.IncludeIcons != null || context.IncludeDescription != null)
+        {
+            // Generate default constructor that applies compile-time options
+            sb.AppendLine($"    public {context.ClassName}() : base(new global::Markout.MarkoutWriterOptions");
+            sb.AppendLine("    {");
+            if (context.BoldFieldNames != null)
+                sb.AppendLine($"        BoldFieldNames = {(context.BoldFieldNames.Value ? "true" : "false")},");
+            if (context.IncludeIcons != null)
+                sb.AppendLine($"        IncludeIcons = {(context.IncludeIcons.Value ? "true" : "false")},");
+            if (context.IncludeDescription != null)
+                sb.AppendLine($"        IncludeDescription = {(context.IncludeDescription.Value ? "true" : "false")},");
+            sb.AppendLine("    }) { }");
+        }
+        else
+        {
+            sb.AppendLine($"    public {context.ClassName}() {{ }}");
+        }
         sb.AppendLine($"    public {context.ClassName}(global::Markout.MarkoutWriterOptions options) : base(options) {{ }}");
         sb.AppendLine();
 

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -86,7 +86,7 @@ internal static class SerializerEmitter
             propsToRender = type.Properties.Where(p => !skip.Contains(p.Name)).ToList();
         }
 
-        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.RenderScalars, type.FieldLayout);
+        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.AutoFields, type.FieldLayout);
 
         sb.AppendLine("    }");
         sb.AppendLine("}");
@@ -384,7 +384,7 @@ internal static class SerializerEmitter
         int indentLevel,
         int baseHeadingLevel = 2,
         int nestingDepth = 0,
-        bool renderScalars = true,
+        bool autoFields = true,
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine)
     {
         var indent = new string(' ', indentLevel * 4);
@@ -398,8 +398,8 @@ internal static class SerializerEmitter
             if (prop.IsIgnored)
                 continue;
 
-            // Skip non-section properties if RenderScalars is false
-            if (!renderScalars && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
+            // Skip non-section properties if AutoFields is false
+            if (!autoFields && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
                 continue;
 
             if ((IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)) && !prop.IsSection)
@@ -409,7 +409,7 @@ internal static class SerializerEmitter
         }
 
         // Emit scalars based on layout
-        if (renderScalars && scalarProps.Count > 0)
+        if (autoFields && scalarProps.Count > 0)
         {
             EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout, nestingDepth);
         }

--- a/src/Markout.SourceGeneration/Parser/ContextMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/ContextMetadata.cs
@@ -11,12 +11,19 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
     public string Namespace { get; }
     public string ClassName { get; }
     public IReadOnlyList<TypeMetadata> Types { get; }
+    public bool? BoldFieldNames { get; }
+    public bool? IncludeIcons { get; }
+    public bool? IncludeDescription { get; }
 
-    public ContextMetadata(string @namespace, string className, IReadOnlyList<TypeMetadata> types)
+    public ContextMetadata(string @namespace, string className, IReadOnlyList<TypeMetadata> types,
+        bool? boldFieldNames = null, bool? includeIcons = null, bool? includeDescription = null)
     {
         Namespace = @namespace;
         ClassName = className;
         Types = types;
+        BoldFieldNames = boldFieldNames;
+        IncludeIcons = includeIcons;
+        IncludeDescription = includeDescription;
     }
 
     public bool Equals(ContextMetadata? other)
@@ -25,6 +32,9 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
         if (ReferenceEquals(this, other)) return true;
         return Namespace == other.Namespace &&
                ClassName == other.ClassName &&
+               BoldFieldNames == other.BoldFieldNames &&
+               IncludeIcons == other.IncludeIcons &&
+               IncludeDescription == other.IncludeDescription &&
                SequenceEqual(Types, other.Types);
     }
 
@@ -34,6 +44,9 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
         unchecked
         {
             var hash = (Namespace?.GetHashCode() ?? 0) * 397 ^ (ClassName?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (BoldFieldNames?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (IncludeIcons?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (IncludeDescription?.GetHashCode() ?? 0);
             foreach (var type in Types)
                 hash = hash * 397 ^ type.GetHashCode();
             return hash;

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -1,0 +1,52 @@
+using Microsoft.CodeAnalysis;
+
+namespace Markout.SourceGeneration.Parser;
+
+/// <summary>
+/// Caches well-known type symbol lookups to avoid repeated string comparisons.
+/// </summary>
+internal sealed class KnownTypeSymbols
+{
+    private readonly Compilation _compilation;
+
+    // Lazy-resolved symbols
+    private INamedTypeSymbol? _markoutField;
+    private bool _markoutFieldResolved;
+
+    private INamedTypeSymbol? _treeNode;
+    private bool _treeNodeResolved;
+
+    private INamedTypeSymbol? _dateTime;
+    private bool _dateTimeResolved;
+
+    private INamedTypeSymbol? _dateTimeOffset;
+    private bool _dateTimeOffsetResolved;
+
+    private INamedTypeSymbol? _iDictionary;
+    private bool _iDictionaryResolved;
+
+    private INamedTypeSymbol? _iEnumerable;
+    private bool _iEnumerableResolved;
+
+    public KnownTypeSymbols(Compilation compilation)
+    {
+        _compilation = compilation;
+    }
+
+    public INamedTypeSymbol? MarkoutField => Resolve(ref _markoutField, ref _markoutFieldResolved, "Markout.MarkoutField");
+    public INamedTypeSymbol? TreeNode => Resolve(ref _treeNode, ref _treeNodeResolved, "Markout.TreeNode");
+    public INamedTypeSymbol? DateTime => Resolve(ref _dateTime, ref _dateTimeResolved, "System.DateTime");
+    public INamedTypeSymbol? DateTimeOffset => Resolve(ref _dateTimeOffset, ref _dateTimeOffsetResolved, "System.DateTimeOffset");
+    public INamedTypeSymbol? IDictionary => Resolve(ref _iDictionary, ref _iDictionaryResolved, "System.Collections.Generic.IDictionary`2");
+    public INamedTypeSymbol? IEnumerable => Resolve(ref _iEnumerable, ref _iEnumerableResolved, "System.Collections.Generic.IEnumerable`1");
+
+    private INamedTypeSymbol? Resolve(ref INamedTypeSymbol? field, ref bool resolved, string metadataName)
+    {
+        if (!resolved)
+        {
+            field = _compilation.GetTypeByMetadataName(metadataName);
+            resolved = true;
+        }
+        return field;
+    }
+}

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -34,7 +34,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public string? TitleProperty { get; }
     public string? TitleContextProperty { get; }
     public string? DescriptionProperty { get; }
-    public bool RenderScalars { get; }
+    public bool AutoFields { get; }
     public FieldLayoutKind FieldLayout { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
 
@@ -47,7 +47,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         string? titleProperty = null,
         string? titleContextProperty = null,
         string? descriptionProperty = null,
-        bool renderScalars = true,
+        bool autoFields = true,
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
@@ -59,7 +59,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         TitleProperty = titleProperty;
         TitleContextProperty = titleContextProperty;
         DescriptionProperty = descriptionProperty;
-        RenderScalars = renderScalars;
+        AutoFields = autoFields;
         FieldLayout = fieldLayout;
         Diagnostics = diagnostics ?? Array.Empty<DiagnosticInfo>();
     }
@@ -75,7 +75,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
                TitleProperty == other.TitleProperty &&
                TitleContextProperty == other.TitleContextProperty &&
                DescriptionProperty == other.DescriptionProperty &&
-               RenderScalars == other.RenderScalars &&
+               AutoFields == other.AutoFields &&
                FieldLayout == other.FieldLayout &&
                SequenceEqual(Properties, other.Properties);
     }
@@ -87,7 +87,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         {
             var hash = FullTypeName.GetHashCode();
             hash = hash * 397 ^ IsValueType.GetHashCode();
-            hash = hash * 397 ^ RenderScalars.GetHashCode();
+            hash = hash * 397 ^ AutoFields.GetHashCode();
             hash = hash * 397 ^ (int)FieldLayout;
             foreach (var prop in Properties)
                 hash = hash * 397 ^ prop.GetHashCode();

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Markout.SourceGeneration.Parser;
 
@@ -34,13 +33,15 @@ internal static class TypeParser
         if (contextAttributes.Length == 0)
             return null;
 
+        var knownTypes = new KnownTypeSymbols(context.SemanticModel.Compilation);
+
         var types = new List<TypeMetadata>();
         foreach (var attr in contextAttributes)
         {
             if (attr.ConstructorArguments.Length > 0 &&
                 attr.ConstructorArguments[0].Value is INamedTypeSymbol typeArg)
             {
-                var typeMeta = ParseTypeSymbol(typeArg, context.SemanticModel.Compilation, null, null, null, null);
+                var typeMeta = ParseTypeSymbol(typeArg, context.SemanticModel.Compilation, knownTypes, null, null, null, null);
                 if (typeMeta != null)
                     types.Add(typeMeta);
             }
@@ -56,7 +57,7 @@ internal static class TypeParser
     private static TypeMetadata? ParseTypeSymbol(
         INamedTypeSymbol typeSymbol,
         Compilation compilation,
-        GeneratorSyntaxContext? generatorContext,
+        KnownTypeSymbols knownTypes,
         string? titleProperty = null,
         string? titleContextProperty = null,
         string? descriptionProperty = null,
@@ -105,7 +106,7 @@ internal static class TypeParser
             if (prop.GetMethod == null)
                 continue;
 
-            var propMeta = ParseProperty(prop, compilation, diagnostics);
+            var propMeta = ParseProperty(prop, compilation, knownTypes, diagnostics);
             if (propMeta != null)
                 properties.Add(propMeta);
         }
@@ -146,6 +147,7 @@ internal static class TypeParser
     private static PropertyMetadata? ParseProperty(
         IPropertySymbol prop,
         Compilation compilation,
+        KnownTypeSymbols knownTypes,
         List<DiagnosticInfo> diagnostics)
     {
         var isIgnored = HasAttribute(prop, MarkoutIgnoreAttribute);
@@ -220,7 +222,7 @@ internal static class TypeParser
             isNullableValueType = true;
         }
 
-        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, isArray) = DeterminePropertyKind(prop.Type, compilation, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
+        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, isArray) = DeterminePropertyKind(prop.Type, compilation, knownTypes, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
 
         // Determine if property is unsupported in table context
         // Joined string arrays are treated as scalars, so they're fine in tables
@@ -263,16 +265,13 @@ internal static class TypeParser
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)
-        DeterminePropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
+        DeterminePropertyKind(ITypeSymbol type, Compilation compilation, KnownTypeSymbols knownTypes, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
-        var typeName = type.ToDisplayString();
-
         // Check for nullable value types
         if (type is INamedTypeSymbol namedType &&
             namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
         {
             type = namedType.TypeArguments[0];
-            typeName = type.ToDisplayString();
         }
 
         // Primitives
@@ -284,19 +283,17 @@ internal static class TypeParser
             SpecialType.System_Int64 => (PropertyKind.Int64, null, null, false, null, false),
             SpecialType.System_Double => (PropertyKind.Double, null, null, false, null, false),
             SpecialType.System_Decimal => (PropertyKind.Decimal, null, null, false, null, false),
-            _ => DetermineComplexPropertyKind(type, compilation, diagnostics, propertyName, propertyLocation)
+            _ => DetermineComplexPropertyKind(type, compilation, knownTypes, diagnostics, propertyName, propertyLocation)
         };
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)
-        DetermineComplexPropertyKind(ITypeSymbol type, Compilation compilation, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
+        DetermineComplexPropertyKind(ITypeSymbol type, Compilation compilation, KnownTypeSymbols knownTypes, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
-        var typeName = type.ToDisplayString();
-
         // DateTime types
-        if (typeName == "System.DateTime")
+        if (SymbolEqualityComparer.Default.Equals(type, knownTypes.DateTime))
             return (PropertyKind.DateTime, null, null, false, null, false);
-        if (typeName == "System.DateTimeOffset")
+        if (SymbolEqualityComparer.Default.Equals(type, knownTypes.DateTimeOffset))
             return (PropertyKind.DateTimeOffset, null, null, false, null, false);
 
         // Enum types
@@ -309,13 +306,13 @@ internal static class TypeParser
             var elementType = arrayType.ElementType;
 
             // Check for MarkoutField[] - renders as compact line or field table
-            if (elementType.ToDisplayString() == "Markout.MarkoutField")
+            if (SymbolEqualityComparer.Default.Equals(elementType, knownTypes.MarkoutField))
                 return (PropertyKind.FieldCollection, null, null, false, null, true);
 
             if (elementType.SpecialType == SpecialType.System_String)
                 return (PropertyKind.StringArray, null, null, false, null, true);
 
-            var elementProps = GetTypeProperties(elementType, compilation, diagnostics);
+            var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics);
             var hasNested = HasNestedContent(elementProps);
             var titleProp = GetTitleProperty(elementType);
             return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp, true);
@@ -325,8 +322,8 @@ internal static class TypeParser
         if (type is INamedTypeSymbol namedType)
         {
             // Detect Dictionary<TKey, TValue> before IEnumerable<T> since dictionaries implement IEnumerable<KeyValuePair>
-            var isDictionary = namedType.AllInterfaces.Any(i =>
-                i.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IDictionary<TKey, TValue>");
+            var isDictionary = knownTypes.IDictionary != null && namedType.AllInterfaces.Any(i =>
+                SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, knownTypes.IDictionary));
 
             if (isDictionary)
             {
@@ -340,8 +337,10 @@ internal static class TypeParser
                 return (PropertyKind.Other, null, null, false, null, false);
             }
 
-            var enumerableInterface = namedType.AllInterfaces
-                .FirstOrDefault(i => i.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>");
+            var enumerableInterface = knownTypes.IEnumerable != null
+                ? namedType.AllInterfaces.FirstOrDefault(i =>
+                    SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, knownTypes.IEnumerable))
+                : null;
 
             if (enumerableInterface != null ||
                 (namedType.OriginalDefinition.ToDisplayString().StartsWith("System.Collections.Generic.") &&
@@ -362,7 +361,7 @@ internal static class TypeParser
                 {
                     // Check for List<MarkoutField> or IReadOnlyList<MarkoutField> - renders as compact line or field table
                     // Requires materialized collection to avoid double-enumeration issues
-                    if (elementType.ToDisplayString() == "Markout.MarkoutField")
+                    if (SymbolEqualityComparer.Default.Equals(elementType, knownTypes.MarkoutField))
                     {
                         var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
                         if (typeDisplayString == "System.Collections.Generic.List<T>" ||
@@ -376,7 +375,7 @@ internal static class TypeParser
                     }
 
                     // Check for List<TreeNode> - renders as tree structure
-                    if (elementType.ToDisplayString() == "Markout.TreeNode")
+                    if (SymbolEqualityComparer.Default.Equals(elementType, knownTypes.TreeNode))
                     {
                         var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
                         if (typeDisplayString == "System.Collections.Generic.List<T>")
@@ -388,7 +387,7 @@ internal static class TypeParser
                     if (elementType.SpecialType == SpecialType.System_String)
                         return (PropertyKind.StringArray, null, null, false, null, false);
 
-                    var elementProps = GetTypeProperties(elementType, compilation, diagnostics);
+                    var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics);
                     var hasNested = HasNestedContent(elementProps);
                     var titleProp = GetTitleProperty(elementType);
                     return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp, false);
@@ -399,7 +398,7 @@ internal static class TypeParser
         // Nested object
         if (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct)
         {
-            var props = GetTypeProperties(type, compilation, diagnostics);
+            var props = GetTypeProperties(type, compilation, knownTypes, diagnostics);
             if (props.Count > 0)
                 return (PropertyKind.NestedObject, null, props, false, null, false);
         }
@@ -436,10 +435,12 @@ internal static class TypeParser
     private static IReadOnlyList<PropertyMetadata> GetTypeProperties(
         ITypeSymbol type,
         Compilation compilation,
+        KnownTypeSymbols? knownTypes = null,
         List<DiagnosticInfo>? diagnostics = null)
     {
         var properties = new List<PropertyMetadata>();
         diagnostics ??= new List<DiagnosticInfo>();
+        knownTypes ??= new KnownTypeSymbols(compilation);
 
         if (type is not INamedTypeSymbol namedType)
             return properties;
@@ -455,7 +456,7 @@ internal static class TypeParser
             if (prop.GetMethod == null)
                 continue;
 
-            var propMeta = ParseProperty(prop, compilation, diagnostics);
+            var propMeta = ParseProperty(prop, compilation, knownTypes, diagnostics);
             if (propMeta != null)
                 properties.Add(propMeta);
         }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -21,6 +21,8 @@ internal static class TypeParser
     private const string MarkoutFormatAttribute = "Markout.MarkoutFormatAttribute";
     private const string MarkoutJoinAttribute = "Markout.MarkoutJoinAttribute";
 
+    private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
+
     public static ContextMetadata? ParseContext(
         GeneratorAttributeSyntaxContext context,
         CancellationToken cancellationToken)
@@ -47,11 +49,30 @@ internal static class TypeParser
             }
         }
 
+        // Parse [MarkoutContextOptions] attribute
+        bool? boldFieldNames = null;
+        bool? includeIcons = null;
+        bool? includeDescription = null;
+        var optionsAttr = classSymbol.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutContextOptionsAttribute);
+        if (optionsAttr != null)
+        {
+            foreach (var named in optionsAttr.NamedArguments)
+            {
+                if (named.Key == "BoldFieldNames" && named.Value.Value is bool bf)
+                    boldFieldNames = bf;
+                else if (named.Key == "IncludeIcons" && named.Value.Value is bool ii)
+                    includeIcons = ii;
+                else if (named.Key == "IncludeDescription" && named.Value.Value is bool id)
+                    includeDescription = id;
+            }
+        }
+
         var ns = classSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : classSymbol.ContainingNamespace.ToDisplayString();
 
-        return new ContextMetadata(ns, classSymbol.Name, types);
+        return new ContextMetadata(ns, classSymbol.Name, types, boldFieldNames, includeIcons, includeDescription);
     }
 
     private static TypeMetadata? ParseTypeSymbol(

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -60,11 +60,11 @@ internal static class TypeParser
         string? titleProperty = null,
         string? titleContextProperty = null,
         string? descriptionProperty = null,
-        bool? renderScalars = null,
+        bool? autoFields = null,
         FieldLayoutKind? fieldLayout = null)
     {
         // If titleProperty/descriptionProperty not passed, try to get them from the type's [MarkoutSerializable] attribute
-        if (titleProperty == null || titleContextProperty == null || descriptionProperty == null || renderScalars == null || fieldLayout == null)
+        if (titleProperty == null || titleContextProperty == null || descriptionProperty == null || autoFields == null || fieldLayout == null)
         {
             var serializableAttr = typeSymbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutSerializableAttribute);
@@ -78,8 +78,8 @@ internal static class TypeParser
                         titleContextProperty ??= tcp;
                     else if (named.Key == "DescriptionProperty" && named.Value.Value is string dp)
                         descriptionProperty ??= dp;
-                    else if (named.Key == "RenderScalars" && named.Value.Value is bool rs)
-                        renderScalars ??= rs;
+                    else if (named.Key == "AutoFields" && named.Value.Value is bool af)
+                        autoFields ??= af;
                     else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
                         fieldLayout ??= (FieldLayoutKind)fl;
                 }
@@ -87,7 +87,7 @@ internal static class TypeParser
         }
 
         // Default to true if not specified
-        renderScalars ??= true;
+        autoFields ??= true;
         // Default to OneLine
         fieldLayout ??= FieldLayoutKind.OneLine;
 
@@ -110,8 +110,8 @@ internal static class TypeParser
                 properties.Add(propMeta);
         }
 
-        // Warn if RenderScalars=false but no sections or field collections exist
-        if (renderScalars == false)
+        // Warn if AutoFields=false but no sections or field collections exist
+        if (autoFields == false)
         {
             bool hasSectionOrFieldCollection = properties.Any(p => 
                 !p.IsIgnored && (p.IsSection || p.Kind == PropertyKind.FieldCollection));
@@ -119,7 +119,7 @@ internal static class TypeParser
             if (!hasSectionOrFieldCollection)
             {
                 diagnostics.Add(new DiagnosticInfo(
-                    DiagnosticDescriptors.RenderScalarsNoContent,
+                    DiagnosticDescriptors.AutoFieldsNoContent,
                     typeSymbol.Locations.FirstOrDefault(),
                     typeSymbol.Name));
             }
@@ -138,7 +138,7 @@ internal static class TypeParser
             titleProperty,
             titleContextProperty,
             descriptionProperty,
-            renderScalars.Value,
+            autoFields.Value,
             fieldLayout.Value,
             diagnostics);
     }

--- a/src/Markout/Attributes/MarkoutContextOptionsAttribute.cs
+++ b/src/Markout/Attributes/MarkoutContextOptionsAttribute.cs
@@ -1,0 +1,36 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies default writer options for a serializer context at compile time.
+/// Options set here are baked into the generated context's default constructor.
+/// They can still be overridden by passing a <see cref="MarkoutWriterOptions"/> instance
+/// to the context constructor at runtime.
+/// </summary>
+/// <example>
+///   <code>
+///   [MarkoutContextOptions(BoldFieldNames = true, IncludeIcons = false)]
+///   [MarkoutContext(typeof(MyType))]
+///   public partial class MyContext : MarkoutSerializerContext { }
+///   </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutContextOptionsAttribute : Attribute
+{
+    /// <summary>
+    /// Gets or sets whether field names should be rendered in bold.
+    /// Default is false.
+    /// </summary>
+    public bool BoldFieldNames { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to include icons in tree nodes.
+    /// Default is true.
+    /// </summary>
+    public bool IncludeIcons { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to include the description paragraph.
+    /// Default is true.
+    /// </summary>
+    public bool IncludeDescription { get; set; } = true;
+}

--- a/src/Markout/Attributes/MarkoutSerializableAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSerializableAttribute.cs
@@ -31,7 +31,7 @@ public sealed class MarkoutSerializableAttribute : Attribute
     /// When false, only properties marked with [MarkoutSection] or IEnumerable&lt;MarkoutField&gt;
     /// properties are rendered. Default is true.
     /// </summary>
-    public bool RenderScalars { get; set; } = true;
+    public bool AutoFields { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the layout for scalar fields.

--- a/src/Markout/MarkoutRenderContext.cs
+++ b/src/Markout/MarkoutRenderContext.cs
@@ -1,0 +1,25 @@
+namespace Markout;
+
+/// <summary>
+/// Describes the current rendering context of a <see cref="MarkoutWriter"/>.
+/// Used to determine what Markdown constructs are valid at the current position.
+/// </summary>
+public enum MarkoutRenderContext
+{
+    /// <summary>
+    /// Top-level block context. Any Markdown construct is valid.
+    /// </summary>
+    Block,
+
+    /// <summary>
+    /// Inside a table. Only inline content and escaped values are valid.
+    /// Block-level elements (headings, code blocks, lists) are not allowed.
+    /// </summary>
+    Table,
+
+    /// <summary>
+    /// Inside a fenced code block. Content is rendered literally, not as Markdown.
+    /// Nested code fences are not allowed.
+    /// </summary>
+    CodeBlock
+}

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -396,8 +396,7 @@ public sealed class MarkoutWriter
             if (i > 0)
                 _writer.Write(" | ");
 
-            _writer.Write(fields[i].Key);
-            _writer.Write(": ");
+            WriteFieldName(fields[i].Key);
             _writer.Write(fields[i].Value ?? string.Empty);
         }
 
@@ -423,8 +422,7 @@ public sealed class MarkoutWriter
             if (i > 0)
                 _writer.Write(" | ");
 
-            _writer.Write(fields[i].Key);
-            _writer.Write(": ");
+            WriteFieldName(fields[i].Key);
             _writer.Write(fields[i].Value ?? string.Empty);
         }
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -22,6 +22,7 @@ public sealed class MarkoutWriter
     private bool _needsBlankLine;
     private bool _hasContent;
     private bool _inTable;
+    private bool _inCodeBlock;
     private string? _currentSectionName;
     private bool _sectionExcluded;
 
@@ -99,6 +100,14 @@ public sealed class MarkoutWriter
     /// Gets whether to include icons in tree nodes.
     /// </summary>
     public bool IncludeIcons => _options.IncludeIcons;
+
+    /// <summary>
+    /// Gets the current rendering context, indicating what Markdown constructs are valid.
+    /// </summary>
+    public MarkoutRenderContext CurrentContext =>
+        _inCodeBlock ? MarkoutRenderContext.CodeBlock :
+        _inTable ? MarkoutRenderContext.Table :
+        MarkoutRenderContext.Block;
 
     /// <summary>
     /// Flushes any buffered output to the underlying stream.
@@ -214,24 +223,38 @@ public sealed class MarkoutWriter
     /// <summary>
     /// Starts a code block with optional language specifier.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if already inside a code block.</exception>
     public void WriteCodeBlockStart(string? language = null)
     {
+        if (_inCodeBlock)
+            throw new InvalidOperationException("Cannot nest code blocks. End the current code block before starting a new one.");
+
         if (_sectionExcluded)
+        {
+            _inCodeBlock = true;
             return;
+        }
 
         EnsureBlankLineIfNeeded();
         _writer.Write("```");
         if (!string.IsNullOrEmpty(language))
             _writer.Write(language);
         _writer.WriteLine();
+        _inCodeBlock = true;
         _hasContent = true;
     }
 
     /// <summary>
     /// Ends a code block.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if not inside a code block.</exception>
     public void WriteCodeBlockEnd()
     {
+        if (!_inCodeBlock)
+            throw new InvalidOperationException("Cannot end a code block without starting one first.");
+
+        _inCodeBlock = false;
+
         if (_sectionExcluded)
             return;
 
@@ -492,6 +515,9 @@ public sealed class MarkoutWriter
     /// </summary>
     public void WriteTableStart(params ReadOnlySpan<string> headers)
     {
+        if (_inCodeBlock)
+            throw new InvalidOperationException("Cannot start a table inside a code block.");
+
         if (_sectionExcluded)
         {
             _inTable = true; // Track state even when excluded

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -465,4 +465,54 @@ public class MarkoutWriterTests
         var expected = "# Title\n\nPreamble text";
         Assert.Equal(expected, writer.ToString());
     }
+
+    [Fact]
+    public void CurrentContext_DefaultIsBlock()
+    {
+        var writer = new MarkoutWriter();
+        Assert.Equal(MarkoutRenderContext.Block, writer.CurrentContext);
+    }
+
+    [Fact]
+    public void CurrentContext_InTable_ReturnsTable()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteTableStart("A", "B");
+        Assert.Equal(MarkoutRenderContext.Table, writer.CurrentContext);
+        writer.WriteTableEnd();
+        Assert.Equal(MarkoutRenderContext.Block, writer.CurrentContext);
+    }
+
+    [Fact]
+    public void CurrentContext_InCodeBlock_ReturnsCodeBlock()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteCodeBlockStart("csharp");
+        Assert.Equal(MarkoutRenderContext.CodeBlock, writer.CurrentContext);
+        writer.WriteCodeBlockEnd();
+        Assert.Equal(MarkoutRenderContext.Block, writer.CurrentContext);
+    }
+
+    [Fact]
+    public void WriteCodeBlockStart_Nested_Throws()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteCodeBlockStart();
+        Assert.Throws<InvalidOperationException>(() => writer.WriteCodeBlockStart());
+    }
+
+    [Fact]
+    public void WriteCodeBlockEnd_WithoutStart_Throws()
+    {
+        var writer = new MarkoutWriter();
+        Assert.Throws<InvalidOperationException>(() => writer.WriteCodeBlockEnd());
+    }
+
+    [Fact]
+    public void WriteTableStart_InCodeBlock_Throws()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteCodeBlockStart();
+        Assert.Throws<InvalidOperationException>(() => writer.WriteTableStart("A"));
+    }
 }

--- a/tests/Markout.Tests/NullableAndTitleTests.cs
+++ b/tests/Markout.Tests/NullableAndTitleTests.cs
@@ -67,7 +67,7 @@ public class StringOnlyOneLine
 
 // --- Title dedup test models ---
 
-[MarkoutSerializable(TitleProperty = nameof(Name), RenderScalars = true)]
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = true)]
 public class TitleDedupRecord
 {
     public string Name { get; set; } = "";
@@ -75,7 +75,7 @@ public class TitleDedupRecord
     public int Count { get; set; }
 }
 
-[MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Summary), RenderScalars = true)]
+[MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Summary), AutoFields = true)]
 public class TitleAndDescDedupRecord
 {
     public string Name { get; set; } = "";
@@ -84,7 +84,7 @@ public class TitleAndDescDedupRecord
     public int Count { get; set; }
 }
 
-[MarkoutSerializable(TitleProperty = nameof(Name), TitleContextProperty = nameof(Version), RenderScalars = true)]
+[MarkoutSerializable(TitleProperty = nameof(Name), TitleContextProperty = nameof(Version), AutoFields = true)]
 public class TitleContextDedupRecord
 {
     public string Name { get; set; } = "";

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -311,11 +311,11 @@ public class SerializerTests
     }
 
     [Fact]
-    public void Serialize_RenderScalarsFalseWithNoSections_ProducesEmptyOutput()
+    public void Serialize_AutoFieldsFalseWithNoSections_ProducesEmptyOutput()
     {
-        // This type has RenderScalars=false but no sections - output will be empty
+        // This type has AutoFields=false but no sections - output will be empty
         // The MARKOUT004 warning is suppressed with #pragma in the type definition
-        var data = new RenderScalarsWarningTest { Name = "Test", Count = 42 };
+        var data = new AutoFieldsWarningTest { Name = "Test", Count = 42 };
 
         var context = new TreeTestContext();
         var mdf = context.Serialize(data);
@@ -538,7 +538,7 @@ public class FileExplorer
 
 [MarkoutContext(typeof(TypeShape))]
 [MarkoutContext(typeof(FileExplorer))]
-[MarkoutContext(typeof(RenderScalarsWarningTest))]
+[MarkoutContext(typeof(AutoFieldsWarningTest))]
 public partial class TreeTestContext : MarkoutSerializerContext
 {
 }
@@ -560,10 +560,10 @@ public partial class DictionaryTestContext : MarkoutSerializerContext
 }
 
 // Test type that intentionally triggers MARKOUT004 warning
-// This verifies the analyzer correctly warns when RenderScalars=false but no sections exist
+// This verifies the analyzer correctly warns when AutoFields=false but no sections exist
 #pragma warning disable MARKOUT004
-[MarkoutSerializable(RenderScalars = false)]
-public class RenderScalarsWarningTest
+[MarkoutSerializable(AutoFields = false)]
+public class AutoFieldsWarningTest
 {
     public string Name { get; set; } = "";
     public int Count { get; set; }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -44,6 +44,19 @@ public partial class TestMarkoutContext : MarkoutSerializerContext
 {
 }
 
+[MarkoutSerializable]
+public class BoldRecord
+{
+    public string? Label { get; set; }
+    public int Value { get; set; }
+}
+
+[MarkoutContextOptions(BoldFieldNames = true)]
+[MarkoutContext(typeof(BoldRecord))]
+public partial class BoldContext : MarkoutSerializerContext
+{
+}
+
 public class SerializerTests
 {
     [Fact]
@@ -377,6 +390,21 @@ public class SerializerTests
         Assert.NotNull(prop);
         Assert.NotNull(prop!.GetMethod);
         Assert.Null(prop.SetMethod);
+    }
+
+    [Fact]
+    public void ContextOptions_BoldFieldNames_AppliedToDefault()
+    {
+        var context = BoldContext.Default;
+        Assert.True(context.Options.BoldFieldNames);
+    }
+
+    [Fact]
+    public void ContextOptions_BoldFieldNames_RendersInOutput()
+    {
+        var record = new BoldRecord { Label = "Test", Value = 1 };
+        var mdf = MarkoutSerializer.Serialize(record, BoldContext.Default);
+        Assert.Contains("**Label:**", mdf);
     }
 
     [Fact]


### PR DESCRIPTION
## Phase 3: Architecture Improvements

### Changes

1. **Rename `RenderScalars` → `AutoFields`** (breaking change)
   - Clearer terminology: "auto fields" describes automatic field rendering
   - Updated attribute, parser, emitter, diagnostics, tests, and README

2. **Writer context tracking and nesting validation**
   - New `MarkoutRenderContext` enum (Block, Table, CodeBlock)
   - `CurrentContext` property on `MarkoutWriter`
   - `_inCodeBlock` tracking with nesting validation
   - 6 new tests

3. **`KnownTypeSymbols` caching**
   - Replaces `ToDisplayString()` string comparisons with `SymbolEqualityComparer` lookups
   - Lazy resolution via `Compilation.GetTypeByMetadataName()`
   - Covers DateTime, DateTimeOffset, MarkoutField, TreeNode, IDictionary, IEnumerable

4. **`[MarkoutContextOptions]` attribute**
   - New attribute with `BoldFieldNames`, `IncludeIcons`, `IncludeDescription` properties
   - Parser reads from context class, emitter generates constructor with compile-time defaults
   - Fixed `WriteCompactFields` to respect `BoldFieldNames` via `WriteFieldName`
   - 2 new tests

### Testing
- 157 tests pass (8 new)
- Validated against dotnet-inspect (324 tests pass, requires `RenderScalars` → `AutoFields` rename)

### Breaking Changes
- `RenderScalars` property renamed to `AutoFields` on `[MarkoutSerializable]`
- Diagnostic ID `MARKOUT001` message updated from "RenderScalars" to "AutoFields"
