### PR TITLE
Stage-based emission refactor and IMarkoutFormattable interface

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Markout.SourceGeneration.Parser;
+
+namespace Markout.SourceGeneration.Emitter;
+
+/// <summary>
+/// Emits source code for table and subsection-per-item rendering.
+/// </summary>
+internal static class CollectionEmitter
+{
+    public static void EmitTableSerialization(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        int indentLevel,
+        int nestingDepth = 0)
+    {
+        if (prop.ElementProperties == null || prop.ElementProperties.Count == 0)
+            return;
+
+        var indent = new string(' ', indentLevel * 4);
+        var visibleProps = prop.ElementProperties.Where(p => !p.IsIgnored).ToList();
+        var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
+
+        // Build header array
+        var headers = string.Join(", ", visibleProps.Select(p => $"\"{EmitHelpers.EscapeString(p.DisplayName)}\""));
+        sb.AppendLine($"{indent}writer.WriteTableStart({headers});");
+
+        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
+        sb.AppendLine($"{indent}{{");
+
+        // Build row values
+        var values = new List<string>();
+        foreach (var elemProp in visibleProps)
+        {
+            var value = EmitHelpers.GetTableCellValue(elemProp, itemVar);
+            values.Add(value);
+        }
+
+        sb.AppendLine($"{indent}    writer.WriteTableRow({string.Join(", ", values)});");
+        sb.AppendLine($"{indent}}}");
+        sb.AppendLine($"{indent}writer.WriteTableEnd();");
+    }
+
+    public static void EmitSubsectionPerItemSerialization(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        int indentLevel,
+        int parentSectionLevel = 2,
+        int nestingDepth = 0)
+    {
+        if (prop.ElementProperties == null || prop.ElementProperties.Count == 0)
+            return;
+
+        var indent = new string(' ', indentLevel * 4);
+        var subsectionLevel = parentSectionLevel + 1;
+        var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
+
+        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
+        sb.AppendLine($"{indent}{{");
+
+        // Write subsection heading using TitleProperty or first string property
+        if (!string.IsNullOrEmpty(prop.ElementTitleProperty))
+        {
+            sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
+            sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty});");
+        }
+        else
+        {
+            // Try to find a suitable property for the heading
+            var titleProp = prop.ElementProperties.FirstOrDefault(p => 
+                !p.IsIgnored && p.Kind == PropertyKind.String && 
+                (p.Name == "Name" || p.Name == "Title" || p.Name == "Id"));
+            
+            if (titleProp != null)
+            {
+                sb.AppendLine($"{indent}    if ({itemVar}.{titleProp.Name} != null)");
+                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{titleProp.Name});");
+            }
+            else
+            {
+                // Fallback: use first string property
+                var firstString = prop.ElementProperties.FirstOrDefault(p => !p.IsIgnored && p.Kind == PropertyKind.String);
+                if (firstString != null)
+                {
+                    sb.AppendLine($"{indent}    if ({itemVar}.{firstString.Name} != null)");
+                    sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{firstString.Name});");
+                }
+            }
+        }
+
+        // Emit property serializations for each item, at a deeper level
+        SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1);
+
+        sb.AppendLine($"{indent}}}");
+    }
+}

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -1,0 +1,118 @@
+using System.Linq;
+using System.Text;
+using Markout.SourceGeneration.Parser;
+
+namespace Markout.SourceGeneration.Emitter;
+
+/// <summary>
+/// Shared helper methods for code emission.
+/// </summary>
+internal static class EmitHelpers
+{
+    public static string GetScalarValueExpression(PropertyMetadata prop, string propAccess, bool nullable = false)
+    {
+        var access = nullable ? $"{propAccess}.Value" : propAccess;
+
+        // Joined string array: render as string.Join(separator, collection)
+        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+        {
+            return $"string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess})";
+        }
+
+        if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+        {
+            return $"({access} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\")";
+        }
+
+        // Custom format overrides default formatting for formattable types
+        if (prop.CustomFormat != null)
+        {
+            if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
+            {
+                return $"{access}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+            }
+        }
+
+        return prop.Kind switch
+        {
+            PropertyKind.Boolean => $"({access} ? \"yes\" : \"no\")",
+            PropertyKind.String => $"{propAccess} ?? \"\"",
+            PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                => $"{access}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.DateTime or PropertyKind.DateTimeOffset
+                => $"{access}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.Enum => $"{access}.ToString()",
+            _ => $"{propAccess}?.ToString() ?? \"\""
+        };
+    }
+
+    public static string GetTableCellValue(PropertyMetadata prop, string itemExpr)
+    {
+        var propAccess = $"{itemExpr}.{prop.Name}";
+
+        if (prop.IsNullableValueType)
+        {
+            var valueExpr = GetScalarValueExpression(prop, propAccess, nullable: true);
+            return $"{propAccess}.HasValue ? {valueExpr} : \"\"";
+        }
+
+        // Joined string array in table cell
+        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+        {
+            return $"{propAccess} != null ? string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess}) : \"\"";
+        }
+
+        if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+        {
+            return $"{propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\"";
+        }
+
+        // Custom format overrides default formatting for formattable types
+        if (prop.CustomFormat != null)
+        {
+            if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
+            {
+                return $"{propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+            }
+        }
+
+        return prop.Kind switch
+        {
+            PropertyKind.Boolean => $"{propAccess} ? \"yes\" : \"no\"",
+            PropertyKind.String => $"{propAccess} ?? \"\"",
+            PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                => $"{propAccess}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.DateTime or PropertyKind.DateTimeOffset
+                => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.Enum => $"{propAccess}.ToString()",
+            _ => $"{propAccess}?.ToString() ?? \"\""
+        };
+    }
+
+    public static string GetCollectionCountCheck(PropertyMetadata prop, string propAccess)
+    {
+        var countProp = prop.IsArray ? "Length" : "Count";
+        return $"{propAccess} != null && {propAccess}.{countProp} > 0";
+    }
+
+    public static bool IsScalarKind(PropertyKind kind)
+    {
+        return kind is
+            PropertyKind.String or
+            PropertyKind.Boolean or
+            PropertyKind.Int32 or
+            PropertyKind.Int64 or
+            PropertyKind.Double or
+            PropertyKind.Decimal or
+            PropertyKind.DateTime or
+            PropertyKind.DateTimeOffset or
+            PropertyKind.Enum;
+    }
+
+    public static string EscapeString(string s)
+    {
+        return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -87,6 +87,7 @@ internal static class EmitHelpers
             PropertyKind.DateTime or PropertyKind.DateTimeOffset
                 => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
             PropertyKind.Enum => $"{propAccess}.ToString()",
+            PropertyKind.Formattable => $"((global::Markout.IMarkoutFormattable){propAccess})?.ToMarkoutString() ?? \"\"",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
     }

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Markout.SourceGeneration.Parser;
+
+namespace Markout.SourceGeneration.Emitter;
+
+/// <summary>
+/// Emits source code for scalar field rendering across different layouts.
+/// </summary>
+internal static class FieldEmitter
+{
+    public static void EmitScalarsWithLayout(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        FieldLayoutKind fieldLayout,
+        int nestingDepth = 0)
+    {
+        switch (fieldLayout)
+        {
+            case FieldLayoutKind.OneLine:
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
+                break;
+
+            case FieldLayoutKind.LineBreaks:
+                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: false);
+                break;
+
+            case FieldLayoutKind.LineBreaksDoubleSpace:
+                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: true);
+                break;
+
+            case FieldLayoutKind.List:
+                EmitListScalars(sb, scalarProps, valueExpr, indentLevel);
+                break;
+
+            default:
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
+                break;
+        }
+    }
+
+    private static void EmitOneLineScalars(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        int nestingDepth = 0)
+    {
+        var indent = new string(' ', indentLevel * 4);
+        bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
+            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null));
+        var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
+
+        if (useBuilder)
+        {
+            // Use List<MarkoutField> builder pattern when any scalar is nullable or string (to skip nulls/empties)
+            sb.AppendLine($"{indent}var {fieldsVar} = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+            foreach (var prop in scalarProps)
+            {
+                var propAccess = $"{valueExpr}.{prop.Name}";
+                if (prop.IsNullableValueType)
+                {
+                    var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
+                    sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+                else if (prop.Kind == PropertyKind.String)
+                {
+                    sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({propAccess}))");
+                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}));");
+                }
+                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                {
+                    var countProp = prop.IsArray ? "Length" : "Count";
+                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)}));");
+                }
+                else
+                {
+                    var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                    sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+            }
+            sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
+            sb.AppendLine($"{indent}    writer.WriteCompactFields({fieldsVar});");
+        }
+        else
+        {
+            // Build inline MarkoutField array (no nullable/string scalars)
+            var fields = new List<string>();
+            foreach (var prop in scalarProps)
+            {
+                var propAccess = $"{valueExpr}.{prop.Name}";
+                var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                fields.Add($"new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr})");
+            }
+
+            sb.AppendLine($"{indent}writer.WriteCompactFields({string.Join(", ", fields)});");
+        }
+    }
+
+    private static void EmitLineBreaksScalars(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        bool doubleSpace)
+    {
+        var indent = new string(' ', indentLevel * 4);
+        var methodName = doubleSpace ? "WriteField" : "WriteFieldNoBreak";
+
+        foreach (var prop in scalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+
+            if (prop.IsNullableValueType)
+            {
+                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                if (prop.Kind == PropertyKind.Boolean)
+                {
+                    if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+                    {
+                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                    }
+                }
+                else if (prop.CustomFormat != null)
+                {
+                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                }
+            }
+            else if (prop.Kind == PropertyKind.String)
+            {
+                sb.AppendLine($"{indent}if ({propAccess} != null)");
+                sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+            }
+            else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+            {
+                var countProp = prop.IsArray ? "Length" : "Count";
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)});");
+            }
+            else if (prop.Kind == PropertyKind.Boolean)
+            {
+                if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+                {
+                    sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess} ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+                }
+            }
+            else if (prop.CustomFormat != null)
+            {
+                sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+            }
+        }
+    }
+
+    private static void EmitListScalars(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel)
+    {
+        var indent = new string(' ', indentLevel * 4);
+
+        foreach (var prop in scalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+
+            if (prop.IsNullableValueType)
+            {
+                var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
+                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+            }
+            else if (prop.Kind == PropertyKind.String)
+            {
+                sb.AppendLine($"{indent}if ({propAccess} != null)");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
+            }
+            else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+            {
+                var countProp = prop.IsArray ? "Length" : "Count";
+                var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+            }
+            else
+            {
+                var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                sb.AppendLine($"{indent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+            }
+        }
+    }
+}

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -312,8 +312,17 @@ internal static class SerializerEmitter
             EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1);
             sb.AppendLine($"{indent}}}");
         }
+        else if (prop.Kind == PropertyKind.Formattable)
+        {
+            sb.AppendLine($"{indent}if ({propAccess} != null)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    ((global::Markout.IMarkoutFormattable){propAccess}).WriteTo(writer);");
+            sb.AppendLine($"{indent}}}");
+        }
         else
         {
+            // For other types, just write the heading unconditionally
             sb.AppendLine($"{indent}writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
         }
     }
@@ -372,6 +381,11 @@ internal static class SerializerEmitter
                     EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth + 1, true, fieldLayout);
                     sb.AppendLine($"{indent}}}");
                 }
+                break;
+
+            case PropertyKind.Formattable:
+                sb.AppendLine($"{indent}if ({propAccess} != null)");
+                sb.AppendLine($"{indent}    ((global::Markout.IMarkoutFormattable){propAccess}).WriteTo(writer);");
                 break;
         }
     }
@@ -546,6 +560,7 @@ internal static class SerializerEmitter
                 : "Table",
             PropertyKind.FieldCollection => "Compact fields",
             PropertyKind.NestedObject => "Fields",
+            PropertyKind.Formattable => "Custom (IMarkoutFormattable)",
             PropertyKind.Tree => "Tree",
             _ => "Field"
         };

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -6,7 +6,10 @@ using Markout.SourceGeneration.Parser;
 namespace Markout.SourceGeneration.Emitter;
 
 /// <summary>
-/// Emits source code for Markout serialization.
+/// Coordinates source code emission for Markout serialization.
+/// Delegates to <see cref="FieldEmitter"/> for scalar field layouts,
+/// <see cref="CollectionEmitter"/> for tables and subsections,
+/// and <see cref="EmitHelpers"/> for shared value expressions.
 /// </summary>
 internal static class SerializerEmitter
 {
@@ -191,6 +194,188 @@ internal static class SerializerEmitter
         return sb.ToString();
     }
 
+    // EmitPropertySerializations is internal so CollectionEmitter can call back into it
+    // for recursive subsection rendering.
+    internal static void EmitPropertySerializations(
+        StringBuilder sb,
+        IReadOnlyList<PropertyMetadata> properties,
+        string valueExpr,
+        int indentLevel,
+        int baseHeadingLevel = 2,
+        int nestingDepth = 0,
+        bool autoFields = true,
+        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine)
+    {
+        var indent = new string(' ', indentLevel * 4);
+
+        // Separate scalars from non-scalars for field layout handling
+        var scalarProps = new List<PropertyMetadata>();
+        var nonScalarProps = new List<PropertyMetadata>();
+
+        foreach (var prop in properties)
+        {
+            if (prop.IsIgnored)
+                continue;
+
+            // Skip non-section properties if AutoFields is false
+            if (!autoFields && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
+                continue;
+
+            if ((EmitHelpers.IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)) && !prop.IsSection)
+                scalarProps.Add(prop);
+            else
+                nonScalarProps.Add(prop);
+        }
+
+        // Emit scalars based on layout
+        if (autoFields && scalarProps.Count > 0)
+        {
+            FieldEmitter.EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout, nestingDepth);
+        }
+
+        // Emit non-scalar properties (sections, arrays, etc.)
+        foreach (var prop in nonScalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+            var effectiveSectionLevel = prop.IsSection 
+                ? System.Math.Max(prop.SectionLevel, baseHeadingLevel) 
+                : baseHeadingLevel;
+
+            if (prop.IsSection)
+            {
+                EmitSectionProperty(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout);
+                continue;
+            }
+
+            // Non-section property handling
+            EmitNonSectionProperty(sb, prop, propAccess, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout);
+        }
+    }
+
+    private static void EmitSectionProperty(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        int indentLevel,
+        int effectiveSectionLevel,
+        int nestingDepth,
+        FieldLayoutKind fieldLayout)
+    {
+        var sectionName = prop.SectionName ?? prop.DisplayName;
+
+        if (prop.Kind == PropertyKind.FieldCollection)
+        {
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteFieldTable({propAccess});");
+            sb.AppendLine($"{indent}}}");
+        }
+        else if (prop.Kind == PropertyKind.ComplexArray && prop.ElementProperties != null)
+        {
+            sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            
+            if (prop.ElementHasNestedContent)
+            {
+                CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+            }
+            else
+            {
+                CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+            }
+            sb.AppendLine($"{indent}}}");
+        }
+        else if (prop.Kind == PropertyKind.StringArray)
+        {
+            sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteArray({propAccess});");
+            sb.AppendLine($"{indent}}}");
+        }
+        else if (prop.Kind == PropertyKind.Tree)
+        {
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteTree({propAccess});");
+            sb.AppendLine($"{indent}}}");
+        }
+        else if (prop.Kind == PropertyKind.NestedObject && prop.ElementProperties != null)
+        {
+            sb.AppendLine($"{indent}if ({propAccess} != null)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1);
+            sb.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            sb.AppendLine($"{indent}writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+        }
+    }
+
+    private static void EmitNonSectionProperty(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        int indentLevel,
+        int baseHeadingLevel,
+        int nestingDepth,
+        FieldLayoutKind fieldLayout)
+    {
+        switch (prop.Kind)
+        {
+            case PropertyKind.StringArray:
+                sb.AppendLine($"{indent}if ({propAccess} != null)");
+                sb.AppendLine($"{indent}    writer.WriteArray(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+                break;
+
+            case PropertyKind.FieldCollection:
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}    writer.WriteCompactFields({propAccess});");
+                break;
+
+            case PropertyKind.Tree:
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}    writer.WriteTree({propAccess});");
+                break;
+
+            case PropertyKind.ComplexArray:
+                if (prop.ElementProperties != null && prop.ElementProperties.Count > 0)
+                {
+                    sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
+                    sb.AppendLine($"{indent}{{");
+                    sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EmitHelpers.EscapeString(prop.DisplayName)}\");");
+                    if (prop.ElementHasNestedContent)
+                    {
+                        CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, baseHeadingLevel, nestingDepth);
+                    }
+                    else
+                    {
+                        CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                    }
+                    sb.AppendLine($"{indent}}}");
+                }
+                break;
+
+            case PropertyKind.NestedObject:
+                if (prop.ElementProperties != null && prop.ElementProperties.Count > 0)
+                {
+                    sb.AppendLine($"{indent}if ({propAccess} != null)");
+                    sb.AppendLine($"{indent}{{");
+                    sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EmitHelpers.EscapeString(prop.DisplayName)}\");");
+                    EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth + 1, true, fieldLayout);
+                    sb.AppendLine($"{indent}}}");
+                }
+                break;
+        }
+    }
+
     private static void EmitSchemaProperty(StringBuilder sb, TypeMetadata type)
     {
         sb.AppendLine($"    private static global::Markout.MarkoutSchemaInfo? _{type.TypeName}Schema;");
@@ -220,9 +405,9 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}new()");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    Name = \"{prop.Name}\",");
-            sb.AppendLine($"{indent}    DisplayName = \"{EscapeString(prop.DisplayName)}\",");
-            sb.AppendLine($"{indent}    TypeName = \"{EscapeString(GetSimpleTypeName(prop.TypeName))}\",");
-            sb.AppendLine($"{indent}    Rendering = \"{EscapeString(rendering)}\",");
+            sb.AppendLine($"{indent}    DisplayName = \"{EmitHelpers.EscapeString(prop.DisplayName)}\",");
+            sb.AppendLine($"{indent}    TypeName = \"{EmitHelpers.EscapeString(GetSimpleTypeName(prop.TypeName))}\",");
+            sb.AppendLine($"{indent}    Rendering = \"{EmitHelpers.EscapeString(rendering)}\",");
             
             // Only show children for non-ignored properties in document context
             if (prop.ElementProperties != null && prop.ElementProperties.Count > 0 && !inTableContext && !prop.IsIgnored)
@@ -270,11 +455,18 @@ internal static class SerializerEmitter
                 suffix++;
             }
 
-            sb.AppendLine($"        public const string {uniqueName} = \"{EscapeString(sectionName)}\";");
+            sb.AppendLine($"        public const string {uniqueName} = \"{EmitHelpers.EscapeString(sectionName)}\";");
         }
 
         sb.AppendLine("    }");
         sb.AppendLine();
+    }
+
+    private static string GetTypeInfoClassName(TypeMetadata type)
+    {
+        if (string.IsNullOrEmpty(type.Namespace))
+            return $"global::{type.TypeName}MarkoutTypeInfo";
+        return $"global::{type.Namespace}.{type.TypeName}MarkoutTypeInfo";
     }
 
     private static string NormalizeSectionName(string name)
@@ -308,7 +500,7 @@ internal static class SerializerEmitter
                 return "Ignored";
             
             // In table context, only scalars (and joined arrays) work
-            if (IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null))
+            if (EmitHelpers.IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null))
                 return "Column" + (prop.Name != prop.DisplayName ? $" \"{prop.DisplayName}\"" : "");
             
             // Unsupported patterns are skipped
@@ -370,568 +562,5 @@ internal static class SerializerEmitter
             .Replace("System.Boolean", "bool")
             .Replace("System.Decimal", "decimal")
             .Replace("System.Double", "double");
-    }
-
-    private static bool IsScalarKind(PropertyKind kind)
-    {
-        return kind is
-            PropertyKind.String or
-            PropertyKind.Boolean or
-            PropertyKind.Int32 or
-            PropertyKind.Int64 or
-            PropertyKind.Double or
-            PropertyKind.Decimal or
-            PropertyKind.DateTime or
-            PropertyKind.DateTimeOffset or
-            PropertyKind.Enum;
-    }
-
-    private static string GetTypeInfoClassName(TypeMetadata type)
-    {
-        if (string.IsNullOrEmpty(type.Namespace))
-            return $"global::{type.TypeName}MarkoutTypeInfo";
-        return $"global::{type.Namespace}.{type.TypeName}MarkoutTypeInfo";
-    }
-
-    private static void EmitPropertySerializations(
-        StringBuilder sb,
-        IReadOnlyList<PropertyMetadata> properties,
-        string valueExpr,
-        int indentLevel,
-        int baseHeadingLevel = 2,
-        int nestingDepth = 0,
-        bool autoFields = true,
-        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine)
-    {
-        var indent = new string(' ', indentLevel * 4);
-
-        // Separate scalars from non-scalars for field layout handling
-        var scalarProps = new List<PropertyMetadata>();
-        var nonScalarProps = new List<PropertyMetadata>();
-
-        foreach (var prop in properties)
-        {
-            if (prop.IsIgnored)
-                continue;
-
-            // Skip non-section properties if AutoFields is false
-            if (!autoFields && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
-                continue;
-
-            if ((IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)) && !prop.IsSection)
-                scalarProps.Add(prop);
-            else
-                nonScalarProps.Add(prop);
-        }
-
-        // Emit scalars based on layout
-        if (autoFields && scalarProps.Count > 0)
-        {
-            EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout, nestingDepth);
-        }
-
-        // Emit non-scalar properties (sections, arrays, etc.)
-        foreach (var prop in nonScalarProps)
-        {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-            var effectiveSectionLevel = prop.IsSection 
-                ? System.Math.Max(prop.SectionLevel, baseHeadingLevel) 
-                : baseHeadingLevel;
-
-            if (prop.IsSection)
-            {
-                var sectionName = prop.SectionName ?? prop.DisplayName;
-
-                if (prop.Kind == PropertyKind.FieldCollection)
-                {
-                    // List<MarkoutField> or IReadOnlyList<MarkoutField> with [MarkoutSection] renders as field table
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                    sb.AppendLine($"{indent}{{");
-                    sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                    sb.AppendLine($"{indent}    writer.WriteFieldTable({propAccess});");
-                    sb.AppendLine($"{indent}}}");
-                }
-                else if (prop.Kind == PropertyKind.ComplexArray && prop.ElementProperties != null)
-                {
-                    sb.AppendLine($"{indent}if ({GetCollectionCountCheck(prop, propAccess)})");
-                    sb.AppendLine($"{indent}{{");
-                    sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                    
-                    if (prop.ElementHasNestedContent)
-                    {
-                        // Render as subsection-per-item
-                        EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, nestingDepth);
-                    }
-                    else
-                    {
-                        // Render as table
-                        EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
-                    }
-                    sb.AppendLine($"{indent}}}");
-                }
-                else if (prop.Kind == PropertyKind.StringArray)
-                {
-                    sb.AppendLine($"{indent}if ({GetCollectionCountCheck(prop, propAccess)})");
-                    sb.AppendLine($"{indent}{{");
-                    sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                    sb.AppendLine($"{indent}    writer.WriteArray({propAccess});");
-                    sb.AppendLine($"{indent}}}");
-                }
-                else if (prop.Kind == PropertyKind.Tree)
-                {
-                    // List<TreeNode> with [MarkoutSection] renders as section with tree
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                    sb.AppendLine($"{indent}{{");
-                    sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                    sb.AppendLine($"{indent}    writer.WriteTree({propAccess});");
-                    sb.AppendLine($"{indent}}}");
-                }
-                else if (prop.Kind == PropertyKind.NestedObject && prop.ElementProperties != null)
-                {
-                    sb.AppendLine($"{indent}if ({propAccess} != null)");
-                    sb.AppendLine($"{indent}{{");
-                    sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                    EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1);
-                    sb.AppendLine($"{indent}}}");
-                }
-                else
-                {
-                    // For other types, just write the heading unconditionally
-                    sb.AppendLine($"{indent}writer.WriteHeading({effectiveSectionLevel}, \"{EscapeString(sectionName)}\");");
-                }
-                continue;
-            }
-
-            // Non-scalar property handling
-            switch (prop.Kind)
-            {
-                case PropertyKind.StringArray:
-                    sb.AppendLine($"{indent}if ({propAccess} != null)");
-                    sb.AppendLine($"{indent}    writer.WriteArray(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
-                    break;
-
-                case PropertyKind.FieldCollection:
-                    // List<MarkoutField> or IReadOnlyList<MarkoutField> - renders as compact line
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                    sb.AppendLine($"{indent}    writer.WriteCompactFields({propAccess});");
-                    break;
-
-                case PropertyKind.Tree:
-                    // List<TreeNode> - renders as tree structure
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                    sb.AppendLine($"{indent}    writer.WriteTree({propAccess});");
-                    break;
-
-                case PropertyKind.ComplexArray:
-                    if (prop.ElementProperties != null && prop.ElementProperties.Count > 0)
-                    {
-                        sb.AppendLine($"{indent}if ({GetCollectionCountCheck(prop, propAccess)})");
-                        sb.AppendLine($"{indent}{{");
-                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.DisplayName)}\");");
-                        if (prop.ElementHasNestedContent)
-                        {
-                            EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, baseHeadingLevel, nestingDepth);
-                        }
-                        else
-                        {
-                            EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
-                        }
-                        sb.AppendLine($"{indent}}}");
-                    }
-                    break;
-
-                case PropertyKind.NestedObject:
-                    if (prop.ElementProperties != null && prop.ElementProperties.Count > 0)
-                    {
-                        sb.AppendLine($"{indent}if ({propAccess} != null)");
-                        sb.AppendLine($"{indent}{{");
-                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EscapeString(prop.DisplayName)}\");");
-                        EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth + 1, true, fieldLayout);
-                        sb.AppendLine($"{indent}}}");
-                    }
-                    break;
-            }
-        }
-    }
-
-    private static void EmitScalarsWithLayout(
-        StringBuilder sb,
-        List<PropertyMetadata> scalarProps,
-        string valueExpr,
-        int indentLevel,
-        FieldLayoutKind fieldLayout,
-        int nestingDepth = 0)
-    {
-        switch (fieldLayout)
-        {
-            case FieldLayoutKind.OneLine:
-                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
-                break;
-
-            case FieldLayoutKind.LineBreaks:
-                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: false);
-                break;
-
-            case FieldLayoutKind.LineBreaksDoubleSpace:
-                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: true);
-                break;
-
-            case FieldLayoutKind.List:
-                EmitListScalars(sb, scalarProps, valueExpr, indentLevel);
-                break;
-
-            default:
-                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
-                break;
-        }
-    }
-
-    private static void EmitOneLineScalars(
-        StringBuilder sb,
-        List<PropertyMetadata> scalarProps,
-        string valueExpr,
-        int indentLevel,
-        int nestingDepth = 0)
-    {
-        var indent = new string(' ', indentLevel * 4);
-        bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null));
-        var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
-
-        if (useBuilder)
-        {
-            // Use List<MarkoutField> builder pattern when any scalar is nullable or string (to skip nulls/empties)
-            sb.AppendLine($"{indent}var {fieldsVar} = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
-            foreach (var prop in scalarProps)
-            {
-                var propAccess = $"{valueExpr}.{prop.Name}";
-                if (prop.IsNullableValueType)
-                {
-                    var valueStr = GetScalarValueExpression(prop, propAccess, nullable: true);
-                    sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
-                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
-                }
-                else if (prop.Kind == PropertyKind.String)
-                {
-                    sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({propAccess}))");
-                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {propAccess}));");
-                }
-                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
-                {
-                    var countProp = prop.IsArray ? "Length" : "Count";
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {GetScalarValueExpression(prop, propAccess)}));");
-                }
-                else
-                {
-                    var valueStr = GetScalarValueExpression(prop, propAccess);
-                    sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr}));");
-                }
-            }
-            sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
-            sb.AppendLine($"{indent}    writer.WriteCompactFields({fieldsVar});");
-        }
-        else
-        {
-            // Build inline MarkoutField array (no nullable/string scalars)
-            var fields = new List<string>();
-            foreach (var prop in scalarProps)
-            {
-                var propAccess = $"{valueExpr}.{prop.Name}";
-                var valueStr = GetScalarValueExpression(prop, propAccess);
-                fields.Add($"new global::Markout.MarkoutField(\"{EscapeString(prop.DisplayName)}\", {valueStr})");
-            }
-
-            sb.AppendLine($"{indent}writer.WriteCompactFields({string.Join(", ", fields)});");
-        }
-    }
-
-    private static void EmitLineBreaksScalars(
-        StringBuilder sb,
-        List<PropertyMetadata> scalarProps,
-        string valueExpr,
-        int indentLevel,
-        bool doubleSpace)
-    {
-        var indent = new string(' ', indentLevel * 4);
-        var methodName = doubleSpace ? "WriteField" : "WriteFieldNoBreak";
-
-        foreach (var prop in scalarProps)
-        {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-
-            if (prop.IsNullableValueType)
-            {
-                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
-                if (prop.Kind == PropertyKind.Boolean)
-                {
-                    if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
-                    {
-                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
-                    }
-                    else
-                    {
-                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
-                    }
-                }
-                else if (prop.CustomFormat != null)
-                {
-                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
-                }
-                else
-                {
-                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
-                }
-            }
-            else if (prop.Kind == PropertyKind.String)
-            {
-                sb.AppendLine($"{indent}if ({propAccess} != null)");
-                sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
-            }
-            else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
-            {
-                var countProp = prop.IsArray ? "Length" : "Count";
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                sb.AppendLine($"{indent}    writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {GetScalarValueExpression(prop, propAccess)});");
-            }
-            else if (prop.Kind == PropertyKind.Boolean)
-            {
-                if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
-                {
-                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\");");
-                }
-                else
-                {
-                    sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
-                }
-            }
-            else if (prop.CustomFormat != null)
-            {
-                sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
-            }
-            else
-            {
-                sb.AppendLine($"{indent}writer.{methodName}(\"{EscapeString(prop.DisplayName)}\", {propAccess});");
-            }
-        }
-    }
-
-    private static void EmitListScalars(
-        StringBuilder sb,
-        List<PropertyMetadata> scalarProps,
-        string valueExpr,
-        int indentLevel)
-    {
-        var indent = new string(' ', indentLevel * 4);
-
-        foreach (var prop in scalarProps)
-        {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-
-            if (prop.IsNullableValueType)
-            {
-                var valueStr = GetScalarValueExpression(prop, propAccess, nullable: true);
-                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
-            }
-            else if (prop.Kind == PropertyKind.String)
-            {
-                sb.AppendLine($"{indent}if ({propAccess} != null)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
-            }
-            else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
-            {
-                var countProp = prop.IsArray ? "Length" : "Count";
-                var valueStr = GetScalarValueExpression(prop, propAccess);
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
-            }
-            else
-            {
-                var valueStr = GetScalarValueExpression(prop, propAccess);
-                sb.AppendLine($"{indent}writer.WriteListItem($\"{EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
-            }
-        }
-    }
-
-    private static string GetScalarValueExpression(PropertyMetadata prop, string propAccess, bool nullable = false)
-    {
-        var access = nullable ? $"{propAccess}.Value" : propAccess;
-
-        // Joined string array: render as string.Join(separator, collection)
-        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
-        {
-            return $"string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess})";
-        }
-
-        if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
-        {
-            return $"({access} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\")";
-        }
-
-        // Custom format overrides default formatting for formattable types
-        if (prop.CustomFormat != null)
-        {
-            if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
-                or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
-            {
-                return $"{access}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
-            }
-        }
-
-        return prop.Kind switch
-        {
-            PropertyKind.Boolean => $"({access} ? \"yes\" : \"no\")",
-            PropertyKind.String => $"{propAccess} ?? \"\"",
-            PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
-                => $"{access}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
-            PropertyKind.DateTime or PropertyKind.DateTimeOffset
-                => $"{access}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
-            PropertyKind.Enum => $"{access}.ToString()",
-            _ => $"{propAccess}?.ToString() ?? \"\""
-        };
-    }
-
-    private static void EmitTableSerialization(
-        StringBuilder sb,
-        PropertyMetadata prop,
-        string propAccess,
-        int indentLevel,
-        int nestingDepth = 0)
-    {
-        if (prop.ElementProperties == null || prop.ElementProperties.Count == 0)
-            return;
-
-        var indent = new string(' ', indentLevel * 4);
-        var visibleProps = prop.ElementProperties.Where(p => !p.IsIgnored).ToList();
-        var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
-
-        // Build header array
-        var headers = string.Join(", ", visibleProps.Select(p => $"\"{EscapeString(p.DisplayName)}\""));
-        sb.AppendLine($"{indent}writer.WriteTableStart({headers});");
-
-        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
-        sb.AppendLine($"{indent}{{");
-
-        // Build row values
-        var values = new List<string>();
-        foreach (var elemProp in visibleProps)
-        {
-            var value = GetTableCellValue(elemProp, itemVar);
-            values.Add(value);
-        }
-
-        sb.AppendLine($"{indent}    writer.WriteTableRow({string.Join(", ", values)});");
-        sb.AppendLine($"{indent}}}");
-        sb.AppendLine($"{indent}writer.WriteTableEnd();");
-    }
-
-    private static void EmitSubsectionPerItemSerialization(
-        StringBuilder sb,
-        PropertyMetadata prop,
-        string propAccess,
-        int indentLevel,
-        int parentSectionLevel = 2,
-        int nestingDepth = 0)
-    {
-        if (prop.ElementProperties == null || prop.ElementProperties.Count == 0)
-            return;
-
-        var indent = new string(' ', indentLevel * 4);
-        var subsectionLevel = parentSectionLevel + 1;
-        var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
-
-        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
-        sb.AppendLine($"{indent}{{");
-
-        // Write subsection heading using TitleProperty or first string property
-        if (!string.IsNullOrEmpty(prop.ElementTitleProperty))
-        {
-            sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
-            sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty});");
-        }
-        else
-        {
-            // Try to find a suitable property for the heading
-            var titleProp = prop.ElementProperties.FirstOrDefault(p => 
-                !p.IsIgnored && p.Kind == PropertyKind.String && 
-                (p.Name == "Name" || p.Name == "Title" || p.Name == "Id"));
-            
-            if (titleProp != null)
-            {
-                sb.AppendLine($"{indent}    if ({itemVar}.{titleProp.Name} != null)");
-                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{titleProp.Name});");
-            }
-            else
-            {
-                // Fallback: use first string property
-                var firstString = prop.ElementProperties.FirstOrDefault(p => !p.IsIgnored && p.Kind == PropertyKind.String);
-                if (firstString != null)
-                {
-                    sb.AppendLine($"{indent}    if ({itemVar}.{firstString.Name} != null)");
-                    sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{firstString.Name});");
-                }
-            }
-        }
-
-        // Emit property serializations for each item, at a deeper level
-        EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1);
-
-        sb.AppendLine($"{indent}}}");
-    }
-
-    private static string GetTableCellValue(PropertyMetadata prop, string itemExpr)
-    {
-        var propAccess = $"{itemExpr}.{prop.Name}";
-
-        if (prop.IsNullableValueType)
-        {
-            var valueExpr = GetScalarValueExpression(prop, propAccess, nullable: true);
-            return $"{propAccess}.HasValue ? {valueExpr} : \"\"";
-        }
-
-        // Joined string array in table cell
-        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
-        {
-            return $"{propAccess} != null ? string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess}) : \"\"";
-        }
-
-        if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
-        {
-            return $"{propAccess} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\"";
-        }
-
-        // Custom format overrides default formatting for formattable types
-        if (prop.CustomFormat != null)
-        {
-            if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
-                or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
-            {
-                return $"{propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
-            }
-        }
-
-        return prop.Kind switch
-        {
-            PropertyKind.Boolean => $"{propAccess} ? \"yes\" : \"no\"",
-            PropertyKind.String => $"{propAccess} ?? \"\"",
-            PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
-                => $"{propAccess}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
-            PropertyKind.DateTime or PropertyKind.DateTimeOffset
-                => $"{propAccess}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
-            PropertyKind.Enum => $"{propAccess}.ToString()",
-            _ => $"{propAccess}?.ToString() ?? \"\""
-        };
-    }
-
-    private static string GetCollectionCountCheck(PropertyMetadata prop, string propAccess)
-    {
-        var countProp = prop.IsArray ? "Length" : "Count";
-        return $"{propAccess} != null && {propAccess}.{countProp} > 0";
-    }
-
-    private static string EscapeString(string s)
-    {
-        return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }
 }

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -28,6 +28,9 @@ internal sealed class KnownTypeSymbols
     private INamedTypeSymbol? _iEnumerable;
     private bool _iEnumerableResolved;
 
+    private INamedTypeSymbol? _iMarkoutFormattable;
+    private bool _iMarkoutFormattableResolved;
+
     public KnownTypeSymbols(Compilation compilation)
     {
         _compilation = compilation;
@@ -39,6 +42,7 @@ internal sealed class KnownTypeSymbols
     public INamedTypeSymbol? DateTimeOffset => Resolve(ref _dateTimeOffset, ref _dateTimeOffsetResolved, "System.DateTimeOffset");
     public INamedTypeSymbol? IDictionary => Resolve(ref _iDictionary, ref _iDictionaryResolved, "System.Collections.Generic.IDictionary`2");
     public INamedTypeSymbol? IEnumerable => Resolve(ref _iEnumerable, ref _iEnumerableResolved, "System.Collections.Generic.IEnumerable`1");
+    public INamedTypeSymbol? IMarkoutFormattable => Resolve(ref _iMarkoutFormattable, ref _iMarkoutFormattableResolved, "Markout.IMarkoutFormattable");
 
     private INamedTypeSymbol? Resolve(ref INamedTypeSymbol? field, ref bool resolved, string metadataName)
     {

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -249,6 +249,7 @@ internal enum PropertyKind
     DateTime,
     DateTimeOffset,
     Enum,
+    Formattable,
     StringArray,
     ComplexArray,
     NestedObject,

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -248,7 +248,7 @@ internal static class TypeParser
         // Determine if property is unsupported in table context
         // Joined string arrays are treated as scalars, so they're fine in tables
         bool isJoinedArray = kind == PropertyKind.StringArray && joinSeparator != null;
-        bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind) && !isJoinedArray;
+        bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind) && !isJoinedArray && kind != PropertyKind.Formattable;
 
         // Emit warning for unsupported properties without [MarkoutIgnoreInTable]
         if (isUnsupportedInTable && !isIgnoredInTable)
@@ -416,6 +416,13 @@ internal static class TypeParser
             }
         }
 
+        // IMarkoutFormattable: custom formatting via interface
+        if (knownTypes.IMarkoutFormattable != null &&
+            type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, knownTypes.IMarkoutFormattable)))
+        {
+            return (PropertyKind.Formattable, null, null, false, null, false);
+        }
+
         // Nested object
         if (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct)
         {
@@ -506,6 +513,7 @@ internal static class TypeParser
             PropertyKind.StringArray => "a string array",
             PropertyKind.ComplexArray => "an array of complex objects",
             PropertyKind.NestedObject => "a complex object",
+            PropertyKind.Formattable => "formattable",
             PropertyKind.Other => "a non-scalar type",
             _ => kind.ToString().ToLowerInvariant()
         };

--- a/src/Markout/IMarkoutFormattable.cs
+++ b/src/Markout/IMarkoutFormattable.cs
@@ -1,0 +1,23 @@
+namespace Markout;
+
+/// <summary>
+/// Allows a type to control its own Markout serialization.
+/// Types implementing this interface can write structured Markdown content
+/// directly to a <see cref="MarkoutWriter"/>.
+/// </summary>
+public interface IMarkoutFormattable
+{
+    /// <summary>
+    /// Writes a structured Markdown representation of this object to the writer.
+    /// Use this for block-level content (headings, fields, tables, lists).
+    /// </summary>
+    /// <param name="writer">The writer to render to.</param>
+    void WriteTo(MarkoutWriter writer);
+
+    /// <summary>
+    /// Returns a single-line string representation for use in inline contexts
+    /// such as table cells and compact field values.
+    /// </summary>
+    /// <returns>A plain text representation, or null to use ToString().</returns>
+    string? ToMarkoutString() => ToString();
+}

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -473,6 +473,33 @@ public class SerializerTests
         Assert.DoesNotContain("Tags", mdf);
         Assert.DoesNotContain("Frameworks", mdf);
     }
+
+    [Fact]
+    public void Serialize_FormattableProperty_UsesWriteTo()
+    {
+        var person = new PersonWithAddress
+        {
+            Name = "Alice",
+            Address = new CustomAddress { Street = "123 Main St", City = "Portland", State = "OR" }
+        };
+        var mdf = MarkoutSerializer.Serialize(person, FormattableTestContext.Default);
+
+        Assert.Contains("Name: Alice", mdf);
+        Assert.Contains("Street: 123 Main St", mdf);
+        Assert.Contains("City: Portland", mdf);
+        Assert.Contains("State: OR", mdf);
+    }
+
+    [Fact]
+    public void Serialize_FormattableProperty_SkipsWhenNull()
+    {
+        var person = new PersonWithAddress { Name = "Bob", Address = null };
+        var mdf = MarkoutSerializer.Serialize(person, FormattableTestContext.Default);
+
+        Assert.Contains("Name: Bob", mdf);
+        Assert.DoesNotContain("Street", mdf);
+        Assert.DoesNotContain("City", mdf);
+    }
 }
 
 [MarkoutSerializable]
@@ -628,5 +655,34 @@ public class ProjectInfo
 
 [MarkoutContext(typeof(ProjectInfo))]
 public partial class JoinTestContext : MarkoutSerializerContext
+{
+}
+
+// IMarkoutFormattable test types
+public class CustomAddress : IMarkoutFormattable
+{
+    public string? Street { get; set; }
+    public string? City { get; set; }
+    public string? State { get; set; }
+
+    public void WriteTo(MarkoutWriter writer)
+    {
+        writer.WriteField("Street", Street);
+        writer.WriteField("City", City);
+        writer.WriteField("State", State);
+    }
+
+    public string? ToMarkoutString() => $"{City}, {State}";
+}
+
+[MarkoutSerializable]
+public class PersonWithAddress
+{
+    public string? Name { get; set; }
+    public CustomAddress? Address { get; set; }
+}
+
+[MarkoutContext(typeof(PersonWithAddress))]
+public partial class FormattableTestContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Phase 4: Architecture & Extensibility

### Changes

1. **Stage-based emission refactor**
   - Split the 937-line monolithic `SerializerEmitter` into focused classes:
     - `EmitHelpers`: shared value expressions, scalar classification, escaping
     - `FieldEmitter`: scalar field layouts (one-line, line-breaks, list)
     - `CollectionEmitter`: table and subsection-per-item rendering
     - `SerializerEmitter`: coordinator (566 lines), type info, context, schema
   - Extracted `EmitPropertySerializations` (159 lines) into `EmitSectionProperty` and `EmitNonSectionProperty`
   - No behavioral changes

2. **`IMarkoutFormattable` interface**
   - New interface with `WriteTo(MarkoutWriter)` for block-level output and `ToMarkoutString()` for inline contexts
   - `PropertyKind.Formattable` detection via `KnownTypeSymbols`
   - Block context: generates `((IMarkoutFormattable)prop).WriteTo(writer)`
   - Table context: generates `((IMarkoutFormattable)prop)?.ToMarkoutString() ?? ""`
   - Formattable types are supported in both document and table contexts
   - Section support for formattable properties

### Testing
- 159 tests pass (2 new for IMarkoutFormattable)
- Validated against dotnet-inspect (324 tests pass, requires `RenderScalars` → `AutoFields` rename from Phase 3)
