### PR TITLE
Add [MarkoutSkipDefault] attribute and partial method hooks

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -116,4 +116,27 @@ internal static class EmitHelpers
     {
         return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }
+
+    /// <summary>
+    /// Returns a condition expression that is true when the property value is NOT the default.
+    /// Used by [MarkoutSkipDefault] to conditionally skip rendering.
+    /// </summary>
+    public static string? GetNonDefaultCondition(PropertyMetadata prop, string propAccess)
+    {
+        if (prop.IsNullableValueType)
+            return $"{propAccess}.HasValue";
+
+        return prop.Kind switch
+        {
+            PropertyKind.String => $"!string.IsNullOrEmpty({propAccess})",
+            PropertyKind.Boolean => propAccess,
+            PropertyKind.Int32 or PropertyKind.Int64 => $"{propAccess} != 0",
+            PropertyKind.Double or PropertyKind.Decimal => $"{propAccess} != 0",
+            PropertyKind.DateTime or PropertyKind.DateTimeOffset => $"{propAccess} != default",
+            PropertyKind.Enum => $"{propAccess} != default({prop.TypeName})",
+            PropertyKind.StringArray => $"{propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0",
+            PropertyKind.Formattable => $"{propAccess} != null",
+            _ => $"{propAccess} != null"
+        };
+    }
 }

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -51,7 +51,8 @@ internal static class FieldEmitter
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null));
+            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || p.SkipWhenDefault);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
         if (useBuilder)
@@ -81,7 +82,16 @@ internal static class FieldEmitter
                 else
                 {
                     var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
-                    sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    if (prop.SkipWhenDefault)
+                    {
+                        var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
+                        sb.AppendLine($"{indent}if ({condition})");
+                        sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    }
                 }
             }
             sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
@@ -115,59 +125,77 @@ internal static class FieldEmitter
         foreach (var prop in scalarProps)
         {
             var propAccess = $"{valueExpr}.{prop.Name}";
+            var emitIndent = indent;
+
+            // Wrap with skip-default condition if needed (for types not already conditionally rendered)
+            bool needsSkipDefault = prop.SkipWhenDefault && !prop.IsNullableValueType
+                && prop.Kind != PropertyKind.String
+                && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            if (needsSkipDefault)
+            {
+                var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
+                sb.AppendLine($"{indent}if ({condition})");
+                sb.AppendLine($"{indent}{{");
+                emitIndent = indent + "    ";
+            }
 
             if (prop.IsNullableValueType)
             {
-                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+                sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
                 if (prop.Kind == PropertyKind.Boolean)
                 {
                     if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
                     {
-                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
+                        sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
                     }
                     else
                     {
-                        sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                        sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
                     }
                 }
                 else if (prop.CustomFormat != null)
                 {
-                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
                 }
                 else
                 {
-                    sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
                 }
             }
             else if (prop.Kind == PropertyKind.String)
             {
-                sb.AppendLine($"{indent}if ({propAccess} != null)");
-                sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+                sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
+                sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
             }
             else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
             {
                 var countProp = prop.IsArray ? "Length" : "Count";
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                sb.AppendLine($"{indent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)});");
+                sb.AppendLine($"{emitIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)});");
             }
             else if (prop.Kind == PropertyKind.Boolean)
             {
                 if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
                 {
-                    sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess} ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
+                    sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess} ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
                 }
                 else
                 {
-                    sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+                    sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
                 }
             }
             else if (prop.CustomFormat != null)
             {
-                sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
+                sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
             }
             else
             {
-                sb.AppendLine($"{indent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+                sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+            }
+
+            if (needsSkipDefault)
+            {
+                sb.AppendLine($"{indent}}}");
             }
         }
     }
@@ -183,29 +211,46 @@ internal static class FieldEmitter
         foreach (var prop in scalarProps)
         {
             var propAccess = $"{valueExpr}.{prop.Name}";
+            var emitIndent = indent;
+
+            bool needsSkipDefault = prop.SkipWhenDefault && !prop.IsNullableValueType
+                && prop.Kind != PropertyKind.String
+                && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            if (needsSkipDefault)
+            {
+                var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
+                sb.AppendLine($"{indent}if ({condition})");
+                sb.AppendLine($"{indent}{{");
+                emitIndent = indent + "    ";
+            }
 
             if (prop.IsNullableValueType)
             {
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
-                sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
+                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
             else if (prop.Kind == PropertyKind.String)
             {
-                sb.AppendLine($"{indent}if ({propAccess} != null)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
+                sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
+                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
             }
             else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
             {
                 var countProp = prop.IsArray ? "Length" : "Count";
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                sb.AppendLine($"{indent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                sb.AppendLine($"{emitIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
             else
             {
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
-                sb.AppendLine($"{indent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                sb.AppendLine($"{emitIndent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+            }
+
+            if (needsSkipDefault)
+            {
+                sb.AppendLine($"{indent}}}");
             }
         }
     }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -29,7 +29,10 @@ internal static class SerializerEmitter
 
         var className = $"{type.TypeName}MarkoutTypeInfo";
 
-        sb.AppendLine($"public sealed class {className} : global::Markout.MarkoutTypeInfo<{type.FullTypeName}>");
+        // Collect section properties for per-section hooks
+        var sectionProps = type.Properties.Where(p => p.IsSection && !p.IsIgnored).ToList();
+
+        sb.AppendLine($"public partial class {className} : global::Markout.MarkoutTypeInfo<{type.FullTypeName}>");
         sb.AppendLine("{");
         sb.AppendLine($"    public static {className} Instance {{ get; }} = new();");
         sb.AppendLine();
@@ -40,6 +43,8 @@ internal static class SerializerEmitter
             sb.AppendLine("        if (value == null) return;");
             sb.AppendLine();
         }
+
+        sb.AppendLine("        OnSerializing(writer, value);");
 
         // Emit title (H1) if TitleProperty is set
         if (!string.IsNullOrEmpty(type.TitleProperty))
@@ -89,9 +94,25 @@ internal static class SerializerEmitter
             propsToRender = type.Properties.Where(p => !skip.Contains(p.Name)).ToList();
         }
 
-        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.AutoFields, type.FieldLayout);
+        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.AutoFields, type.FieldLayout, "value", type.FullTypeName);
 
+        sb.AppendLine();
+        sb.AppendLine("        OnSerialized(writer, value);");
         sb.AppendLine("    }");
+        sb.AppendLine();
+
+        // Emit partial method declarations for hooks
+        sb.AppendLine($"    partial void OnSerializing(global::Markout.MarkoutWriter writer, {type.FullTypeName} value);");
+        sb.AppendLine($"    partial void OnSerialized(global::Markout.MarkoutWriter writer, {type.FullTypeName} value);");
+
+        // Emit per-section hooks
+        foreach (var sectionProp in sectionProps)
+        {
+            var hookName = sectionProp.SectionName ?? sectionProp.DisplayName;
+            var safeName = new string(hookName.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+            sb.AppendLine($"    partial void OnBeforeSection{safeName}(global::Markout.MarkoutWriter writer, {type.FullTypeName} value, ref bool skip);");
+        }
+
         sb.AppendLine("}");
 
         return sb.ToString();
@@ -204,7 +225,9 @@ internal static class SerializerEmitter
         int baseHeadingLevel = 2,
         int nestingDepth = 0,
         bool autoFields = true,
-        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine)
+        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
+        string? rootValueExpr = null,
+        string? rootTypeName = null)
     {
         var indent = new string(' ', indentLevel * 4);
 
@@ -243,7 +266,7 @@ internal static class SerializerEmitter
 
             if (prop.IsSection)
             {
-                EmitSectionProperty(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout);
+                EmitSectionProperty(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
                 continue;
             }
 
@@ -260,9 +283,44 @@ internal static class SerializerEmitter
         int indentLevel,
         int effectiveSectionLevel,
         int nestingDepth,
-        FieldLayoutKind fieldLayout)
+        FieldLayoutKind fieldLayout,
+        string? rootValueExpr = null,
+        string? rootTypeName = null)
     {
         var sectionName = prop.SectionName ?? prop.DisplayName;
+
+        // Emit per-section hook at top level only
+        if (rootValueExpr != null && rootTypeName != null)
+        {
+            var safeName = new string(sectionName.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+            var skipVar = $"__skip{safeName}";
+            sb.AppendLine($"{indent}var {skipVar} = false;");
+            sb.AppendLine($"{indent}OnBeforeSection{safeName}(writer, {rootValueExpr}, ref {skipVar});");
+            sb.AppendLine($"{indent}if (!{skipVar})");
+            sb.AppendLine($"{indent}{{");
+
+            // Re-emit the section body with increased indent
+            EmitSectionBody(sb, prop, propAccess, indent + "    ", indentLevel + 1, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+
+            sb.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            EmitSectionBody(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+        }
+    }
+
+    private static void EmitSectionBody(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        int indentLevel,
+        int effectiveSectionLevel,
+        int nestingDepth,
+        FieldLayoutKind fieldLayout,
+        string sectionName)
+    {
 
         if (prop.Kind == PropertyKind.FieldCollection)
         {

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -129,6 +129,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public bool IsArray { get; }
     public string? CustomFormat { get; }
     public string? JoinSeparator { get; }
+    public bool SkipWhenDefault { get; }
 
     public PropertyMetadata(
         string name,
@@ -150,7 +151,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         bool isNullableValueType = false,
         bool isArray = false,
         string? customFormat = null,
-        string? joinSeparator = null)
+        string? joinSeparator = null,
+        bool skipWhenDefault = false)
     {
         Name = name;
         DisplayName = displayName;
@@ -172,6 +174,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         IsArray = isArray;
         CustomFormat = customFormat;
         JoinSeparator = joinSeparator;
+        SkipWhenDefault = skipWhenDefault;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -197,6 +200,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                IsArray == other.IsArray &&
                CustomFormat == other.CustomFormat &&
                JoinSeparator == other.JoinSeparator &&
+               SkipWhenDefault == other.SkipWhenDefault &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -208,6 +212,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             var hash = (Name?.GetHashCode() ?? 0) * 397 ^ (TypeName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (int)Kind;
             hash = hash * 397 ^ (DisplayName?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ SkipWhenDefault.GetHashCode();
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -20,6 +20,7 @@ internal static class TypeParser
     private const string MarkoutBoolFormatAttribute = "Markout.MarkoutBoolFormatAttribute";
     private const string MarkoutFormatAttribute = "Markout.MarkoutFormatAttribute";
     private const string MarkoutJoinAttribute = "Markout.MarkoutJoinAttribute";
+    private const string MarkoutSkipDefaultAttribute = "Markout.MarkoutSkipDefaultAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -235,6 +236,10 @@ internal static class TypeParser
             joinSeparator = sep;
         }
 
+        // Parse [MarkoutSkipDefault] attribute
+        bool skipWhenDefault = prop.GetAttributes()
+            .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipDefaultAttribute);
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -282,7 +287,8 @@ internal static class TypeParser
             isNullableValueType,
             isArray,
             customFormat,
-            joinSeparator);
+            joinSeparator,
+            skipWhenDefault);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)

--- a/src/Markout/Attributes/MarkoutSkipDefaultAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSkipDefaultAttribute.cs
@@ -1,0 +1,11 @@
+namespace Markout;
+
+/// <summary>
+/// Skips rendering a property when its value equals the default for its type
+/// (e.g., <c>false</c> for <see langword="bool"/>, <c>0</c> for <see langword="int"/>,
+/// <see langword="null"/> for reference types).
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutSkipDefaultAttribute : Attribute
+{
+}

--- a/tests/Markout.Tests/PartialHookTests.cs
+++ b/tests/Markout.Tests/PartialHookTests.cs
@@ -1,0 +1,25 @@
+namespace Markout.Tests;
+
+// Partial implementation of generated TypeInfo hooks for testing
+public partial class PackageWithSectionsMarkoutTypeInfo
+{
+    // Track whether hooks were called for test assertions
+    internal static bool OnSerializingCalled { get; set; }
+    internal static bool OnSerializedCalled { get; set; }
+    internal static bool SkipAssembliesSection { get; set; }
+
+    partial void OnSerializing(global::Markout.MarkoutWriter writer, PackageWithSections value)
+    {
+        OnSerializingCalled = true;
+    }
+
+    partial void OnSerialized(global::Markout.MarkoutWriter writer, PackageWithSections value)
+    {
+        OnSerializedCalled = true;
+    }
+
+    partial void OnBeforeSectionAssemblies(global::Markout.MarkoutWriter writer, PackageWithSections value, ref bool skip)
+    {
+        skip = SkipAssembliesSection;
+    }
+}

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -500,6 +500,136 @@ public class SerializerTests
         Assert.DoesNotContain("Street", mdf);
         Assert.DoesNotContain("City", mdf);
     }
+
+    [Fact]
+    public void Serialize_SkipDefault_SuppressesFalseAndZero()
+    {
+        var status = new ServerStatus { Name = "Server1", IsOnline = false, ConnectionCount = 0, AlertLevel = Priority.Low, BytesTransferred = 0, CpuUsage = 0 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultTestContext.Default);
+
+        Assert.Contains("Name: Server1", mdf);
+        Assert.DoesNotContain("IsOnline", mdf);
+        Assert.DoesNotContain("ConnectionCount", mdf);
+        Assert.DoesNotContain("AlertLevel", mdf);
+        Assert.DoesNotContain("BytesTransferred", mdf);
+        Assert.DoesNotContain("CpuUsage", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipDefault_RendersNonDefaultValues()
+    {
+        var status = new ServerStatus { Name = "Server1", IsOnline = true, ConnectionCount = 42, AlertLevel = Priority.High, BytesTransferred = 1024, CpuUsage = 85.5 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultTestContext.Default);
+
+        Assert.Contains("Name: Server1", mdf);
+        Assert.Contains("IsOnline", mdf);
+        Assert.Contains("ConnectionCount", mdf);
+        Assert.Contains("AlertLevel", mdf);
+        Assert.Contains("BytesTransferred", mdf);
+        Assert.Contains("CpuUsage", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipDefault_LineBreaksLayout()
+    {
+        var status = new ServerStatusLineBreaks { Name = "Server1", IsOnline = false, ConnectionCount = 0 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultLineBreaksContext.Default);
+
+        Assert.Contains("Name", mdf);
+        Assert.DoesNotContain("IsOnline", mdf);
+        Assert.DoesNotContain("ConnectionCount", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipDefault_LineBreaksRendersNonDefault()
+    {
+        var status = new ServerStatusLineBreaks { Name = "Server1", IsOnline = true, ConnectionCount = 5 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultLineBreaksContext.Default);
+
+        Assert.Contains("IsOnline", mdf);
+        Assert.Contains("ConnectionCount", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipDefault_ListLayout()
+    {
+        var status = new ServerStatusList { Name = "Server1", IsOnline = false, ConnectionCount = 0 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultListContext.Default);
+
+        Assert.Contains("Name", mdf);
+        Assert.DoesNotContain("IsOnline", mdf);
+        Assert.DoesNotContain("ConnectionCount", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipDefault_ListRendersNonDefault()
+    {
+        var status = new ServerStatusList { Name = "Server1", IsOnline = true, ConnectionCount = 10 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultListContext.Default);
+
+        Assert.Contains("IsOnline", mdf);
+        Assert.Contains("ConnectionCount", mdf);
+    }
+
+    [Fact]
+    public void Serialize_PartialHooks_OnSerializingAndOnSerializedCalled()
+    {
+        PackageWithSectionsMarkoutTypeInfo.OnSerializingCalled = false;
+        PackageWithSectionsMarkoutTypeInfo.OnSerializedCalled = false;
+
+        var pkg = new PackageWithSections
+        {
+            Name = "TestPkg",
+            Version = "1.0",
+            Dependencies = [new SimpleDep { Id = "Dep1", Version = "2.0" }]
+        };
+        MarkoutSerializer.Serialize(pkg, SectionTestContext.Default);
+
+        Assert.True(PackageWithSectionsMarkoutTypeInfo.OnSerializingCalled);
+        Assert.True(PackageWithSectionsMarkoutTypeInfo.OnSerializedCalled);
+    }
+
+    [Fact]
+    public void Serialize_PartialHooks_SkipSectionWhenRequested()
+    {
+        PackageWithSectionsMarkoutTypeInfo.SkipAssembliesSection = true;
+        try
+        {
+            var pkg = new PackageWithSections
+            {
+                Name = "TestPkg",
+                Version = "1.0",
+                Dependencies = [new SimpleDep { Id = "Dep1", Version = "2.0" }],
+                Assemblies = [new SimpleAsm { Name = "Test.dll", Arch = "x64" }]
+            };
+            var mdf = MarkoutSerializer.Serialize(pkg, SectionTestContext.Default);
+
+            Assert.Contains("Dependencies", mdf);
+            Assert.DoesNotContain("Assemblies", mdf);
+            Assert.DoesNotContain("Test.dll", mdf);
+        }
+        finally
+        {
+            PackageWithSectionsMarkoutTypeInfo.SkipAssembliesSection = false;
+        }
+    }
+
+    [Fact]
+    public void Serialize_PartialHooks_SectionRendersWhenNotSkipped()
+    {
+        PackageWithSectionsMarkoutTypeInfo.SkipAssembliesSection = false;
+
+        var pkg = new PackageWithSections
+        {
+            Name = "TestPkg",
+            Version = "1.0",
+            Assemblies = [new SimpleAsm { Name = "Test.dll", Arch = "x64" }]
+        };
+        var mdf = MarkoutSerializer.Serialize(pkg, SectionTestContext.Default);
+
+        Assert.Contains("Assemblies", mdf);
+        Assert.Contains("Test.dll", mdf);
+    }
 }
 
 [MarkoutSerializable]
@@ -684,5 +814,57 @@ public class PersonWithAddress
 
 [MarkoutContext(typeof(PersonWithAddress))]
 public partial class FormattableTestContext : MarkoutSerializerContext
+{
+}
+
+// SkipWhenDefault test types
+[MarkoutSerializable]
+public class ServerStatus
+{
+    public string? Name { get; set; }
+    [MarkoutSkipDefault]
+    public bool IsOnline { get; set; }
+    [MarkoutSkipDefault]
+    public int ConnectionCount { get; set; }
+    [MarkoutSkipDefault]
+    public Priority AlertLevel { get; set; }
+    [MarkoutSkipDefault]
+    public long BytesTransferred { get; set; }
+    [MarkoutSkipDefault]
+    public double CpuUsage { get; set; }
+}
+
+[MarkoutContext(typeof(ServerStatus))]
+public partial class SkipDefaultTestContext : MarkoutSerializerContext
+{
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class ServerStatusLineBreaks
+{
+    public string? Name { get; set; }
+    [MarkoutSkipDefault]
+    public bool IsOnline { get; set; }
+    [MarkoutSkipDefault]
+    public int ConnectionCount { get; set; }
+}
+
+[MarkoutContext(typeof(ServerStatusLineBreaks))]
+public partial class SkipDefaultLineBreaksContext : MarkoutSerializerContext
+{
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.List)]
+public class ServerStatusList
+{
+    public string? Name { get; set; }
+    [MarkoutSkipDefault]
+    public bool IsOnline { get; set; }
+    [MarkoutSkipDefault]
+    public int ConnectionCount { get; set; }
+}
+
+[MarkoutContext(typeof(ServerStatusList))]
+public partial class SkipDefaultListContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Phase 6: Conditional Fields & Graceful Fallback

### `[MarkoutSkipDefault]` Attribute

New opt-in attribute that skips rendering a property when its value equals the default for its type:

- `bool` → skips when `false`
- `int`, `long` → skips when `0`
- `double`, `decimal` → skips when `0`
- `enum` → skips when first value (`default`)
- `DateTime`, `DateTimeOffset` → skips when `default`
- `string` → skips when `null` or empty (already auto-skipped, attribute is redundant but harmless)

Works across all field layouts: OneLine (compact), LineBreaks, and List.

**Example:**
```csharp
[MarkoutSerializable]
public class ServerStatus
{
    public string? Name { get; set; }
    [MarkoutSkipDefault]
    public bool IsOnline { get; set; }
    [MarkoutSkipDefault]
    public int ConnectionCount { get; set; }
}
```

When `IsOnline = false` and `ConnectionCount = 0`, only `Name` renders.

### Partial Method Hooks (Graceful Fallback)

TypeInfo classes changed from `sealed` to `partial`, enabling user-defined hooks:

- **`OnSerializing(writer, value)`** — called before property rendering
- **`OnSerialized(writer, value)`** — called after property rendering
- **`OnBeforeSection{Name}(writer, value, ref bool skip)`** — per-section hook to conditionally skip sections

Unimplemented `partial void` methods are eliminated by the compiler (zero overhead). Users implement hooks by adding a partial class file:

```csharp
public partial class PackageMarkoutTypeInfo
{
    partial void OnBeforeSectionAssemblies(MarkoutWriter writer, Package value, ref bool skip)
    {
    }
}
```

### Changes
- `src/Markout/Attributes/MarkoutSkipDefaultAttribute.cs` — new attribute
- `TypeMetadata.cs` — `SkipWhenDefault` property
- `TypeParser.cs` — parse `[MarkoutSkipDefault]` attribute
- `EmitHelpers.cs` — `GetNonDefaultCondition()` method
- `FieldEmitter.cs` — conditional wrapping for all layouts
- `SerializerEmitter.cs` — partial class, hook emission, per-section hooks
- `PartialHookTests.cs` — partial method implementation for testing
- `SerializerTests.cs` — 10 new tests

### Testing
- 182 tests pass (Debug + Release)
- Validated against dotnet-inspect (324 tests)