### PR TITLE
Propagate element type settings to collection subsections

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -86,8 +86,16 @@ internal static class CollectionEmitter
         // Write subsection heading using TitleProperty or first string property
         if (!string.IsNullOrEmpty(prop.ElementTitleProperty))
         {
-            sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
-            sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty});");
+            if (!string.IsNullOrEmpty(prop.ElementTitleContextProperty))
+            {
+                sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
+                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty}, {itemVar}.{prop.ElementTitleContextProperty});");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
+                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty});");
+            }
         }
         else
         {
@@ -114,7 +122,7 @@ internal static class CollectionEmitter
         }
 
         // Emit property serializations for each item, at a deeper level
-        SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1);
+        SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1, prop.ElementAutoFields, prop.ElementFieldLayout);
 
         sb.AppendLine($"{indent}}}");
     }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -127,6 +127,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public IReadOnlyList<PropertyMetadata>? ElementProperties { get; }
     public bool ElementHasNestedContent { get; }
     public string? ElementTitleProperty { get; }
+    public string? ElementTitleContextProperty { get; }
+    public bool ElementAutoFields { get; }
+    public FieldLayoutKind ElementFieldLayout { get; }
     public string? BoolTrueValue { get; }
     public string? BoolFalseValue { get; }
     public bool IsNullableValueType { get; }
@@ -154,6 +157,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         IReadOnlyList<PropertyMetadata>? elementProperties = null,
         bool elementHasNestedContent = false,
         string? elementTitleProperty = null,
+        string? elementTitleContextProperty = null,
+        bool elementAutoFields = true,
+        FieldLayoutKind elementFieldLayout = FieldLayoutKind.OneLine,
         string? boolTrueValue = null,
         string? boolFalseValue = null,
         bool isNullableValueType = false,
@@ -180,6 +186,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         ElementProperties = elementProperties;
         ElementHasNestedContent = elementHasNestedContent;
         ElementTitleProperty = elementTitleProperty;
+        ElementTitleContextProperty = elementTitleContextProperty;
+        ElementAutoFields = elementAutoFields;
+        ElementFieldLayout = elementFieldLayout;
         BoolTrueValue = boolTrueValue;
         BoolFalseValue = boolFalseValue;
         IsNullableValueType = isNullableValueType;
@@ -210,6 +219,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                ElementTypeName == other.ElementTypeName &&
                ElementHasNestedContent == other.ElementHasNestedContent &&
                ElementTitleProperty == other.ElementTitleProperty &&
+               ElementTitleContextProperty == other.ElementTitleContextProperty &&
+               ElementAutoFields == other.ElementAutoFields &&
+               ElementFieldLayout == other.ElementFieldLayout &&
                BoolTrueValue == other.BoolTrueValue &&
                BoolFalseValue == other.BoolFalseValue &&
                IsNullableValueType == other.IsNullableValueType &&
@@ -229,6 +241,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (int)Kind;
             hash = hash * 397 ^ (DisplayName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ SkipWhenDefault.GetHashCode();
+            hash = hash * 397 ^ ElementAutoFields.GetHashCode();
+            hash = hash * 397 ^ (int)ElementFieldLayout;
             hash = hash * 397 ^ (SectionIgnoreProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionFormatProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionFormatterTypeName?.GetHashCode() ?? 0);

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -260,7 +260,7 @@ internal static class TypeParser
             isNullableValueType = true;
         }
 
-        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, isArray) = DeterminePropertyKind(prop.Type, compilation, knownTypes, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
+        var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, elementTitleContextProperty, elementAutoFields, elementFieldLayout, isArray) = DeterminePropertyKind(prop.Type, compilation, knownTypes, diagnostics, prop.Name, prop.Locations.FirstOrDefault());
 
         // Determine if property is unsupported in table context
         // Joined string arrays are treated as scalars, so they're fine in tables
@@ -298,6 +298,9 @@ internal static class TypeParser
             elementProperties,
             hasNestedContent,
             elementTitleProperty,
+            elementTitleContextProperty,
+            elementAutoFields,
+            elementFieldLayout,
             boolTrueValue,
             boolFalseValue,
             isNullableValueType,
@@ -307,7 +310,7 @@ internal static class TypeParser
             skipWhenDefault);
     }
 
-    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)
+    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)
         DeterminePropertyKind(ITypeSymbol type, Compilation compilation, KnownTypeSymbols knownTypes, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
         // Check for nullable value types
@@ -320,28 +323,28 @@ internal static class TypeParser
         // Primitives
         return type.SpecialType switch
         {
-            SpecialType.System_String => (PropertyKind.String, null, null, false, null, false),
-            SpecialType.System_Boolean => (PropertyKind.Boolean, null, null, false, null, false),
-            SpecialType.System_Int32 => (PropertyKind.Int32, null, null, false, null, false),
-            SpecialType.System_Int64 => (PropertyKind.Int64, null, null, false, null, false),
-            SpecialType.System_Double => (PropertyKind.Double, null, null, false, null, false),
-            SpecialType.System_Decimal => (PropertyKind.Decimal, null, null, false, null, false),
+            SpecialType.System_String => (PropertyKind.String, null, null, false, null, null, true, FieldLayoutKind.OneLine, false),
+            SpecialType.System_Boolean => (PropertyKind.Boolean, null, null, false, null, null, true, FieldLayoutKind.OneLine, false),
+            SpecialType.System_Int32 => (PropertyKind.Int32, null, null, false, null, null, true, FieldLayoutKind.OneLine, false),
+            SpecialType.System_Int64 => (PropertyKind.Int64, null, null, false, null, null, true, FieldLayoutKind.OneLine, false),
+            SpecialType.System_Double => (PropertyKind.Double, null, null, false, null, null, true, FieldLayoutKind.OneLine, false),
+            SpecialType.System_Decimal => (PropertyKind.Decimal, null, null, false, null, null, true, FieldLayoutKind.OneLine, false),
             _ => DetermineComplexPropertyKind(type, compilation, knownTypes, diagnostics, propertyName, propertyLocation)
         };
     }
 
-    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, bool IsArray)
+    private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)
         DetermineComplexPropertyKind(ITypeSymbol type, Compilation compilation, KnownTypeSymbols knownTypes, List<DiagnosticInfo>? diagnostics = null, string? propertyName = null, Location? propertyLocation = null)
     {
         // DateTime types
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.DateTime))
-            return (PropertyKind.DateTime, null, null, false, null, false);
+            return (PropertyKind.DateTime, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.DateTimeOffset))
-            return (PropertyKind.DateTimeOffset, null, null, false, null, false);
+            return (PropertyKind.DateTimeOffset, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
 
         // Enum types
         if (type.TypeKind == TypeKind.Enum)
-            return (PropertyKind.Enum, null, null, false, null, false);
+            return (PropertyKind.Enum, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
 
         // Check for arrays
         if (type is IArrayTypeSymbol arrayType)
@@ -350,15 +353,15 @@ internal static class TypeParser
 
             // Check for MarkoutField[] - renders as compact line or field table
             if (SymbolEqualityComparer.Default.Equals(elementType, knownTypes.MarkoutField))
-                return (PropertyKind.FieldCollection, null, null, false, null, true);
+                return (PropertyKind.FieldCollection, null, null, false, null, null, true, FieldLayoutKind.OneLine, true);
 
             if (elementType.SpecialType == SpecialType.System_String)
-                return (PropertyKind.StringArray, null, null, false, null, true);
+                return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.OneLine, true);
 
             var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics);
             var hasNested = HasNestedContent(elementProps);
-            var titleProp = GetTitleProperty(elementType);
-            return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp, true);
+            var elementSettings = GetElementTypeSettings(elementType);
+            return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, elementSettings.TitleProperty, elementSettings.TitleContextProperty, elementSettings.AutoFields, elementSettings.FieldLayout, true);
         }
 
         // Check for IEnumerable<T> / List<T> / etc.
@@ -377,7 +380,7 @@ internal static class TypeParser
                         propertyLocation,
                         propertyName));
                 }
-                return (PropertyKind.Other, null, null, false, null, false);
+                return (PropertyKind.Other, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
             }
 
             var enumerableInterface = knownTypes.IEnumerable != null
@@ -411,7 +414,7 @@ internal static class TypeParser
                             typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>" ||
                             typeDisplayString == "System.Collections.Generic.IList<T>")
                         {
-                            return (PropertyKind.FieldCollection, null, null, false, null, false);
+                            return (PropertyKind.FieldCollection, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
                         }
                         // IEnumerable<MarkoutField> without materialization is not supported
                         // User should use List<MarkoutField> or IReadOnlyList<MarkoutField>
@@ -423,17 +426,17 @@ internal static class TypeParser
                         var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
                         if (typeDisplayString == "System.Collections.Generic.List<T>")
                         {
-                            return (PropertyKind.Tree, null, null, false, null, false);
+                            return (PropertyKind.Tree, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
                         }
                     }
 
                     if (elementType.SpecialType == SpecialType.System_String)
-                        return (PropertyKind.StringArray, null, null, false, null, false);
+                        return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
 
                     var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics);
                     var hasNested = HasNestedContent(elementProps);
-                    var titleProp = GetTitleProperty(elementType);
-                    return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, titleProp, false);
+                    var elementSettings = GetElementTypeSettings(elementType);
+                    return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, elementSettings.TitleProperty, elementSettings.TitleContextProperty, elementSettings.AutoFields, elementSettings.FieldLayout, false);
                 }
             }
         }
@@ -442,7 +445,7 @@ internal static class TypeParser
         if (knownTypes.IMarkoutFormattable != null &&
             type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, knownTypes.IMarkoutFormattable)))
         {
-            return (PropertyKind.Formattable, null, null, false, null, false);
+            return (PropertyKind.Formattable, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
         }
 
         // Nested object
@@ -450,36 +453,49 @@ internal static class TypeParser
         {
             var props = GetTypeProperties(type, compilation, knownTypes, diagnostics);
             if (props.Count > 0)
-                return (PropertyKind.NestedObject, null, props, false, null, false);
+                return (PropertyKind.NestedObject, null, props, false, null, null, true, FieldLayoutKind.OneLine, false);
         }
 
-        return (PropertyKind.Other, null, null, false, null, false);
+        return (PropertyKind.Other, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
     }
 
     private static bool HasNestedContent(IReadOnlyList<PropertyMetadata>? props)
     {
         if (props == null) return false;
-        return props.Any(p => !p.IsIgnored && 
-            (p.Kind == PropertyKind.NestedObject || p.Kind == PropertyKind.ComplexArray));
+        return props.Any(p => !p.IsIgnored &&
+            (p.Kind == PropertyKind.NestedObject || p.Kind == PropertyKind.ComplexArray ||
+             p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree));
     }
 
-    private static string? GetTitleProperty(ITypeSymbol type)
+    private static (string? TitleProperty, string? TitleContextProperty, bool AutoFields, FieldLayoutKind FieldLayout) GetElementTypeSettings(ITypeSymbol type)
     {
-        if (type is not INamedTypeSymbol namedType) return null;
-        
+        if (type is not INamedTypeSymbol namedType)
+            return (null, null, true, FieldLayoutKind.OneLine);
+
+        string? titleProperty = null;
+        string? titleContextProperty = null;
+        bool autoFields = true;
+        FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine;
+
         var serializableAttr = namedType.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutSerializableAttribute);
-        
+
         if (serializableAttr != null)
         {
             foreach (var named in serializableAttr.NamedArguments)
             {
                 if (named.Key == "TitleProperty" && named.Value.Value is string tp)
-                    return tp;
+                    titleProperty = tp;
+                else if (named.Key == "TitleContextProperty" && named.Value.Value is string tcp)
+                    titleContextProperty = tcp;
+                else if (named.Key == "AutoFields" && named.Value.Value is bool af)
+                    autoFields = af;
+                else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
+                    fieldLayout = (FieldLayoutKind)fl;
             }
         }
-        
-        return null;
+
+        return (titleProperty, titleContextProperty, autoFields, fieldLayout);
     }
 
     private static IReadOnlyList<PropertyMetadata> GetTypeProperties(

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -556,7 +556,159 @@ public class NestedStructureTests
     }
 
     #endregion
+
+    #region Multi-TFM Wrapper Pattern: Collection with FieldCollection elements
+
+    [Fact]
+    public void Serialize_CollectionWithFieldCollectionElements_RendersSubsections()
+    {
+        var report = new MultiTfmAuditReport
+        {
+            Title = "System.Text.Json",
+            Items =
+            [
+                new AuditItem
+                {
+                    Name = "System.Text.Json.dll",
+                    Framework = "net9.0",
+                    SomeField = "should not appear",
+                    InfoSection = [new("Name", "System.Text.Json"), new("Version", "9.0.0")]
+                },
+                new AuditItem
+                {
+                    Name = "System.Text.Json.dll",
+                    Framework = "net8.0",
+                    SomeField = "should not appear",
+                    InfoSection = [new("Name", "System.Text.Json"), new("Version", "8.0.0")]
+                }
+            ]
+        };
+
+        var mdf = MarkoutSerializer.Serialize(report, MultiTfmAuditReportContext.Default);
+
+        // Single H1 from wrapper
+        Assert.Single(mdf.Split('\n'), l => l.StartsWith("# "));
+        Assert.Contains("# System.Text.Json", mdf);
+
+        // H2 section heading
+        Assert.Contains("## Items", mdf);
+
+        // H3 subsection per item with context
+        Assert.Contains("### System.Text.Json.dll (net9.0)", mdf);
+        Assert.Contains("### System.Text.Json.dll (net8.0)", mdf);
+
+        // H4 item sections (Info within each item)
+        Assert.Contains("#### Info", mdf);
+
+        // FieldCollection content renders as field table
+        Assert.Contains("| Name | System.Text.Json |", mdf);
+        Assert.Contains("| Version | 9.0.0 |", mdf);
+        Assert.Contains("| Version | 8.0.0 |", mdf);
+    }
+
+    [Fact]
+    public void Serialize_CollectionElement_AutoFieldsFalse_SuppressesScalarFields()
+    {
+        var report = new MultiTfmAuditReport
+        {
+            Title = "Test",
+            Items =
+            [
+                new AuditItem
+                {
+                    Name = "test.dll",
+                    Framework = "net9.0",
+                    SomeField = "this should not appear",
+                    InfoSection = [new("Key", "Value")]
+                }
+            ]
+        };
+
+        var mdf = MarkoutSerializer.Serialize(report, MultiTfmAuditReportContext.Default);
+
+        // SomeField should NOT appear because AutoFields=false on AuditItem
+        Assert.DoesNotContain("SomeField", mdf);
+        Assert.DoesNotContain("this should not appear", mdf);
+    }
+
+    [Fact]
+    public void Serialize_CollectionElement_TitleContextProperty_RendersInParentheses()
+    {
+        var report = new MultiTfmAuditReport
+        {
+            Title = "Test",
+            Items =
+            [
+                new AuditItem
+                {
+                    Name = "Foo.dll",
+                    Framework = "net9.0",
+                    InfoSection = [new("A", "B")]
+                }
+            ]
+        };
+
+        var mdf = MarkoutSerializer.Serialize(report, MultiTfmAuditReportContext.Default);
+
+        // Title with context renders as "### Foo.dll (net9.0)"
+        Assert.Contains("### Foo.dll (net9.0)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_CollectionElement_NullContext_RendersWithoutParentheses()
+    {
+        var report = new MultiTfmAuditReport
+        {
+            Title = "Test",
+            Items =
+            [
+                new AuditItem
+                {
+                    Name = "Foo.dll",
+                    Framework = null,
+                    InfoSection = [new("A", "B")]
+                }
+            ]
+        };
+
+        var mdf = MarkoutSerializer.Serialize(report, MultiTfmAuditReportContext.Default);
+
+        // No context — should render without parentheses
+        Assert.Contains("### Foo.dll", mdf);
+        Assert.DoesNotContain("### Foo.dll (", mdf);
+    }
+
+    #endregion
 }
+
+#region Multi-TFM Wrapper Pattern: Collection with FieldCollection Elements
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class MultiTfmAuditReport
+{
+    public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Items")]
+    public List<AuditItem>? Items { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), TitleContextProperty = nameof(Framework), AutoFields = false)]
+public class AuditItem
+{
+    public string Name { get; set; } = "";
+    public string? Framework { get; set; }
+    public string SomeField { get; set; } = "";
+
+    [MarkoutSection(Name = "Info")]
+    public List<MarkoutField> InfoSection { get; set; } = [];
+}
+
+[MarkoutContext(typeof(MultiTfmAuditReport))]
+public partial class MultiTfmAuditReportContext : MarkoutSerializerContext
+{
+}
+
+#endregion
 
 #region Real-World Pattern: DotNet Inspector Structure
 


### PR DESCRIPTION
## Summary
- Fix `HasNestedContent` to recognize `FieldCollection` and `Tree` property kinds, triggering subsection-per-item rendering for collection elements that have nested sections
- Propagate `AutoFields`, `FieldLayout`, and `TitleContextProperty` from element type's `[MarkoutSerializable]` attribute through to collection element serialization
- Rename `GetTitleProperty` to `GetElementTypeSettings` to read all four named args from the attribute

## Motivation

A wrapper type like `AssemblyAuditReport` with a `List<AssemblyAudit>` section should serialize each element as a subsection with its own heading hierarchy. Previously, collection elements with `FieldCollection` sections (like `List<MarkoutField>`) fell back to table rendering because `HasNestedContent` only checked for `NestedObject` and `ComplexArray`. Additionally, `AutoFields=false` and `TitleContextProperty` were not propagated from the element type, causing unwanted compact lines and missing context in headings.

## Test plan
- [x] 4 new tests in `NestedStructureTests.cs` covering subsection rendering, AutoFields suppression, TitleContextProperty, and null context
- [x] All 192 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)