### PR TITLE
Add SuppressTableWarnings option to MarkoutContextOptions

### DIFF
--- a/src/Markout.SourceGeneration/Parser/ContextMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/ContextMetadata.cs
@@ -14,9 +14,11 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
     public bool? BoldFieldNames { get; }
     public bool? IncludeIcons { get; }
     public bool? IncludeDescription { get; }
+    public bool SuppressTableWarnings { get; }
 
     public ContextMetadata(string @namespace, string className, IReadOnlyList<TypeMetadata> types,
-        bool? boldFieldNames = null, bool? includeIcons = null, bool? includeDescription = null)
+        bool? boldFieldNames = null, bool? includeIcons = null, bool? includeDescription = null,
+        bool suppressTableWarnings = false)
     {
         Namespace = @namespace;
         ClassName = className;
@@ -24,6 +26,7 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
         BoldFieldNames = boldFieldNames;
         IncludeIcons = includeIcons;
         IncludeDescription = includeDescription;
+        SuppressTableWarnings = suppressTableWarnings;
     }
 
     public bool Equals(ContextMetadata? other)
@@ -35,6 +38,7 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
                BoldFieldNames == other.BoldFieldNames &&
                IncludeIcons == other.IncludeIcons &&
                IncludeDescription == other.IncludeDescription &&
+               SuppressTableWarnings == other.SuppressTableWarnings &&
                SequenceEqual(Types, other.Types);
     }
 
@@ -47,6 +51,7 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
             hash = hash * 397 ^ (BoldFieldNames?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (IncludeIcons?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (IncludeDescription?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ SuppressTableWarnings.GetHashCode();
             foreach (var type in Types)
                 hash = hash * 397 ^ type.GetHashCode();
             return hash;

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -38,22 +38,11 @@ internal static class TypeParser
 
         var knownTypes = new KnownTypeSymbols(context.SemanticModel.Compilation);
 
-        var types = new List<TypeMetadata>();
-        foreach (var attr in contextAttributes)
-        {
-            if (attr.ConstructorArguments.Length > 0 &&
-                attr.ConstructorArguments[0].Value is INamedTypeSymbol typeArg)
-            {
-                var typeMeta = ParseTypeSymbol(typeArg, context.SemanticModel.Compilation, knownTypes, null, null, null, null);
-                if (typeMeta != null)
-                    types.Add(typeMeta);
-            }
-        }
-
-        // Parse [MarkoutContextOptions] attribute
+        // Parse [MarkoutContextOptions] attribute (before processing types, as options affect type parsing)
         bool? boldFieldNames = null;
         bool? includeIcons = null;
         bool? includeDescription = null;
+        bool suppressTableWarnings = false;
         var optionsAttr = classSymbol.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutContextOptionsAttribute);
         if (optionsAttr != null)
@@ -66,6 +55,20 @@ internal static class TypeParser
                     includeIcons = ii;
                 else if (named.Key == "IncludeDescription" && named.Value.Value is bool id)
                     includeDescription = id;
+                else if (named.Key == "SuppressTableWarnings" && named.Value.Value is bool stw)
+                    suppressTableWarnings = stw;
+            }
+        }
+
+        var types = new List<TypeMetadata>();
+        foreach (var attr in contextAttributes)
+        {
+            if (attr.ConstructorArguments.Length > 0 &&
+                attr.ConstructorArguments[0].Value is INamedTypeSymbol typeArg)
+            {
+                var typeMeta = ParseTypeSymbol(typeArg, context.SemanticModel.Compilation, knownTypes, null, null, null, null, suppressTableWarnings: suppressTableWarnings);
+                if (typeMeta != null)
+                    types.Add(typeMeta);
             }
         }
 
@@ -73,7 +76,7 @@ internal static class TypeParser
             ? string.Empty
             : classSymbol.ContainingNamespace.ToDisplayString();
 
-        return new ContextMetadata(ns, classSymbol.Name, types, boldFieldNames, includeIcons, includeDescription);
+        return new ContextMetadata(ns, classSymbol.Name, types, boldFieldNames, includeIcons, includeDescription, suppressTableWarnings);
     }
 
     private static TypeMetadata? ParseTypeSymbol(
@@ -84,7 +87,8 @@ internal static class TypeParser
         string? titleContextProperty = null,
         string? descriptionProperty = null,
         bool? autoFields = null,
-        FieldLayoutKind? fieldLayout = null)
+        FieldLayoutKind? fieldLayout = null,
+        bool suppressTableWarnings = false)
     {
         // If titleProperty/descriptionProperty not passed, try to get them from the type's [MarkoutSerializable] attribute
         if (titleProperty == null || titleContextProperty == null || descriptionProperty == null || autoFields == null || fieldLayout == null)
@@ -152,6 +156,11 @@ internal static class TypeParser
             ? string.Empty
             : typeSymbol.ContainingNamespace.ToDisplayString();
 
+        // Filter out MARKOUT001 warnings when SuppressTableWarnings is enabled
+        var filteredDiagnostics = suppressTableWarnings
+            ? diagnostics.Where(d => d.Descriptor.Id != "MARKOUT001").ToList()
+            : diagnostics;
+
         return new TypeMetadata(
             ns,
             typeSymbol.Name,
@@ -163,7 +172,7 @@ internal static class TypeParser
             descriptionProperty,
             autoFields.Value,
             fieldLayout.Value,
-            diagnostics);
+            filteredDiagnostics);
     }
 
     private static PropertyMetadata? ParseProperty(

--- a/src/Markout/Attributes/MarkoutContextOptionsAttribute.cs
+++ b/src/Markout/Attributes/MarkoutContextOptionsAttribute.cs
@@ -33,4 +33,13 @@ public sealed class MarkoutContextOptionsAttribute : Attribute
     /// Default is true.
     /// </summary>
     public bool IncludeDescription { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether to suppress MARKOUT001 warnings for properties
+    /// that are unsupported in table context. Useful when domain model types
+    /// from external libraries are processed transitively and cannot be annotated
+    /// with [MarkoutIgnoreInTable].
+    /// Default is false.
+    /// </summary>
+    public bool SuppressTableWarnings { get; set; }
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">


### PR DESCRIPTION
## Summary

Adds a `SuppressTableWarnings` property to `MarkoutContextOptionsAttribute` that suppresses MARKOUT001 warnings for properties unsupported in table context.

## Motivation

When a Markout context serializes types that reference domain model types from external libraries, the source generator walks into those types transitively and emits MARKOUT001 for every complex/array property. Since those types are defined in a separate library, they cannot be annotated with `[MarkoutIgnoreInTable]`.

This is the case in `dotnet-inspect`, where app-layer view models reference domain types from `DotnetInspector.Metadata`. Removing `[MarkoutIgnoreInTable]` from the domain library (to make it a pure, dependency-free domain model) requires a way to suppress the resulting warnings at the context level.

## Usage

```csharp
[MarkoutContextOptions(SuppressTableWarnings = true)]
[MarkoutContext(typeof(MyViewModelThatReferencesExternalTypes))]
public partial class MyContext : MarkoutSerializerContext { }
```

## Changes

- `MarkoutContextOptionsAttribute`: add `SuppressTableWarnings` property (default `false`)
- `ContextMetadata`: thread the option through equality/hashing
- `TypeParser`: parse the option from the attribute and filter MARKOUT001 diagnostics when enabled
- Version bump: 0.3.2 → 0.3.3

All 192 existing tests pass.