### PR TITLE
Add IMarkoutValueFormatter<T> and [MarkoutValueFormatter] attribute

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -13,6 +13,12 @@ internal static class EmitHelpers
     {
         var access = nullable ? $"{propAccess}.Value" : propAccess;
 
+        // Value formatter takes highest priority
+        if (prop.ValueFormatterTypeName != null)
+        {
+            return $"new {prop.ValueFormatterTypeName}().Format({access})";
+        }
+
         // Joined string array: render as string.Join(separator, collection)
         if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
         {
@@ -53,8 +59,18 @@ internal static class EmitHelpers
 
         if (prop.IsNullableValueType)
         {
+            if (prop.ValueFormatterTypeName != null)
+            {
+                return $"{propAccess}.HasValue ? new {prop.ValueFormatterTypeName}().Format({propAccess}.Value) : \"\"";
+            }
             var valueExpr = GetScalarValueExpression(prop, propAccess, nullable: true);
             return $"{propAccess}.HasValue ? {valueExpr} : \"\"";
+        }
+
+        // Value formatter takes highest priority
+        if (prop.ValueFormatterTypeName != null)
+        {
+            return $"new {prop.ValueFormatterTypeName}().Format({propAccess})";
         }
 
         // Joined string array in table cell

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -139,7 +139,19 @@ internal static class FieldEmitter
                 emitIndent = indent + "    ";
             }
 
-            if (prop.IsNullableValueType)
+            if (prop.ValueFormatterTypeName != null)
+            {
+                if (prop.IsNullableValueType)
+                {
+                    sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", new {prop.ValueFormatterTypeName}().Format({propAccess}.Value));");
+                }
+                else
+                {
+                    sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", new {prop.ValueFormatterTypeName}().Format({propAccess}));");
+                }
+            }
+            else if (prop.IsNullableValueType)
             {
                 sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
                 if (prop.Kind == PropertyKind.Boolean)

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -137,6 +137,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? CustomFormat { get; }
     public string? JoinSeparator { get; }
     public bool SkipWhenDefault { get; }
+    public string? ValueFormatterTypeName { get; }
 
     public PropertyMetadata(
         string name,
@@ -166,7 +167,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         bool isArray = false,
         string? customFormat = null,
         string? joinSeparator = null,
-        bool skipWhenDefault = false)
+        bool skipWhenDefault = false,
+        string? valueFormatterTypeName = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -196,6 +198,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         CustomFormat = customFormat;
         JoinSeparator = joinSeparator;
         SkipWhenDefault = skipWhenDefault;
+        ValueFormatterTypeName = valueFormatterTypeName;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -229,6 +232,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                CustomFormat == other.CustomFormat &&
                JoinSeparator == other.JoinSeparator &&
                SkipWhenDefault == other.SkipWhenDefault &&
+               ValueFormatterTypeName == other.ValueFormatterTypeName &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -247,6 +251,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionFormatProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionFormatterTypeName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionColumnName?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (ValueFormatterTypeName?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -21,6 +21,7 @@ internal static class TypeParser
     private const string MarkoutFormatAttribute = "Markout.MarkoutFormatAttribute";
     private const string MarkoutJoinAttribute = "Markout.MarkoutJoinAttribute";
     private const string MarkoutSkipDefaultAttribute = "Markout.MarkoutSkipDefaultAttribute";
+    private const string MarkoutValueFormatterAttribute = "Markout.MarkoutValueFormatterAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -247,6 +248,16 @@ internal static class TypeParser
             customFormat = fmt;
         }
 
+        // Parse [MarkoutValueFormatter] attribute
+        string? valueFormatterTypeName = null;
+        var valueFormatterAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutValueFormatterAttribute);
+        if (valueFormatterAttr?.ConstructorArguments.Length > 0 &&
+            valueFormatterAttr.ConstructorArguments[0].Value is INamedTypeSymbol valueFormatterType)
+        {
+            valueFormatterTypeName = valueFormatterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        }
+
         // Parse [MarkoutJoin] attribute
         string? joinSeparator = null;
         var joinAttr = prop.GetAttributes()
@@ -316,7 +327,8 @@ internal static class TypeParser
             isArray,
             customFormat,
             joinSeparator,
-            skipWhenDefault);
+            skipWhenDefault,
+            valueFormatterTypeName);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutValueFormatterAttribute.cs
+++ b/src/Markout/Attributes/MarkoutValueFormatterAttribute.cs
@@ -1,0 +1,12 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies a custom formatter type to use when rendering a property value.
+/// The formatter must implement <see cref="IMarkoutValueFormatter{T}"/> for the property type.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutValueFormatterAttribute : Attribute
+{
+    public Type FormatterType { get; }
+    public MarkoutValueFormatterAttribute(Type formatterType) => FormatterType = formatterType;
+}

--- a/src/Markout/IMarkoutValueFormatter.cs
+++ b/src/Markout/IMarkoutValueFormatter.cs
@@ -1,0 +1,11 @@
+namespace Markout;
+
+/// <summary>
+/// Formats a property value before rendering it as a Markout field value.
+/// Implement this interface and reference it from [MarkoutValueFormatter] to
+/// customize how a property is displayed.
+/// </summary>
+public interface IMarkoutValueFormatter<in T>
+{
+    string Format(T value);
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.3.3</Version>
+    <Version>0.3.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">


### PR DESCRIPTION
Adds property-level value formatting for Markout serialization.

## New types

- **`IMarkoutValueFormatter<T>`** — interface for custom property value formatting
- **`[MarkoutValueFormatter(typeof(...))]`** — attribute to specify a formatter on a property

## Usage

```csharp
public class ByteSizeFormatter : IMarkoutValueFormatter<long>
{
    public string Format(long value) => value switch
    {
        >= 1_048_576 => $"{value / 1_048_576.0:0.#} MB",
        >= 1_024 => $"{value / 1_024.0:0.#} KB",
        _ => $"{value} B"
    };
}

[MarkoutValueFormatter(typeof(ByteSizeFormatter))]
[MarkoutPropertyName("Package Size")]
public long? PackageSize { get; set; }
// Renders: **Package Size:** 2.3 MB
```

## Source generator support

- Value formatter takes highest priority (over `[MarkoutFormat]` and default formatting)
- Handles nullable value types with `.HasValue` checks  
- Works in both field and table cell contexts
- All 192 tests pass