### PR TITLE
Update samples to Markout 0.3.4

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.3.0
+#:package Markout@0.3.4
 // CanCon. It's the law!
 
 using System.Text.Json;

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.3.0
+#:package Markout@0.3.4
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.3.0
+#:package Markout@0.3.4
 
 using System.Text.Json;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
Update the `#:package` directive in all file-based samples from `Markout@0.3.0` to `Markout@0.3.4`.

**Changed files:**
- `samples/CanadianContent/CanadianContent.cs`
- `samples/DotNetReleases/DotNetReleases.cs`
- `samples/LatestCves/LatestCves.cs`

The `Serialization` sample uses project references and requires no update.