### PR TITLE
Add expressiveness features for v0.4.0

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.3.4
+#:package Markout@0.4.0
 // CanCon. It's the law!
 
 using System.Text.Json;
@@ -227,9 +227,11 @@ public class CanConOverview
     public string Title { get; set; } = "";
 
     [MarkoutSection(Name = "Actors")]
+    [MarkoutMaxItems(5)]
     public List<ActorRow>? Actors { get; set; }
 
     [MarkoutSection(Name = "Shows")]
+    [MarkoutMaxItems(5)]
     public List<ShowRow>? Shows { get; set; }
 }
 

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.3.4
+#:package Markout@0.4.0
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -38,9 +38,11 @@ public class ReleasesView
     public string Title { get; set; } = "";
     
     [MarkoutPropertyName("Latest Major")]
+    [MarkoutSkipNull]
     public string? LatestMajor { get; set; }
     
     [MarkoutPropertyName("Latest LTS")]
+    [MarkoutSkipNull]
     public string? LatestLtsMajor { get; set; }
     
     [MarkoutSection(Name = "All Releases")]
@@ -52,6 +54,7 @@ public class ReleaseRow
 {
     public string Version { get; set; } = "";
     public string Type { get; set; } = "";
+    [MarkoutBoolFormat("✓", "✗")]
     public bool Supported { get; set; }
 }
 

--- a/samples/HelloMarkout/HelloMarkout.cs
+++ b/samples/HelloMarkout/HelloMarkout.cs
@@ -1,0 +1,24 @@
+#!/usr/bin/env dotnet run
+#:package Markout@0.4.0
+
+using Markout;
+
+var product = new ProductView
+{
+    Name = "Widget Pro",
+    Category = "Electronics",
+    Price = 49.99m
+};
+
+MarkoutSerializer.Serialize(product, Console.Out, ProductContext.Default);
+
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class ProductView
+{
+    public string Name { get; set; } = "";
+    public string Category { get; set; } = "";
+    public decimal Price { get; set; }
+}
+
+[MarkoutContext(typeof(ProductView))]
+public partial class ProductContext : MarkoutSerializerContext { }

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.3.4
+#:package Markout@0.4.0
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/Serialization/AdvancedFeatures.cs
+++ b/samples/Serialization/AdvancedFeatures.cs
@@ -1,0 +1,131 @@
+using Markout;
+
+namespace Markout.Samples.Serialization;
+
+#region SkipNullAndDisplayFormat
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class ServerView
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutSkipNull]
+    public string? Region { get; set; }
+
+    [MarkoutDisplayFormat("{0:N0} req/s")]
+    public long RequestsPerSecond { get; set; }
+
+    [MarkoutSkipNull]
+    [MarkoutDisplayFormat("{0:P1}")]
+    public double? CpuUsage { get; set; }
+
+    [MarkoutSkipDefault]
+    public bool MaintenanceMode { get; set; }
+}
+#endregion
+
+#region ConditionalSections
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class AuditReport
+{
+    [MarkoutIgnore]
+    public string? Title { get; set; }
+
+    public bool HasWarnings { get; set; }
+    public bool HasErrors { get; set; }
+
+    [MarkoutSection(Name = "Warnings", ShowWhenProperty = nameof(HasWarnings))]
+    public List<string>? Warnings { get; set; }
+
+    [MarkoutSection(Name = "Errors", ShowWhenProperty = nameof(HasErrors))]
+    public List<string>? Errors { get; set; }
+
+    [MarkoutSection(Name = "Files")]
+    [MarkoutMaxItems(5)]
+    public List<string>? Files { get; set; }
+}
+#endregion
+
+#region TableDisplay
+[MarkoutSerializable]
+public class MetricRow
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutTableDisplay("{0:N0} req")]
+    public long Requests { get; set; }
+
+    [MarkoutTableDisplay("{0:P0}")]
+    public double ErrorRate { get; set; }
+}
+#endregion
+
+[MarkoutContext(typeof(ServerView))]
+[MarkoutContext(typeof(AuditReport))]
+[MarkoutContext(typeof(MetricRow))]
+public partial class AdvancedContext : MarkoutSerializerContext { }
+
+/// <summary>
+/// Demonstrates the new expressiveness features: SkipNull, DisplayFormat,
+/// ShowWhenProperty, MaxItems, and TableDisplay.
+/// </summary>
+public static class AdvancedFeatures
+{
+    /// <summary>
+    /// Shows SkipNull and DisplayFormat on scalar fields.
+    /// </summary>
+    public static void SkipNullAndDisplayFormat()
+    {
+        #region SkipNullAndDisplayFormatUsage
+        var server = new ServerView
+        {
+            Name = "prod-web-01",
+            Region = "us-east-1",
+            RequestsPerSecond = 12500,
+            CpuUsage = 0.73,
+            MaintenanceMode = false // skipped because [MarkoutSkipDefault]
+        };
+
+        string markdown = MarkoutSerializer.Serialize(server, AdvancedContext.Default);
+        // # prod-web-01
+        //
+        // Region: us-east-1 | RequestsPerSecond: 12,500 req/s | CpuUsage: 73.0 %
+        #endregion
+
+        Console.WriteLine(markdown);
+        Console.WriteLine();
+
+        // With nulls — Region and CpuUsage are omitted
+        var minimal = new ServerView
+        {
+            Name = "staging-01",
+            RequestsPerSecond = 50,
+            Region = null,
+            CpuUsage = null
+        };
+        Console.WriteLine(MarkoutSerializer.Serialize(minimal, AdvancedContext.Default));
+    }
+
+    /// <summary>
+    /// Shows conditional sections and MaxItems truncation.
+    /// </summary>
+    public static void ConditionalSectionsAndMaxItems()
+    {
+        #region ConditionalSectionsUsage
+        var report = new AuditReport
+        {
+            Title = "Build Audit",
+            HasWarnings = true,
+            HasErrors = false,
+            Warnings = new() { "Deprecated API usage in Foo.cs", "Missing XML docs on Bar.cs" },
+            Errors = new() { "This won't show because HasErrors is false" },
+            Files = new() { "Foo.cs", "Bar.cs", "Baz.cs", "Qux.cs", "Quux.cs", "Corge.cs", "Grault.cs" }
+        };
+
+        string markdown = MarkoutSerializer.Serialize(report, AdvancedContext.Default);
+        // Warnings section appears, Errors section is hidden
+        // Files section shows first 5 with "... and 2 more"
+        #endregion
+
+        Console.WriteLine(markdown);
+    }
+}

--- a/samples/Serialization/AdvancedFeatures.cs
+++ b/samples/Serialization/AdvancedFeatures.cs
@@ -59,9 +59,36 @@ public class MetricRow
 }
 #endregion
 
+#region ShowWhenAndLink
+[MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.LineBreaks)]
+public class PackageView
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutLink]
+    [MarkoutSkipNull]
+    public string? Homepage { get; set; }
+
+    [MarkoutLink(TextProperty = nameof(Name))]
+    [MarkoutSkipNull]
+    public string? Repository { get; set; }
+
+    public bool IsVerified { get; set; }
+
+    [MarkoutShowWhen(nameof(IsVerified))]
+    public string? VerifiedBy { get; set; }
+
+    public bool IsTool { get; set; }
+
+    [MarkoutShowWhen(nameof(IsTool))]
+    public string? ToolCommand { get; set; }
+}
+#endregion
+
 [MarkoutContext(typeof(ServerView))]
 [MarkoutContext(typeof(AuditReport))]
 [MarkoutContext(typeof(MetricRow))]
+[MarkoutContext(typeof(PackageView))]
 public partial class AdvancedContext : MarkoutSerializerContext { }
 
 /// <summary>
@@ -127,5 +154,42 @@ public static class AdvancedFeatures
         #endregion
 
         Console.WriteLine(markdown);
+    }
+
+    /// <summary>
+    /// Shows [MarkoutShowWhen] for conditional fields and [MarkoutLink] for URL rendering.
+    /// </summary>
+    public static void ShowWhenAndLinks()
+    {
+        #region ShowWhenAndLinkUsage
+        var pkg = new PackageView
+        {
+            Name = "dotnet-inspect",
+            Homepage = "https://github.com/richlander/dotnet-inspect",
+            Repository = "https://github.com/richlander/dotnet-inspect.git",
+            IsVerified = true,
+            VerifiedBy = "Microsoft",
+            IsTool = true,
+            ToolCommand = "dotnet inspect"
+        };
+
+        string markdown = MarkoutSerializer.Serialize(pkg, AdvancedContext.Default);
+        // Homepage renders as [url](url)
+        // Repository renders as [dotnet-inspect](url) via TextProperty
+        // VerifiedBy shows because IsVerified is true
+        // ToolCommand shows because IsTool is true
+        #endregion
+
+        Console.WriteLine(markdown);
+        Console.WriteLine();
+
+        // With IsVerified=false, IsTool=false — those fields are hidden
+        var basic = new PackageView
+        {
+            Name = "SomeLib",
+            IsVerified = false,
+            IsTool = false
+        };
+        Console.WriteLine(MarkoutSerializer.Serialize(basic, AdvancedContext.Default));
     }
 }

--- a/samples/SkipNullDemo/SkipNullDemo.cs
+++ b/samples/SkipNullDemo/SkipNullDemo.cs
@@ -1,0 +1,34 @@
+#!/usr/bin/env dotnet run
+#:package Markout@0.4.0
+
+// Demonstrates [MarkoutSkipNull] — optional fields are omitted when null.
+
+using Markout;
+
+// Only Name and License are set — Repository and Stars are omitted from output
+var pkg = new PackageView
+{
+    Name = "Markout",
+    License = "MIT",
+    Repository = null,
+    Downloads = 1200,
+    Stars = null
+};
+
+MarkoutSerializer.Serialize(pkg, Console.Out, PackageContext.Default);
+
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class PackageView
+{
+    public string Name { get; set; } = "";
+    [MarkoutSkipNull]
+    public string? License { get; set; }
+    [MarkoutSkipNull]
+    public string? Repository { get; set; }
+    public int Downloads { get; set; }
+    [MarkoutSkipNull]
+    public int? Stars { get; set; }
+}
+
+[MarkoutContext(typeof(PackageView))]
+public partial class PackageContext : MarkoutSerializerContext { }

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -117,7 +117,12 @@ internal static class EmitHelpers
     public static string GetTableCellValue(PropertyMetadata prop, string itemExpr)
     {
         var propAccess = $"{itemExpr}.{prop.Name}";
+        var result = GetTableCellValueCore(prop, propAccess, itemExpr);
+        return WrapWithLink(prop, result, itemExpr);
+    }
 
+    private static string GetTableCellValueCore(PropertyMetadata prop, string propAccess, string itemExpr)
+    {
         if (prop.IsNullableValueType)
         {
             if (prop.ValueFormatterTypeName != null)
@@ -188,6 +193,27 @@ internal static class EmitHelpers
             PropertyKind.Formattable => $"((global::Markout.IMarkoutFormattable){propAccess})?.ToMarkoutString() ?? \"\"",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
+    }
+
+    /// <summary>
+    /// Wraps a value expression with markdown link formatting if the property has [MarkoutLink].
+    /// </summary>
+    /// <param name="prop">The property metadata.</param>
+    /// <param name="innerExpr">The formatted value expression (the URL).</param>
+    /// <param name="parentExpr">The parent object expression, used to access TextProperty.</param>
+    public static string WrapWithLink(PropertyMetadata prop, string innerExpr, string parentExpr)
+    {
+        if (!prop.IsLink)
+            return innerExpr;
+
+        if (prop.LinkTextProperty != null)
+        {
+            // [text](url) where text comes from another property
+            return $"$\"[{{{parentExpr}.{prop.LinkTextProperty}}}]({{{innerExpr}}})\"";
+        }
+
+        // [url](url) — bare link
+        return $"$\"[{{{innerExpr}}}]({{{innerExpr}}})\"";
     }
 
     public static string GetCollectionCountCheck(PropertyMetadata prop, string propAccess)

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -16,7 +16,8 @@ internal static class EmitHelpers
         // Value formatter takes highest priority
         if (prop.ValueFormatterTypeName != null)
         {
-            return $"new {prop.ValueFormatterTypeName}().Format({access})";
+            var expr = $"new {prop.ValueFormatterTypeName}().Format({access})";
+            return WrapWithDisplayFormat(prop, expr);
         }
 
         // Joined string array: render as string.Join(separator, collection)
@@ -36,9 +37,69 @@ internal static class EmitHelpers
             if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
                 or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
             {
-                return $"{access}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+                var expr = $"{access}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+                return WrapWithDisplayFormat(prop, expr);
             }
         }
+
+        // DisplayFormat wraps the final value
+        if (prop.DisplayFormat != null)
+        {
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.DisplayFormat)}\", {access})";
+        }
+
+        return prop.Kind switch
+        {
+            PropertyKind.Boolean => $"({access} ? \"yes\" : \"no\")",
+            PropertyKind.String => $"{propAccess} ?? \"\"",
+            PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
+                => $"{access}.ToString(System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.DateTime or PropertyKind.DateTimeOffset
+                => $"{access}.ToString(\"O\", System.Globalization.CultureInfo.InvariantCulture)",
+            PropertyKind.Enum => $"{access}.ToString()",
+            _ => $"{propAccess}?.ToString() ?? \"\""
+        };
+    }
+
+    private static string WrapWithDisplayFormat(PropertyMetadata prop, string innerExpr)
+    {
+        if (prop.DisplayFormat != null)
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.DisplayFormat)}\", {innerExpr})";
+        return innerExpr;
+    }
+
+    private static string WrapWithTableOrDisplayFormat(PropertyMetadata prop, string innerExpr)
+    {
+        if (prop.TableDisplayFormat != null)
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.TableDisplayFormat)}\", {innerExpr})";
+        if (prop.DisplayFormat != null)
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.DisplayFormat)}\", {innerExpr})";
+        return innerExpr;
+    }
+
+    private static string WrapWithTableDisplayFormat(PropertyMetadata prop, string innerExpr)
+    {
+        if (prop.TableDisplayFormat != null)
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.TableDisplayFormat)}\", {innerExpr})";
+        return innerExpr;
+    }
+
+    /// <summary>
+    /// Like GetScalarValueExpression but without DisplayFormat wrapping.
+    /// Used when we need to apply TableDisplayFormat instead.
+    /// </summary>
+    private static string GetScalarValueExpressionNoDisplayFormat(PropertyMetadata prop, string propAccess, bool nullable = false)
+    {
+        var access = nullable ? $"{propAccess}.Value" : propAccess;
+
+        if (prop.ValueFormatterTypeName != null)
+            return $"new {prop.ValueFormatterTypeName}().Format({access})";
+
+        if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
+            return $"({access} ? \"{EscapeString(prop.BoolTrueValue)}\" : \"{EscapeString(prop.BoolFalseValue)}\")";
+
+        if (prop.CustomFormat != null && prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
+            return $"{access}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
 
         return prop.Kind switch
         {
@@ -61,7 +122,14 @@ internal static class EmitHelpers
         {
             if (prop.ValueFormatterTypeName != null)
             {
-                return $"{propAccess}.HasValue ? new {prop.ValueFormatterTypeName}().Format({propAccess}.Value) : \"\"";
+                var inner = $"new {prop.ValueFormatterTypeName}().Format({propAccess}.Value)";
+                return $"{propAccess}.HasValue ? {WrapWithTableOrDisplayFormat(prop, inner)} : \"\"";
+            }
+            // For nullable with table display, we need to get the inner value then wrap
+            if (prop.TableDisplayFormat != null)
+            {
+                var innerValue = GetScalarValueExpressionNoDisplayFormat(prop, propAccess, nullable: true);
+                return $"{propAccess}.HasValue ? {WrapWithTableDisplayFormat(prop, innerValue)} : \"\"";
             }
             var valueExpr = GetScalarValueExpression(prop, propAccess, nullable: true);
             return $"{propAccess}.HasValue ? {valueExpr} : \"\"";
@@ -70,7 +138,8 @@ internal static class EmitHelpers
         // Value formatter takes highest priority
         if (prop.ValueFormatterTypeName != null)
         {
-            return $"new {prop.ValueFormatterTypeName}().Format({propAccess})";
+            var inner = $"new {prop.ValueFormatterTypeName}().Format({propAccess})";
+            return WrapWithTableOrDisplayFormat(prop, inner);
         }
 
         // Joined string array in table cell
@@ -90,8 +159,21 @@ internal static class EmitHelpers
             if (prop.Kind is PropertyKind.Int32 or PropertyKind.Int64 or PropertyKind.Double or PropertyKind.Decimal
                 or PropertyKind.DateTime or PropertyKind.DateTimeOffset)
             {
-                return $"{propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+                var inner = $"{propAccess}.ToString(\"{EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture)";
+                return WrapWithTableOrDisplayFormat(prop, inner);
             }
+        }
+
+        // TableDisplayFormat takes priority over DisplayFormat in table context
+        if (prop.TableDisplayFormat != null)
+        {
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.TableDisplayFormat)}\", {propAccess})";
+        }
+
+        // DisplayFormat wraps the final value
+        if (prop.DisplayFormat != null)
+        {
+            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.DisplayFormat)}\", {propAccess})";
         }
 
         return prop.Kind switch
@@ -114,6 +196,51 @@ internal static class EmitHelpers
         return $"{propAccess} != null && {propAccess}.{countProp} > 0";
     }
 
+    /// <summary>
+    /// Emits truncation logic for [MarkoutMaxItems]. Call after emitting the collection variable.
+    /// Returns the variable name to use for iteration (either the original or a truncated version).
+    /// </summary>
+    public static (string IterVar, bool NeedsEllipsis) EmitMaxItemsTruncation(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        int nestingDepth)
+    {
+        if (prop.MaxItems == null)
+            return (propAccess, false);
+
+        var maxItems = prop.MaxItems.Value;
+        var ellipsis = prop.MaxItemsEllipsisFormat ?? "... and {0} more";
+        var countProp = prop.IsArray ? "Length" : "Count";
+        var truncVar = nestingDepth == 0 ? "__truncated" : $"__truncated{nestingDepth}";
+        var remainVar = nestingDepth == 0 ? "__remaining" : $"__remaining{nestingDepth}";
+
+        sb.AppendLine($"{indent}var {remainVar} = {propAccess}.{countProp} - {maxItems};");
+        sb.AppendLine($"{indent}var {truncVar} = {remainVar} > 0 ? global::System.Linq.Enumerable.Take({propAccess}, {maxItems}) : {propAccess};");
+
+        return (truncVar, true);
+    }
+
+    public static void EmitMaxItemsEllipsis(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        int nestingDepth)
+    {
+        if (prop.MaxItems == null)
+            return;
+
+        var maxItems = prop.MaxItems.Value;
+        var ellipsis = prop.MaxItemsEllipsisFormat ?? "... and {0} more";
+        var countProp = prop.IsArray ? "Length" : "Count";
+        var remainVar = nestingDepth == 0 ? "__remaining" : $"__remaining{nestingDepth}";
+
+        sb.AppendLine($"{indent}if ({remainVar} > 0)");
+        sb.AppendLine($"{indent}    writer.WriteParagraph(string.Format(\"{EscapeString(ellipsis)}\", {remainVar}));");
+    }
+
     public static bool IsScalarKind(PropertyKind kind)
     {
         return kind is
@@ -131,6 +258,30 @@ internal static class EmitHelpers
     public static string EscapeString(string s)
     {
         return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+
+    /// <summary>
+    /// Returns a condition expression that is true when the property value is NOT null/empty.
+    /// Used by [MarkoutSkipNull] to conditionally skip rendering.
+    /// Unlike GetNonDefaultCondition, this does not skip non-null defaults like false or 0.
+    /// </summary>
+    public static string? GetNonNullCondition(PropertyMetadata prop, string propAccess)
+    {
+        if (prop.IsNullableValueType)
+            return $"{propAccess}.HasValue";
+
+        return prop.Kind switch
+        {
+            PropertyKind.String => $"!string.IsNullOrEmpty({propAccess})",
+            PropertyKind.StringArray => $"{propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0",
+            PropertyKind.Formattable => $"{propAccess} != null",
+            // Non-nullable value types (bool, int, etc.) are never null — no condition needed
+            PropertyKind.Boolean or PropertyKind.Int32 or PropertyKind.Int64
+                or PropertyKind.Double or PropertyKind.Decimal
+                or PropertyKind.DateTime or PropertyKind.DateTimeOffset
+                or PropertyKind.Enum => null,
+            _ => $"{propAccess} != null"
+        };
     }
 
     /// <summary>

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -52,7 +52,7 @@ internal static class FieldEmitter
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
             || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
-            || p.SkipWhenDefault || p.SkipWhenNull);
+            || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
         if (useBuilder)
@@ -62,49 +62,67 @@ internal static class FieldEmitter
             foreach (var prop in scalarProps)
             {
                 var propAccess = $"{valueExpr}.{prop.Name}";
+                var fieldIndent = indent;
+
+                // ShowWhenProperty guard wraps the entire field emission
+                if (prop.ShowWhenProperty != null)
+                {
+                    sb.AppendLine($"{indent}if ({valueExpr}.{prop.ShowWhenProperty})");
+                    sb.AppendLine($"{indent}{{");
+                    fieldIndent = indent + "    ";
+                }
+
                 if (prop.IsNullableValueType)
                 {
                     var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
-                    sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
-                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+                    sb.AppendLine($"{fieldIndent}if ({propAccess}.HasValue)");
+                    sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
                 else if (prop.Kind == PropertyKind.String)
                 {
-                    sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({propAccess}))");
-                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}));");
+                    var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
+                    sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
+                    sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
                 else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
                 {
                     var countProp = prop.IsArray ? "Length" : "Count";
-                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                    sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)}));");
+                    sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                    sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)}));");
                 }
                 else
                 {
                     var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                    valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                     if (prop.SkipWhenDefault)
                     {
                         var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
-                        sb.AppendLine($"{indent}if ({condition})");
-                        sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                        sb.AppendLine($"{fieldIndent}if ({condition})");
+                        sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                     }
                     else if (prop.SkipWhenNull)
                     {
                         var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
                         if (condition != null)
                         {
-                            sb.AppendLine($"{indent}if ({condition})");
-                            sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                            sb.AppendLine($"{fieldIndent}if ({condition})");
+                            sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                         }
                         else
                         {
-                            sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                            sb.AppendLine($"{fieldIndent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                         }
                     }
                     else
                     {
-                        sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                        sb.AppendLine($"{fieldIndent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                     }
+                }
+
+                if (prop.ShowWhenProperty != null)
+                {
+                    sb.AppendLine($"{indent}}}");
                 }
             }
             sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
@@ -118,6 +136,7 @@ internal static class FieldEmitter
             {
                 var propAccess = $"{valueExpr}.{prop.Name}";
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                 fields.Add($"new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr})");
             }
 
@@ -140,6 +159,15 @@ internal static class FieldEmitter
             var propAccess = $"{valueExpr}.{prop.Name}";
             var emitIndent = indent;
 
+            // ShowWhenProperty wraps the entire field emission
+            bool hasShowWhen = prop.ShowWhenProperty != null;
+            if (hasShowWhen)
+            {
+                sb.AppendLine($"{indent}if ({valueExpr}.{prop.ShowWhenProperty})");
+                sb.AppendLine($"{indent}{{");
+                emitIndent = indent + "    ";
+            }
+
             // Wrap with skip-default or skip-null condition if needed (for types not already conditionally rendered)
             bool needsSkipDefault = prop.SkipWhenDefault && !prop.IsNullableValueType
                 && prop.Kind != PropertyKind.String
@@ -150,18 +178,18 @@ internal static class FieldEmitter
             if (needsSkipDefault)
             {
                 var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
-                sb.AppendLine($"{indent}if ({condition})");
-                sb.AppendLine($"{indent}{{");
-                emitIndent = indent + "    ";
+                sb.AppendLine($"{emitIndent}if ({condition})");
+                sb.AppendLine($"{emitIndent}{{");
+                emitIndent = emitIndent + "    ";
             }
             else if (needsSkipNull)
             {
                 var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
                 if (condition != null)
                 {
-                    sb.AppendLine($"{indent}if ({condition})");
-                    sb.AppendLine($"{indent}{{");
-                    emitIndent = indent + "    ";
+                    sb.AppendLine($"{emitIndent}if ({condition})");
+                    sb.AppendLine($"{emitIndent}{{");
+                    emitIndent = emitIndent + "    ";
                 }
             }
 
@@ -202,8 +230,9 @@ internal static class FieldEmitter
             }
             else if (prop.Kind == PropertyKind.String)
             {
+                var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
-                sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
+                sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr});");
             }
             else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
             {
@@ -233,6 +262,10 @@ internal static class FieldEmitter
 
             if (needsSkipDefault || needsSkipNull)
             {
+                sb.AppendLine($"{(hasShowWhen ? indent + "    " : indent)}}}");
+            }
+            if (hasShowWhen)
+            {
                 sb.AppendLine($"{indent}}}");
             }
         }
@@ -251,6 +284,15 @@ internal static class FieldEmitter
             var propAccess = $"{valueExpr}.{prop.Name}";
             var emitIndent = indent;
 
+            // ShowWhenProperty wraps the entire field emission
+            bool hasShowWhen = prop.ShowWhenProperty != null;
+            if (hasShowWhen)
+            {
+                sb.AppendLine($"{indent}if ({valueExpr}.{prop.ShowWhenProperty})");
+                sb.AppendLine($"{indent}{{");
+                emitIndent = indent + "    ";
+            }
+
             bool needsSkipDefault = prop.SkipWhenDefault && !prop.IsNullableValueType
                 && prop.Kind != PropertyKind.String
                 && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
@@ -260,31 +302,33 @@ internal static class FieldEmitter
             if (needsSkipDefault)
             {
                 var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
-                sb.AppendLine($"{indent}if ({condition})");
-                sb.AppendLine($"{indent}{{");
-                emitIndent = indent + "    ";
+                sb.AppendLine($"{emitIndent}if ({condition})");
+                sb.AppendLine($"{emitIndent}{{");
+                emitIndent = emitIndent + "    ";
             }
             else if (needsSkipNull)
             {
                 var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
                 if (condition != null)
                 {
-                    sb.AppendLine($"{indent}if ({condition})");
-                    sb.AppendLine($"{indent}{{");
-                    emitIndent = indent + "    ";
+                    sb.AppendLine($"{emitIndent}if ({condition})");
+                    sb.AppendLine($"{emitIndent}{{");
+                    emitIndent = emitIndent + "    ";
                 }
             }
 
             if (prop.IsNullableValueType)
             {
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
+                valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
                 sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
             else if (prop.Kind == PropertyKind.String)
             {
+                var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
-                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{propAccess}}}\");");
+                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
             else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
             {
@@ -296,10 +340,15 @@ internal static class FieldEmitter
             else
             {
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                 sb.AppendLine($"{emitIndent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
 
             if (needsSkipDefault || needsSkipNull)
+            {
+                sb.AppendLine($"{(hasShowWhen ? indent + "    " : indent)}}}");
+            }
+            if (hasShowWhen)
             {
                 sb.AppendLine($"{indent}}}");
             }

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -52,7 +52,7 @@ internal static class FieldEmitter
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
             || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
-            || p.SkipWhenDefault);
+            || p.SkipWhenDefault || p.SkipWhenNull);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
         if (useBuilder)
@@ -87,6 +87,19 @@ internal static class FieldEmitter
                         var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
                         sb.AppendLine($"{indent}if ({condition})");
                         sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    }
+                    else if (prop.SkipWhenNull)
+                    {
+                        var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
+                        if (condition != null)
+                        {
+                            sb.AppendLine($"{indent}if ({condition})");
+                            sb.AppendLine($"{indent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                        }
+                        else
+                        {
+                            sb.AppendLine($"{indent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                        }
                     }
                     else
                     {
@@ -127,8 +140,11 @@ internal static class FieldEmitter
             var propAccess = $"{valueExpr}.{prop.Name}";
             var emitIndent = indent;
 
-            // Wrap with skip-default condition if needed (for types not already conditionally rendered)
+            // Wrap with skip-default or skip-null condition if needed (for types not already conditionally rendered)
             bool needsSkipDefault = prop.SkipWhenDefault && !prop.IsNullableValueType
+                && prop.Kind != PropertyKind.String
+                && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            bool needsSkipNull = !needsSkipDefault && prop.SkipWhenNull && !prop.IsNullableValueType
                 && prop.Kind != PropertyKind.String
                 && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
             if (needsSkipDefault)
@@ -137,6 +153,16 @@ internal static class FieldEmitter
                 sb.AppendLine($"{indent}if ({condition})");
                 sb.AppendLine($"{indent}{{");
                 emitIndent = indent + "    ";
+            }
+            else if (needsSkipNull)
+            {
+                var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
+                if (condition != null)
+                {
+                    sb.AppendLine($"{indent}if ({condition})");
+                    sb.AppendLine($"{indent}{{");
+                    emitIndent = indent + "    ";
+                }
             }
 
             if (prop.ValueFormatterTypeName != null)
@@ -205,7 +231,7 @@ internal static class FieldEmitter
                 sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
             }
 
-            if (needsSkipDefault)
+            if (needsSkipDefault || needsSkipNull)
             {
                 sb.AppendLine($"{indent}}}");
             }
@@ -228,12 +254,25 @@ internal static class FieldEmitter
             bool needsSkipDefault = prop.SkipWhenDefault && !prop.IsNullableValueType
                 && prop.Kind != PropertyKind.String
                 && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            bool needsSkipNull = !needsSkipDefault && prop.SkipWhenNull && !prop.IsNullableValueType
+                && prop.Kind != PropertyKind.String
+                && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
             if (needsSkipDefault)
             {
                 var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
                 sb.AppendLine($"{indent}if ({condition})");
                 sb.AppendLine($"{indent}{{");
                 emitIndent = indent + "    ";
+            }
+            else if (needsSkipNull)
+            {
+                var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
+                if (condition != null)
+                {
+                    sb.AppendLine($"{indent}if ({condition})");
+                    sb.AppendLine($"{indent}{{");
+                    emitIndent = indent + "    ";
+                }
             }
 
             if (prop.IsNullableValueType)
@@ -260,7 +299,7 @@ internal static class FieldEmitter
                 sb.AppendLine($"{emitIndent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
 
-            if (needsSkipDefault)
+            if (needsSkipDefault || needsSkipNull)
             {
                 sb.AppendLine($"{indent}}}");
             }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -291,24 +291,39 @@ internal static class SerializerEmitter
     {
         var sectionName = prop.SectionName ?? prop.DisplayName;
 
+        // Emit ShowWhenProperty guard if configured
+        var showWhenIndent = indent;
+        var showWhenIndentLevel = indentLevel;
+        if (prop.SectionShowWhenProperty != null && rootValueExpr != null)
+        {
+            sb.AppendLine($"{indent}if ({rootValueExpr}.{prop.SectionShowWhenProperty})");
+            sb.AppendLine($"{indent}{{");
+            showWhenIndent = indent + "    ";
+            showWhenIndentLevel = indentLevel + 1;
+        }
+
         // Emit per-section hook at top level only
         if (rootValueExpr != null && rootTypeName != null)
         {
             var safeName = new string(sectionName.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
             var skipVar = $"__skip{prop.Name}";
-            sb.AppendLine($"{indent}var {skipVar} = false;");
-            sb.AppendLine($"{indent}OnBeforeSection{safeName}(writer, {rootValueExpr}, ref {skipVar});");
-            sb.AppendLine($"{indent}if (!{skipVar})");
-            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{showWhenIndent}var {skipVar} = false;");
+            sb.AppendLine($"{showWhenIndent}OnBeforeSection{safeName}(writer, {rootValueExpr}, ref {skipVar});");
+            sb.AppendLine($"{showWhenIndent}if (!{skipVar})");
+            sb.AppendLine($"{showWhenIndent}{{");
 
-            // Re-emit the section body with increased indent
-            EmitSectionBody(sb, prop, propAccess, indent + "    ", indentLevel + 1, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+            EmitSectionBody(sb, prop, propAccess, showWhenIndent + "    ", showWhenIndentLevel + 1, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
 
-            sb.AppendLine($"{indent}}}");
+            sb.AppendLine($"{showWhenIndent}}}");
         }
         else
         {
-            EmitSectionBody(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+            EmitSectionBody(sb, prop, propAccess, showWhenIndent, showWhenIndentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+        }
+
+        if (prop.SectionShowWhenProperty != null && rootValueExpr != null)
+        {
+            sb.AppendLine($"{indent}}}");
         }
     }
 
@@ -338,13 +353,30 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
             
-            if (prop.ElementHasNestedContent)
+            if (prop.MaxItems != null)
             {
-                CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+                var innerIndent = indent + "    ";
+                var (truncVar, _) = EmitHelpers.EmitMaxItemsTruncation(sb, prop, propAccess, innerIndent, nestingDepth);
+                if (prop.ElementHasNestedContent)
+                {
+                    CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, truncVar, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+                }
+                else
+                {
+                    CollectionEmitter.EmitTableSerialization(sb, prop, truncVar, indentLevel + 1, nestingDepth);
+                }
+                EmitHelpers.EmitMaxItemsEllipsis(sb, prop, propAccess, innerIndent, nestingDepth);
             }
             else
             {
-                CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                if (prop.ElementHasNestedContent)
+                {
+                    CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+                }
+                else
+                {
+                    CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                }
             }
             sb.AppendLine($"{indent}}}");
         }
@@ -353,7 +385,17 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
-            sb.AppendLine($"{indent}    writer.WriteArray({propAccess});");
+            if (prop.MaxItems != null)
+            {
+                var innerIndent = indent + "    ";
+                var (truncVar, _) = EmitHelpers.EmitMaxItemsTruncation(sb, prop, propAccess, innerIndent, nestingDepth);
+                sb.AppendLine($"{innerIndent}writer.WriteArray({truncVar});");
+                EmitHelpers.EmitMaxItemsEllipsis(sb, prop, propAccess, innerIndent, nestingDepth);
+            }
+            else
+            {
+                sb.AppendLine($"{indent}    writer.WriteArray({propAccess});");
+            }
             sb.AppendLine($"{indent}}}");
         }
         else if (prop.Kind == PropertyKind.Tree)
@@ -361,7 +403,17 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
-            sb.AppendLine($"{indent}    writer.WriteTree({propAccess});");
+            if (prop.MaxItems != null)
+            {
+                var innerIndent = indent + "    ";
+                var (truncVar, _) = EmitHelpers.EmitMaxItemsTruncation(sb, prop, propAccess, innerIndent, nestingDepth);
+                sb.AppendLine($"{innerIndent}writer.WriteTree({truncVar});");
+                EmitHelpers.EmitMaxItemsEllipsis(sb, prop, propAccess, innerIndent, nestingDepth);
+            }
+            else
+            {
+                sb.AppendLine($"{indent}    writer.WriteTree({propAccess});");
+            }
             sb.AppendLine($"{indent}}}");
         }
         else if (prop.Kind == PropertyKind.NestedObject && prop.ElementProperties != null)

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -123,6 +123,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? SectionFormatProperty { get; }
     public string? SectionFormatterTypeName { get; }
     public string? SectionColumnName { get; }
+    public string? SectionShowWhenProperty { get; }
     public string? ElementTypeName { get; }
     public IReadOnlyList<PropertyMetadata>? ElementProperties { get; }
     public bool ElementHasNestedContent { get; }
@@ -138,6 +139,11 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? JoinSeparator { get; }
     public bool SkipWhenDefault { get; }
     public string? ValueFormatterTypeName { get; }
+    public bool SkipWhenNull { get; }
+    public string? DisplayFormat { get; }
+    public int? MaxItems { get; }
+    public string? MaxItemsEllipsisFormat { get; }
+    public string? TableDisplayFormat { get; }
 
     public PropertyMetadata(
         string name,
@@ -154,6 +160,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? sectionFormatProperty = null,
         string? sectionFormatterTypeName = null,
         string? sectionColumnName = null,
+        string? sectionShowWhenProperty = null,
         string? elementTypeName = null,
         IReadOnlyList<PropertyMetadata>? elementProperties = null,
         bool elementHasNestedContent = false,
@@ -168,7 +175,12 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? customFormat = null,
         string? joinSeparator = null,
         bool skipWhenDefault = false,
-        string? valueFormatterTypeName = null)
+        string? valueFormatterTypeName = null,
+        bool skipWhenNull = false,
+        string? displayFormat = null,
+        int? maxItems = null,
+        string? maxItemsEllipsisFormat = null,
+        string? tableDisplayFormat = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -184,6 +196,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         SectionFormatProperty = sectionFormatProperty;
         SectionFormatterTypeName = sectionFormatterTypeName;
         SectionColumnName = sectionColumnName;
+        SectionShowWhenProperty = sectionShowWhenProperty;
         ElementTypeName = elementTypeName;
         ElementProperties = elementProperties;
         ElementHasNestedContent = elementHasNestedContent;
@@ -199,6 +212,11 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         JoinSeparator = joinSeparator;
         SkipWhenDefault = skipWhenDefault;
         ValueFormatterTypeName = valueFormatterTypeName;
+        SkipWhenNull = skipWhenNull;
+        DisplayFormat = displayFormat;
+        MaxItems = maxItems;
+        MaxItemsEllipsisFormat = maxItemsEllipsisFormat;
+        TableDisplayFormat = tableDisplayFormat;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -219,6 +237,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                SectionFormatProperty == other.SectionFormatProperty &&
                SectionFormatterTypeName == other.SectionFormatterTypeName &&
                SectionColumnName == other.SectionColumnName &&
+               SectionShowWhenProperty == other.SectionShowWhenProperty &&
                ElementTypeName == other.ElementTypeName &&
                ElementHasNestedContent == other.ElementHasNestedContent &&
                ElementTitleProperty == other.ElementTitleProperty &&
@@ -233,6 +252,11 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                JoinSeparator == other.JoinSeparator &&
                SkipWhenDefault == other.SkipWhenDefault &&
                ValueFormatterTypeName == other.ValueFormatterTypeName &&
+               SkipWhenNull == other.SkipWhenNull &&
+               DisplayFormat == other.DisplayFormat &&
+               MaxItems == other.MaxItems &&
+               MaxItemsEllipsisFormat == other.MaxItemsEllipsisFormat &&
+               TableDisplayFormat == other.TableDisplayFormat &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -245,12 +269,18 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (int)Kind;
             hash = hash * 397 ^ (DisplayName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ SkipWhenDefault.GetHashCode();
+            hash = hash * 397 ^ SkipWhenNull.GetHashCode();
+            hash = hash * 397 ^ (DisplayFormat?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (MaxItems?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (MaxItemsEllipsisFormat?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (TableDisplayFormat?.GetHashCode() ?? 0);
             hash = hash * 397 ^ ElementAutoFields.GetHashCode();
             hash = hash * 397 ^ (int)ElementFieldLayout;
             hash = hash * 397 ^ (SectionIgnoreProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionFormatProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionFormatterTypeName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionColumnName?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (SectionShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (ValueFormatterTypeName?.GetHashCode() ?? 0);
             return hash;
         }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -144,6 +144,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public int? MaxItems { get; }
     public string? MaxItemsEllipsisFormat { get; }
     public string? TableDisplayFormat { get; }
+    public string? ShowWhenProperty { get; }
+    public bool IsLink { get; }
+    public string? LinkTextProperty { get; }
 
     public PropertyMetadata(
         string name,
@@ -180,7 +183,10 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? displayFormat = null,
         int? maxItems = null,
         string? maxItemsEllipsisFormat = null,
-        string? tableDisplayFormat = null)
+        string? tableDisplayFormat = null,
+        string? showWhenProperty = null,
+        bool isLink = false,
+        string? linkTextProperty = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -217,6 +223,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         MaxItems = maxItems;
         MaxItemsEllipsisFormat = maxItemsEllipsisFormat;
         TableDisplayFormat = tableDisplayFormat;
+        ShowWhenProperty = showWhenProperty;
+        IsLink = isLink;
+        LinkTextProperty = linkTextProperty;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -257,6 +266,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                MaxItems == other.MaxItems &&
                MaxItemsEllipsisFormat == other.MaxItemsEllipsisFormat &&
                TableDisplayFormat == other.TableDisplayFormat &&
+               ShowWhenProperty == other.ShowWhenProperty &&
+               IsLink == other.IsLink &&
+               LinkTextProperty == other.LinkTextProperty &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -282,6 +294,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionColumnName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (ValueFormatterTypeName?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (ShowWhenProperty?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ IsLink.GetHashCode();
+            hash = hash * 397 ^ (LinkTextProperty?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -26,6 +26,8 @@ internal static class TypeParser
     private const string MarkoutMaxItemsAttribute = "Markout.MarkoutMaxItemsAttribute";
     private const string MarkoutTableDisplayAttribute = "Markout.MarkoutTableDisplayAttribute";
     private const string MarkoutValueFormatterAttribute = "Markout.MarkoutValueFormatterAttribute";
+    private const string MarkoutShowWhenAttribute = "Markout.MarkoutShowWhenAttribute";
+    private const string MarkoutLinkAttribute = "Markout.MarkoutLinkAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -319,6 +321,31 @@ internal static class TypeParser
             tableDisplayFormat = tdf;
         }
 
+        // Parse [MarkoutShowWhen] attribute
+        string? showWhenProperty = null;
+        var showWhenAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutShowWhenAttribute);
+        if (showWhenAttr?.ConstructorArguments.Length > 0 &&
+            showWhenAttr.ConstructorArguments[0].Value is string swpField)
+        {
+            showWhenProperty = swpField;
+        }
+
+        // Parse [MarkoutLink] attribute
+        bool isLink = false;
+        string? linkTextProperty = null;
+        var linkAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutLinkAttribute);
+        if (linkAttr != null)
+        {
+            isLink = true;
+            foreach (var named in linkAttr.NamedArguments)
+            {
+                if (named.Key == "TextProperty" && named.Value.Value is string ltp)
+                    linkTextProperty = ltp;
+            }
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -381,7 +408,10 @@ internal static class TypeParser
             displayFormat,
             maxItems,
             maxItemsEllipsisFormat,
-            tableDisplayFormat);
+            tableDisplayFormat,
+            showWhenProperty,
+            isLink,
+            linkTextProperty);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -21,6 +21,10 @@ internal static class TypeParser
     private const string MarkoutFormatAttribute = "Markout.MarkoutFormatAttribute";
     private const string MarkoutJoinAttribute = "Markout.MarkoutJoinAttribute";
     private const string MarkoutSkipDefaultAttribute = "Markout.MarkoutSkipDefaultAttribute";
+    private const string MarkoutSkipNullAttribute = "Markout.MarkoutSkipNullAttribute";
+    private const string MarkoutDisplayFormatAttribute = "Markout.MarkoutDisplayFormatAttribute";
+    private const string MarkoutMaxItemsAttribute = "Markout.MarkoutMaxItemsAttribute";
+    private const string MarkoutTableDisplayAttribute = "Markout.MarkoutTableDisplayAttribute";
     private const string MarkoutValueFormatterAttribute = "Markout.MarkoutValueFormatterAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
@@ -191,6 +195,7 @@ internal static class TypeParser
         string? sectionFormatProperty = null;
         string? sectionFormatterTypeName = null;
         string? sectionColumnName = null;
+        string? sectionShowWhenProperty = null;
 
         if (isSection)
         {
@@ -212,6 +217,8 @@ internal static class TypeParser
                         sectionFormatterTypeName = formatterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                     else if (named.Key == "ColumnName" && named.Value.Value is string cn)
                         sectionColumnName = cn;
+                    else if (named.Key == "ShowWhenProperty" && named.Value.Value is string swp)
+                        sectionShowWhenProperty = swp;
                 }
             }
         }
@@ -272,6 +279,46 @@ internal static class TypeParser
         bool skipWhenDefault = prop.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipDefaultAttribute);
 
+        // Parse [MarkoutSkipNull] attribute
+        bool skipWhenNull = prop.GetAttributes()
+            .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipNullAttribute);
+
+        // Parse [MarkoutDisplayFormat] attribute
+        string? displayFormat = null;
+        var displayFormatAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutDisplayFormatAttribute);
+        if (displayFormatAttr?.ConstructorArguments.Length > 0 &&
+            displayFormatAttr.ConstructorArguments[0].Value is string df)
+        {
+            displayFormat = df;
+        }
+
+        // Parse [MarkoutMaxItems] attribute
+        int? maxItems = null;
+        string? maxItemsEllipsisFormat = null;
+        var maxItemsAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutMaxItemsAttribute);
+        if (maxItemsAttr?.ConstructorArguments.Length > 0 &&
+            maxItemsAttr.ConstructorArguments[0].Value is int mi)
+        {
+            maxItems = mi;
+            foreach (var named in maxItemsAttr.NamedArguments)
+            {
+                if (named.Key == "EllipsisFormat" && named.Value.Value is string ef)
+                    maxItemsEllipsisFormat = ef;
+            }
+        }
+
+        // Parse [MarkoutTableDisplay] attribute
+        string? tableDisplayFormat = null;
+        var tableDisplayAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutTableDisplayAttribute);
+        if (tableDisplayAttr?.ConstructorArguments.Length > 0 &&
+            tableDisplayAttr.ConstructorArguments[0].Value is string tdf)
+        {
+            tableDisplayFormat = tdf;
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -314,6 +361,7 @@ internal static class TypeParser
             sectionFormatProperty,
             sectionFormatterTypeName,
             sectionColumnName,
+            sectionShowWhenProperty,
             elementTypeName,
             elementProperties,
             hasNestedContent,
@@ -328,7 +376,12 @@ internal static class TypeParser
             customFormat,
             joinSeparator,
             skipWhenDefault,
-            valueFormatterTypeName);
+            valueFormatterTypeName,
+            skipWhenNull,
+            displayFormat,
+            maxItems,
+            maxItemsEllipsisFormat,
+            tableDisplayFormat);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutDisplayFormatAttribute.cs
+++ b/src/Markout/Attributes/MarkoutDisplayFormatAttribute.cs
@@ -1,0 +1,32 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies a composite format string to apply when rendering a property value.
+/// The format string uses <see cref="string.Format(string, object)"/> syntax where
+/// <c>{0}</c> is replaced with the property value.
+/// </summary>
+/// <example>
+///   <code>
+///   [MarkoutDisplayFormat("{0:N0} downloads")]
+///   public long TotalDownloads { get; set; }
+///   // Renders as: TotalDownloads: 1,234,567 downloads
+///
+///   [MarkoutDisplayFormat("{0:P0}")]
+///   public double CpuUsage { get; set; }
+///   // Renders as: CpuUsage: 85%
+///   </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutDisplayFormatAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the composite format string.
+    /// </summary>
+    public string Format { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified format string.
+    /// </summary>
+    /// <param name="format">A composite format string where <c>{0}</c> represents the property value.</param>
+    public MarkoutDisplayFormatAttribute(string format) => Format = format;
+}

--- a/src/Markout/Attributes/MarkoutLinkAttribute.cs
+++ b/src/Markout/Attributes/MarkoutLinkAttribute.cs
@@ -1,0 +1,30 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies that a string property should be rendered as a Markdown link.
+/// </summary>
+/// <remarks>
+/// When <see cref="TextProperty"/> is not set, the URL is used as both the link text and target:
+/// <c>[https://example.com](https://example.com)</c>.
+/// When <see cref="TextProperty"/> is set, the referenced property provides the link text:
+/// <c>[My Site](https://example.com)</c>.
+/// </remarks>
+/// <example>
+/// <code>
+/// [MarkoutLink]
+/// public string? Url { get; set; }
+///
+/// [MarkoutLink(TextProperty = nameof(Name))]
+/// public string? Repository { get; set; }
+/// public string Name { get; set; } = "";
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutLinkAttribute : Attribute
+{
+    /// <summary>
+    /// Gets or sets the name of a string property on the same type to use as the link text.
+    /// When not set, the URL value itself is used as the link text.
+    /// </summary>
+    public string? TextProperty { get; set; }
+}

--- a/src/Markout/Attributes/MarkoutMaxItemsAttribute.cs
+++ b/src/Markout/Attributes/MarkoutMaxItemsAttribute.cs
@@ -1,0 +1,38 @@
+namespace Markout;
+
+/// <summary>
+/// Limits the number of items rendered from a collection property.
+/// When the collection exceeds the limit, remaining items are replaced with an ellipsis message.
+/// </summary>
+/// <example>
+///   <code>
+///   [MarkoutMaxItems(5)]
+///   public List&lt;string&gt; Files { get; set; }
+///   // Renders first 5 items, then: "... and 10 more"
+///
+///   [MarkoutMaxItems(3, EllipsisFormat = "({0} more items not shown)")]
+///   public List&lt;string&gt; Logs { get; set; }
+///   // Renders first 3 items, then: "(7 more items not shown)"
+///   </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutMaxItemsAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the maximum number of items to render.
+    /// </summary>
+    public int Count { get; }
+
+    /// <summary>
+    /// Gets or sets the format string for the ellipsis message.
+    /// <c>{0}</c> is replaced with the number of remaining items.
+    /// Default is <c>"... and {0} more"</c>.
+    /// </summary>
+    public string EllipsisFormat { get; set; } = "... and {0} more";
+
+    /// <summary>
+    /// Initializes a new instance with the specified maximum item count.
+    /// </summary>
+    /// <param name="count">The maximum number of items to render before truncation.</param>
+    public MarkoutMaxItemsAttribute(int count) => Count = count;
+}

--- a/src/Markout/Attributes/MarkoutSectionAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSectionAttribute.cs
@@ -40,4 +40,10 @@ public sealed class MarkoutSectionAttribute : Attribute
     /// When null, the original property display name is used.
     /// </summary>
     public string? ColumnName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of a boolean property that controls whether this section is rendered.
+    /// When the property value is <c>false</c>, the section is skipped entirely.
+    /// </summary>
+    public string? ShowWhenProperty { get; set; }
 }

--- a/src/Markout/Attributes/MarkoutShowWhenAttribute.cs
+++ b/src/Markout/Attributes/MarkoutShowWhenAttribute.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies that this field should only be rendered when a boolean property on the same type is <c>true</c>.
+/// </summary>
+/// <remarks>
+/// Use this attribute to conditionally show individual fields based on the value of another property.
+/// For conditional sections, use <see cref="MarkoutSectionAttribute.ShowWhenProperty"/> instead.
+/// </remarks>
+/// <example>
+/// <code>
+/// [MarkoutShowWhen(nameof(IsVerified))]
+/// public string? VerifiedBy { get; set; }
+///
+/// public bool IsVerified { get; set; }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutShowWhenAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the name of the boolean property that controls visibility.
+    /// </summary>
+    public string PropertyName { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified boolean property name.
+    /// </summary>
+    /// <param name="propertyName">The name of a boolean property on the same type.</param>
+    public MarkoutShowWhenAttribute(string propertyName) => PropertyName = propertyName;
+}

--- a/src/Markout/Attributes/MarkoutSkipNullAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSkipNullAttribute.cs
@@ -1,0 +1,13 @@
+namespace Markout;
+
+/// <summary>
+/// Skips rendering a property when its value is null or empty.
+/// For strings, skips when null or empty. For collections, skips when null or empty.
+/// For nullable value types, skips when null.
+/// Unlike <see cref="MarkoutSkipDefaultAttribute"/>, this does not skip non-null default values
+/// like <c>false</c> for <see langword="bool"/> or <c>0</c> for <see langword="int"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutSkipNullAttribute : Attribute
+{
+}

--- a/src/Markout/Attributes/MarkoutTableDisplayAttribute.cs
+++ b/src/Markout/Attributes/MarkoutTableDisplayAttribute.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies an alternate format string for a property when rendered in a table column.
+/// In block/field context, the property uses its normal rendering.
+/// In table context, the value is formatted using <see cref="string.Format(string, object)"/>
+/// where <c>{0}</c> is replaced with the property value.
+/// </summary>
+/// <example>
+///   <code>
+///   // Without [MarkoutTableDisplay]: table shows raw count "42"
+///   // With [MarkoutTableDisplay]: table shows "42 items", block shows "42"
+///   [MarkoutTableDisplay("{0} items")]
+///   public int Count { get; set; }
+///   </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutTableDisplayAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the format string to use when rendering in a table column.
+    /// <c>{0}</c> is replaced with the property value.
+    /// </summary>
+    public string Format { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified table display format.
+    /// </summary>
+    /// <param name="format">A composite format string where <c>{0}</c> represents the property value.</param>
+    public MarkoutTableDisplayAttribute(string format) => Format = format;
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.3.4</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -823,6 +823,131 @@ public class SerializerTests
         Assert.DoesNotContain("42 items", mdf);
     }
 
+    // --- ShowWhen tests ---
+
+    [Fact]
+    public void Serialize_ShowWhen_LineBreaks_ShowsWhenTrue()
+    {
+        var pkg = new VerifiedPackage { Name = "MyPkg", IsVerified = true, VerifiedBy = "Microsoft", IsTool = false, ToolFormat = "global" };
+        var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
+
+        Assert.Contains("VerifiedBy: Microsoft", mdf);
+        Assert.DoesNotContain("ToolFormat", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhen_LineBreaks_HidesWhenFalse()
+    {
+        var pkg = new VerifiedPackage { Name = "MyPkg", IsVerified = false, VerifiedBy = "Microsoft", IsTool = false, ToolFormat = "global" };
+        var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
+
+        Assert.DoesNotContain("VerifiedBy", mdf);
+        Assert.DoesNotContain("ToolFormat", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhen_OneLine_ShowsWhenTrue()
+    {
+        var pkg = new VerifiedPackageOneLine { Name = "MyPkg", IsVerified = true, VerifiedBy = "Microsoft" };
+        var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
+
+        Assert.Contains("VerifiedBy: Microsoft", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhen_OneLine_HidesWhenFalse()
+    {
+        var pkg = new VerifiedPackageOneLine { Name = "MyPkg", IsVerified = false, VerifiedBy = "Microsoft" };
+        var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
+
+        Assert.DoesNotContain("VerifiedBy", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhen_List_ShowsWhenTrue()
+    {
+        var pkg = new VerifiedPackageList { Name = "MyPkg", IsVerified = true, VerifiedBy = "Microsoft" };
+        var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
+
+        Assert.Contains("VerifiedBy: Microsoft", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhen_List_HidesWhenFalse()
+    {
+        var pkg = new VerifiedPackageList { Name = "MyPkg", IsVerified = false, VerifiedBy = "Microsoft" };
+        var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
+
+        Assert.DoesNotContain("VerifiedBy", mdf);
+    }
+
+    // --- Link tests ---
+
+    [Fact]
+    public void Serialize_Link_LineBreaks_BareLink()
+    {
+        var project = new LinkProjectInfo { Name = "Markout", Homepage = "https://github.com/markout" };
+        var mdf = MarkoutSerializer.Serialize(project, LinkTestContext.Default);
+
+        Assert.Contains("[https://github.com/markout](https://github.com/markout)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_Link_LineBreaks_WithTextProperty()
+    {
+        var project = new LinkProjectInfo { Name = "Markout", Repository = "https://github.com/markout" };
+        var mdf = MarkoutSerializer.Serialize(project, LinkTestContext.Default);
+
+        Assert.Contains("[Markout](https://github.com/markout)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_Link_LineBreaks_NullSkipped()
+    {
+        var project = new LinkProjectInfo { Name = "Markout" };
+        var mdf = MarkoutSerializer.Serialize(project, LinkTestContext.Default);
+
+        Assert.DoesNotContain("Homepage", mdf);
+        Assert.DoesNotContain("Repository", mdf);
+    }
+
+    [Fact]
+    public void Serialize_Link_OneLine_BareLink()
+    {
+        var project = new LinkProjectOneLine { Name = "Markout", Url = "https://example.com" };
+        var mdf = MarkoutSerializer.Serialize(project, LinkTestContext.Default);
+
+        Assert.Contains("[https://example.com](https://example.com)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_Link_List_BareAndTextProperty()
+    {
+        var project = new LinkProjectList { Name = "Markout", Url = "https://example.com", Repository = "https://github.com/markout" };
+        var mdf = MarkoutSerializer.Serialize(project, LinkTestContext.Default);
+
+        Assert.Contains("[https://example.com](https://example.com)", mdf);
+        Assert.Contains("[Markout](https://github.com/markout)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_Link_InTable()
+    {
+        var view = new LinkProjectListView
+        {
+            Title = "Projects",
+            Projects = new List<LinkProjectRow>
+            {
+                new() { Name = "Alpha", Url = "https://alpha.com" },
+                new() { Name = "Beta", Url = "https://beta.com" }
+            }
+        };
+        var mdf = MarkoutSerializer.Serialize(view, LinkTestContext.Default);
+
+        Assert.Contains("[https://alpha.com](https://alpha.com)", mdf);
+        Assert.Contains("[https://beta.com](https://beta.com)", mdf);
+    }
+
     [Fact]
     public void Serialize_IgnoreProperty_CompactTable_OmitsDescription()
     {
@@ -1409,6 +1534,9 @@ public class ConditionalReport
 }
 
 [MarkoutContext(typeof(ConditionalReport))]
+[MarkoutContext(typeof(VerifiedPackage))]
+[MarkoutContext(typeof(VerifiedPackageOneLine))]
+[MarkoutContext(typeof(VerifiedPackageList))]
 public partial class ShowWhenTestContext : MarkoutSerializerContext
 {
 }
@@ -1455,5 +1583,93 @@ public class InventoryView
 [MarkoutContext(typeof(InventoryView))]
 [MarkoutContext(typeof(ItemRow))]
 public partial class TableDisplayTestContext : MarkoutSerializerContext
+{
+}
+
+// --- ShowWhen test types ---
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class VerifiedPackage
+{
+    public string Name { get; set; } = "";
+    public bool IsVerified { get; set; }
+    [MarkoutShowWhen(nameof(IsVerified))]
+    public string? VerifiedBy { get; set; }
+    public bool IsTool { get; set; }
+    [MarkoutShowWhen(nameof(IsTool))]
+    public string? ToolFormat { get; set; }
+}
+
+[MarkoutSerializable]
+public class VerifiedPackageOneLine
+{
+    public string Name { get; set; } = "";
+    public bool IsVerified { get; set; }
+    [MarkoutShowWhen(nameof(IsVerified))]
+    public string? VerifiedBy { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.List)]
+public class VerifiedPackageList
+{
+    public string Name { get; set; } = "";
+    public bool IsVerified { get; set; }
+    [MarkoutShowWhen(nameof(IsVerified))]
+    public string? VerifiedBy { get; set; }
+}
+
+// --- Link test types ---
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class LinkProjectInfo
+{
+    public string Name { get; set; } = "";
+    [MarkoutLink]
+    public string? Homepage { get; set; }
+    [MarkoutLink(TextProperty = nameof(Name))]
+    public string? Repository { get; set; }
+}
+
+[MarkoutSerializable]
+public class LinkProjectOneLine
+{
+    public string Name { get; set; } = "";
+    [MarkoutLink]
+    public string? Url { get; set; }
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.List)]
+public class LinkProjectList
+{
+    public string Name { get; set; } = "";
+    [MarkoutLink]
+    public string? Url { get; set; }
+    [MarkoutLink(TextProperty = nameof(Name))]
+    public string? Repository { get; set; }
+}
+
+[MarkoutSerializable]
+public class LinkProjectRow
+{
+    public string Name { get; set; } = "";
+    [MarkoutLink]
+    public string? Url { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class LinkProjectListView
+{
+    [MarkoutIgnore]
+    public string? Title { get; set; }
+    [MarkoutSection(Name = "Projects")]
+    public List<LinkProjectRow>? Projects { get; set; }
+}
+
+[MarkoutContext(typeof(LinkProjectInfo))]
+[MarkoutContext(typeof(LinkProjectOneLine))]
+[MarkoutContext(typeof(LinkProjectList))]
+[MarkoutContext(typeof(LinkProjectListView))]
+[MarkoutContext(typeof(LinkProjectRow))]
+public partial class LinkTestContext : MarkoutSerializerContext
 {
 }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -572,6 +572,258 @@ public class SerializerTests
     }
 
     [Fact]
+    public void Serialize_SkipNull_SuppressesNullStrings()
+    {
+        var pkg = new PackageInfo { Name = "MyPackage", License = null, Repository = null, Downloads = 100 };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullTestContext.Default);
+
+        Assert.Contains("Name: MyPackage", mdf);
+        Assert.Contains("Downloads: 100", mdf);
+        Assert.DoesNotContain("License", mdf);
+        Assert.DoesNotContain("Repository", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_RendersNonNullStrings()
+    {
+        var pkg = new PackageInfo { Name = "MyPackage", License = "MIT", Repository = "https://github.com/test", Downloads = 100 };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullTestContext.Default);
+
+        Assert.Contains("License: MIT", mdf);
+        Assert.Contains("Repository: https://github.com/test", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_SuppressesNullNullableInt()
+    {
+        var pkg = new PackageInfo { Name = "MyPackage", Downloads = 100, Stars = null };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullTestContext.Default);
+
+        Assert.DoesNotContain("Stars", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_RendersNonNullNullableInt()
+    {
+        var pkg = new PackageInfo { Name = "MyPackage", Downloads = 100, Stars = 42 };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullTestContext.Default);
+
+        Assert.Contains("Stars: 42", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_DoesNotSuppressZeroOrFalse()
+    {
+        var pkg = new PackageInfo { Name = "MyPackage", Downloads = 0, Stars = 0 };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullTestContext.Default);
+
+        Assert.Contains("Downloads: 0", mdf);
+        Assert.Contains("Stars: 0", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_LineBreaksLayout()
+    {
+        var pkg = new PackageInfoLineBreaks { Name = "MyPackage", License = null, Repository = null };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullLineBreaksContext.Default);
+
+        Assert.Contains("Name", mdf);
+        Assert.DoesNotContain("License", mdf);
+        Assert.DoesNotContain("Repository", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_LineBreaksRendersNonNull()
+    {
+        var pkg = new PackageInfoLineBreaks { Name = "MyPackage", License = "MIT", Repository = "https://example.com" };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullLineBreaksContext.Default);
+
+        Assert.Contains("License", mdf);
+        Assert.Contains("Repository", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_ListLayout()
+    {
+        var pkg = new PackageInfoList { Name = "MyPackage", License = null, Repository = null };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullListContext.Default);
+
+        Assert.Contains("Name", mdf);
+        Assert.DoesNotContain("License", mdf);
+        Assert.DoesNotContain("Repository", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipNull_ListRendersNonNull()
+    {
+        var pkg = new PackageInfoList { Name = "MyPackage", License = "MIT", Repository = "https://example.com" };
+        var mdf = MarkoutSerializer.Serialize(pkg, SkipNullListContext.Default);
+
+        Assert.Contains("License", mdf);
+        Assert.Contains("Repository", mdf);
+    }
+
+    [Fact]
+    public void Serialize_DisplayFormat_AppliesFormatString()
+    {
+        var stats = new DownloadStats { Name = "MyPackage", TotalDownloads = 1234567, CpuUsage = 0.856 };
+        var mdf = MarkoutSerializer.Serialize(stats, DisplayFormatTestContext.Default);
+
+        Assert.Contains("1,234,567 downloads", mdf);
+        Assert.Contains("85.6", mdf);  // P1 format: "85.6 %"
+    }
+
+    [Fact]
+    public void Serialize_DisplayFormat_InTableContext()
+    {
+        var report = new DownloadReport
+        {
+            Title = "Stats",
+            Packages = new List<DownloadRow>
+            {
+                new() { Name = "Pkg1", Downloads = 5000000 },
+                new() { Name = "Pkg2", Downloads = 42 }
+            }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, DisplayFormatTestContext.Default);
+
+        Assert.Contains("5,000,000 downloads", mdf);
+        Assert.Contains("42 downloads", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhenProperty_ShowsSection()
+    {
+        var report = new ConditionalReport
+        {
+            Title = "Report",
+            ShowDetails = true,
+            ShowSummary = false,
+            Details = new() { "Detail 1", "Detail 2" },
+            Summary = new() { "Summary line" }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, ShowWhenTestContext.Default);
+
+        Assert.Contains("## Details", mdf);
+        Assert.Contains("Detail 1", mdf);
+        Assert.DoesNotContain("## Summary", mdf);
+        Assert.DoesNotContain("Summary line", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhenProperty_HidesSection()
+    {
+        var report = new ConditionalReport
+        {
+            Title = "Report",
+            ShowDetails = false,
+            ShowSummary = true,
+            Details = new() { "Detail 1" },
+            Summary = new() { "Summary line" }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, ShowWhenTestContext.Default);
+
+        Assert.DoesNotContain("## Details", mdf);
+        Assert.Contains("## Summary", mdf);
+        Assert.Contains("Summary line", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ShowWhenProperty_MutualExclusion()
+    {
+        var report = new ConditionalReport
+        {
+            Title = "Report",
+            ShowDetails = true,
+            ShowSummary = true,
+            Details = new() { "Detail 1" },
+            Summary = new() { "Summary line" }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, ShowWhenTestContext.Default);
+
+        Assert.Contains("## Details", mdf);
+        Assert.Contains("## Summary", mdf);
+    }
+
+    [Fact]
+    public void Serialize_MaxItems_TruncatesStringArray()
+    {
+        var report = new FileReport
+        {
+            Title = "Report",
+            Files = new() { "a.cs", "b.cs", "c.cs", "d.cs", "e.cs" }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, MaxItemsTestContext.Default);
+
+        Assert.Contains("a.cs", mdf);
+        Assert.Contains("b.cs", mdf);
+        Assert.Contains("c.cs", mdf);
+        Assert.DoesNotContain("d.cs", mdf);
+        Assert.DoesNotContain("e.cs", mdf);
+        Assert.Contains("... and 2 more", mdf);
+    }
+
+    [Fact]
+    public void Serialize_MaxItems_CustomEllipsisFormat()
+    {
+        var report = new FileReport
+        {
+            Title = "Report",
+            Logs = new() { "log1", "log2", "log3", "log4", "log5" }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, MaxItemsTestContext.Default);
+
+        Assert.Contains("log1", mdf);
+        Assert.Contains("log2", mdf);
+        Assert.DoesNotContain("log3", mdf);
+        Assert.Contains("(3 more items not shown)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_MaxItems_NoTruncationWhenUnderLimit()
+    {
+        var report = new FileReport
+        {
+            Title = "Report",
+            Files = new() { "a.cs", "b.cs" }
+        };
+        var mdf = MarkoutSerializer.Serialize(report, MaxItemsTestContext.Default);
+
+        Assert.Contains("a.cs", mdf);
+        Assert.Contains("b.cs", mdf);
+        Assert.DoesNotContain("... and", mdf);
+    }
+
+    [Fact]
+    public void Serialize_TableDisplay_FormatsInTableContext()
+    {
+        var view = new InventoryView
+        {
+            Title = "Inventory",
+            Items = new()
+            {
+                new() { Name = "Widgets", Count = 42 },
+                new() { Name = "Gadgets", Count = 7 }
+            }
+        };
+        var mdf = MarkoutSerializer.Serialize(view, TableDisplayTestContext.Default);
+
+        Assert.Contains("42 items", mdf);
+        Assert.Contains("7 items", mdf);
+    }
+
+    [Fact]
+    public void Serialize_TableDisplay_BlockContextUsesNormalFormat()
+    {
+        var item = new ItemRow { Name = "Widget", Count = 42 };
+        var mdf = MarkoutSerializer.Serialize(item, TableDisplayTestContext.Default);
+
+        // In block context, Count should render as "42" not "42 items"
+        Assert.Contains("Count: 42", mdf);
+        Assert.DoesNotContain("42 items", mdf);
+    }
+
+    [Fact]
     public void Serialize_IgnoreProperty_CompactTable_OmitsDescription()
     {
         var data = new ApiWithIgnoreProperty
@@ -1053,5 +1305,155 @@ public class ApiWithFormatter
 [MarkoutContext(typeof(ApiWithFormatter))]
 [MarkoutContext(typeof(MethodRow))]
 public partial class FormatterTestContext : MarkoutSerializerContext
+{
+}
+
+// SkipWhenNull test types
+[MarkoutSerializable]
+public class PackageInfo
+{
+    public string? Name { get; set; }
+    [MarkoutSkipNull]
+    public string? License { get; set; }
+    [MarkoutSkipNull]
+    public string? Repository { get; set; }
+    public int Downloads { get; set; }
+    [MarkoutSkipNull]
+    public int? Stars { get; set; }
+}
+
+[MarkoutContext(typeof(PackageInfo))]
+public partial class SkipNullTestContext : MarkoutSerializerContext
+{
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.LineBreaks)]
+public class PackageInfoLineBreaks
+{
+    public string? Name { get; set; }
+    [MarkoutSkipNull]
+    public string? License { get; set; }
+    [MarkoutSkipNull]
+    public string? Repository { get; set; }
+}
+
+[MarkoutContext(typeof(PackageInfoLineBreaks))]
+public partial class SkipNullLineBreaksContext : MarkoutSerializerContext
+{
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.List)]
+public class PackageInfoList
+{
+    public string? Name { get; set; }
+    [MarkoutSkipNull]
+    public string? License { get; set; }
+    [MarkoutSkipNull]
+    public string? Repository { get; set; }
+}
+
+[MarkoutContext(typeof(PackageInfoList))]
+public partial class SkipNullListContext : MarkoutSerializerContext
+{
+}
+
+// DisplayFormat test types
+[MarkoutSerializable]
+public class DownloadStats
+{
+    public string? Name { get; set; }
+    [MarkoutDisplayFormat("{0:N0} downloads")]
+    public long TotalDownloads { get; set; }
+    [MarkoutDisplayFormat("{0:P1}")]
+    public double CpuUsage { get; set; }
+}
+
+[MarkoutSerializable]
+public class DownloadRow
+{
+    public string Name { get; set; } = "";
+    [MarkoutDisplayFormat("{0:N0} downloads")]
+    public long Downloads { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class DownloadReport
+{
+    [MarkoutIgnore]
+    public string? Title { get; set; }
+    [MarkoutSection(Name = "Packages")]
+    public List<DownloadRow>? Packages { get; set; }
+}
+
+[MarkoutContext(typeof(DownloadStats))]
+[MarkoutContext(typeof(DownloadReport))]
+[MarkoutContext(typeof(DownloadRow))]
+public partial class DisplayFormatTestContext : MarkoutSerializerContext
+{
+}
+
+// ShowWhenProperty test types
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class ConditionalReport
+{
+    [MarkoutIgnore]
+    public string? Title { get; set; }
+    public bool ShowDetails { get; set; }
+    public bool ShowSummary { get; set; }
+
+    [MarkoutSection(Name = "Details", ShowWhenProperty = nameof(ShowDetails))]
+    public List<string>? Details { get; set; }
+
+    [MarkoutSection(Name = "Summary", ShowWhenProperty = nameof(ShowSummary))]
+    public List<string>? Summary { get; set; }
+}
+
+[MarkoutContext(typeof(ConditionalReport))]
+public partial class ShowWhenTestContext : MarkoutSerializerContext
+{
+}
+
+// MaxItems test types
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class FileReport
+{
+    [MarkoutIgnore]
+    public string? Title { get; set; }
+
+    [MarkoutSection(Name = "Files")]
+    [MarkoutMaxItems(3)]
+    public List<string>? Files { get; set; }
+
+    [MarkoutSection(Name = "Logs")]
+    [MarkoutMaxItems(2, EllipsisFormat = "({0} more items not shown)")]
+    public List<string>? Logs { get; set; }
+}
+
+[MarkoutContext(typeof(FileReport))]
+public partial class MaxItemsTestContext : MarkoutSerializerContext
+{
+}
+
+// TableDisplay test types
+[MarkoutSerializable]
+public class ItemRow
+{
+    public string Name { get; set; } = "";
+    [MarkoutTableDisplay("{0} items")]
+    public int Count { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class InventoryView
+{
+    [MarkoutIgnore]
+    public string? Title { get; set; }
+    [MarkoutSection(Name = "Items")]
+    public List<ItemRow>? Items { get; set; }
+}
+
+[MarkoutContext(typeof(InventoryView))]
+[MarkoutContext(typeof(ItemRow))]
+public partial class TableDisplayTestContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## New Attributes

Seven new attributes to reduce boilerplate in view models (informed by dotnet-inspect pain points):

### `[MarkoutSkipNull]` — Null/Empty Suppression
Skips rendering when a string is null/empty, a collection is null/empty, or a nullable value type is null. Unlike `[MarkoutSkipDefault]`, does **not** skip `false` or `0`.

```csharp
[MarkoutSkipNull]
public string? License { get; set; }  // omitted when null
```

### `[MarkoutDisplayFormat]` — Display Format Strings
Wraps a property value in `string.Format()` before rendering.

```csharp
[MarkoutDisplayFormat("{0:N0} downloads")]
public long TotalDownloads { get; set; }  // renders: "1,234,567 downloads"
```

### `[MarkoutSection(ShowWhenProperty = "...")]` — Conditional Sections
Controls section visibility via a bool property.

```csharp
[MarkoutSection(Name = "Errors", ShowWhenProperty = nameof(HasErrors))]
public List<string>? Errors { get; set; }
```

### `[MarkoutMaxItems(n)]` — Collection Truncation
Limits rendering to N items with configurable ellipsis text.

```csharp
[MarkoutMaxItems(10, EllipsisFormat = "({0} more not shown)")]
public List<string>? Files { get; set; }
```

### `[MarkoutTableDisplay]` — Table vs Block Display
Alternate format string used only in table columns.

```csharp
[MarkoutTableDisplay("{0} items")]
public int Count { get; set; }  // table: "42 items", block: "42"
```

### `[MarkoutShowWhen]` — Conditional Field Rendering
Shows a field only when a bool property on the same type is `true`.

```csharp
[MarkoutShowWhen(nameof(IsVerified))]
public string? VerifiedBy { get; set; }  // only shown when IsVerified is true
```

### `[MarkoutLink]` — Markdown Link Rendering
Renders a string property as a Markdown `[text](url)` link.

```csharp
[MarkoutLink]
public string? Homepage { get; set; }  // renders: [url](url)

[MarkoutLink(TextProperty = nameof(Name))]
public string? Repository { get; set; }  // renders: [Name](url)
```

## Samples

- **HelloMarkout** — 15-line minimal sample (super simple)
- **SkipNullDemo** — demonstrates `[MarkoutSkipNull]` (simple)
- **CanadianContent** — updated with `[MarkoutMaxItems]` (medium)
- **DotNetReleases** — updated with `[MarkoutSkipNull]`, `[MarkoutBoolFormat]` (medium)
- **Serialization/AdvancedFeatures.cs** — all new features including `[MarkoutShowWhen]` and `[MarkoutLink]` (advanced)

## Tests

192 → 223 tests (31 new covering all 7 features across all layouts).

## Version

0.3.4 → 0.4.0