### PR TITLE
Fix declaration order for non-section compound properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Latest LTS: 10.0
 - **`[MarkoutPropertyName("...")]`** - Custom property display name
 - **`[MarkoutIgnore]`** - Excludes a property from output
 - **`[MarkoutIgnoreInTable]`** - Excludes a property only in table context (silences MARKOUT001 warning)
-- **`[MarkoutSection(Name = "...")]`** - Renders property as H2 section
+- **`[MarkoutSection(Name = "...")]`** - Groups property under an H2 section (scalars grouped by name, collections as tables/lists)
 - **`[MarkoutBoolFormat]`** - Custom true/false display values
 - **`[MarkoutContext(typeof(...))]`** - Registers types for source generation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,6 +30,7 @@ var city = new CityView
 {
     Name = "Vancouver",
     Country = "Canada",
+    Population = 2_632_000,
     Temperature = 6.2,
     Latitude = 49.2827,
     Longitude = -123.1207,
@@ -43,10 +44,22 @@ public class CityView
 {
     public string Name { get; set; } = "";
     public string Country { get; set; } = "";
-    public double Temperature { get; set; }
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Population { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
     public double Latitude { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
     public double Longitude { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
+    [MarkoutPropertyName("Altitude (m)")]
     public int Altitude { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
+    [MarkoutDisplayFormat("{0:0.0} °C")]
+    public double Temperature { get; set; }
 }
 
 [MarkoutContext(typeof(CityView))]
@@ -58,7 +71,11 @@ Output:
 ```markdown
 # Vancouver
 
-Country: Canada | Temperature: 6.2 | Latitude: 49.2827 | Longitude: -123.1207 | Altitude: 0
+Country: Canada | Population: 2,632,000
+
+## Geography
+
+Latitude: 49.2827 | Longitude: -123.1207 | Altitude (m): 0 | Temperature: 6.2 °C
 ```
 
 > This is the [HelloMarkout](../samples/HelloMarkout/HelloMarkout.cs) sample.
@@ -73,7 +90,7 @@ The source generator fills in the `partial class` with all the serialization log
 
 ## Quick Tweaks
 
-The same city can be rendered differently by changing just the `FieldLayout`. `LineBreaks` puts one field per line:
+The same city can be rendered differently by changing just the `FieldLayout`. `LineBreaks` puts one field per line — both top-level fields and within sections:
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.LineBreaks)]
@@ -84,10 +101,14 @@ public class CityView { /* same properties */ }
 # Vancouver
 
 Country: Canada
-Temperature: 6.2
+Population: 2,632,000
+
+## Geography
+
 Latitude: 49.2827
 Longitude: -123.1207
-Altitude: 0
+Altitude (m): 0
+Temperature: 6.2 °C
 ```
 
 > **Note:** In standard Markdown, adjacent lines without a blank line between them collapse into a single paragraph when rendered as HTML. `LineBreaksDoubleSpace` avoids this by appending two trailing spaces (`  `) to each line, which Markdown renders as `<br>`. Use `LineBreaks` when you're targeting plain text or terminals; use `LineBreaksDoubleSpace` when your output will be rendered as HTML.
@@ -103,35 +124,14 @@ public class CityView { /* same properties */ }
 # Vancouver
 
 - Country: Canada
-- Temperature: 6.2
+- Population: 2,632,000
+
+## Geography
+
 - Latitude: 49.2827
 - Longitude: -123.1207
-- Altitude: 0
-```
-
-Property-level attributes let you refine individual fields without changing the overall layout. `[MarkoutFormat]` applies a .NET format string — `F4` keeps 4 decimal places while `F2` rounds to 2 — and `[MarkoutDisplayFormat]` wraps the value in surrounding text:
-
-```csharp
-[MarkoutSerializable(TitleProperty = nameof(Name))]
-public class CityView
-{
-    public string Name { get; set; } = "";
-    public string Country { get; set; } = "";
-    [MarkoutDisplayFormat("{0}°C")]
-    public double Temperature { get; set; }
-    [MarkoutFormat("F4")]
-    public double Latitude { get; set; }
-    [MarkoutFormat("F2")]
-    public double Longitude { get; set; }
-    [MarkoutDisplayFormat("{0}m")]
-    public int Altitude { get; set; }
-}
-```
-
-```markdown
-# Vancouver
-
-Country: Canada | Temperature: 6.2°C | Latitude: 49.2827 | Longitude: -123.12 | Altitude: 0m
+- Altitude (m): 0
+- Temperature: 6.2 °C
 ```
 
 ## Defining View Models
@@ -528,7 +528,48 @@ When `IsVerified` is `false`, `VerifiedBy` is not rendered — even if it has a 
 
 ## Sections and Collections
 
-When a property is a `List<T>` of complex objects, it renders as a section with a heading and table. Use `[MarkoutSection]` to name the section:
+Use `[MarkoutSection]` to group properties under a heading. It works on both scalar properties and collections.
+
+### Scalar Sections
+
+When scalar properties share the same section name, they are grouped under a single heading:
+
+```csharp
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class PackageView
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSkipNull]
+    [MarkoutValueFormatter(typeof(CompactNumberFormatter))]
+    public long? Downloads { get; set; }
+
+    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSkipNull]
+    [MarkoutValueFormatter(typeof(ByteSizeFormatter))]
+    [MarkoutPropertyName("Package Size")]
+    public long? PackageSize { get; set; }
+}
+```
+
+```markdown
+# System.Text.Json
+
+## Statistics
+
+Downloads: 5.1B | Package Size: 2.1 MB
+```
+
+When all fields in a scalar section are null or skipped, the heading is suppressed entirely — no empty sections appear.
+
+All property-level attributes work within scalar sections: `[MarkoutSkipNull]`, `[MarkoutValueFormatter]`, `[MarkoutFormat]`, `[MarkoutLink]`, `[MarkoutShowWhen]`, etc.
+
+> See the [HelloMarkout](../samples/HelloMarkout/HelloMarkout.cs) sample for a Geography section using scalar properties.
+
+### Collection Sections
+
+When a `List<T>` of complex objects has `[MarkoutSection]`, it renders as a headed table:
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Title))]
@@ -542,8 +583,6 @@ public class ShowDetailView
     public List<ActorRow>? Cast { get; set; }
 }
 ```
-
-Output:
 
 ```markdown
 # The Expanse
@@ -888,7 +927,7 @@ writer.WriteCodeBlockEnd();
 | `[MarkoutPropertyName("...")]` | Property | Sets the display name for a field or column. |
 | `[MarkoutIgnore]` | Property | Excludes the property from all output. |
 | `[MarkoutIgnoreInTable]` | Property | Excludes the property in table context only. |
-| `[MarkoutSection]` | Property | Renders the property as a headed section. Properties: `Name`, `Level`, `ShowWhenProperty`, `IgnoreProperty`, `FormatProperty`, `Formatter`, `ColumnName`. |
+| `[MarkoutSection]` | Property | Renders the property under a headed section. Works on scalar properties (grouped by name) and collections (tables, lists, trees). Properties: `Name`, `Level`, `ShowWhenProperty`, `IgnoreProperty`, `FormatProperty`, `Formatter`, `ColumnName`. |
 | `[MarkoutBoolFormat("T", "F")]` | Property | Custom true/false display strings. |
 | `[MarkoutFormat("...")]` | Property | .NET format string passed to `ToString()`. |
 | `[MarkoutDisplayFormat("...")]` | Property | Composite format string via `string.Format()`. `{0}` is the value. |

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.4.0
+#:package Markout@0.5.0
 // CanCon. It's the law!
 
 using System.Text.Json;

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.4.0
+#:package Markout@0.5.0
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/HelloMarkout/HelloMarkout.cs
+++ b/samples/HelloMarkout/HelloMarkout.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.4.0
+#:package Markout@0.5.0
 
 using Markout;
 
@@ -7,6 +7,7 @@ var city = new CityView
 {
     Name = "Vancouver",
     Country = "Canada",
+    Population = 2_632_000,
     Temperature = 6.2,
     Latitude = 49.2827,
     Longitude = -123.1207,
@@ -20,10 +21,22 @@ public class CityView
 {
     public string Name { get; set; } = "";
     public string Country { get; set; } = "";
-    public double Temperature { get; set; }
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Population { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
     public double Latitude { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
     public double Longitude { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
+    [MarkoutPropertyName("Altitude (m)")]
     public int Altitude { get; set; }
+
+    [MarkoutSection(Name = "Geography")]
+    [MarkoutDisplayFormat("{0:0.0} °C")]
+    public double Temperature { get; set; }
 }
 
 [MarkoutContext(typeof(CityView))]

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.4.0
+#:package Markout@0.5.0
 
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/samples/SkipNullDemo/SkipNullDemo.cs
+++ b/samples/SkipNullDemo/SkipNullDemo.cs
@@ -1,5 +1,5 @@
 #!/usr/bin/env dotnet run
-#:package Markout@0.4.0
+#:package Markout@0.5.0
 
 // Demonstrates [MarkoutSkipNull] — optional fields are omitted when null.
 

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -16,28 +16,30 @@ internal static class FieldEmitter
         string valueExpr,
         int indentLevel,
         FieldLayoutKind fieldLayout,
-        int nestingDepth = 0)
+        int nestingDepth = 0,
+        string? sectionHeading = null,
+        int sectionLevel = 2)
     {
         switch (fieldLayout)
         {
             case FieldLayoutKind.OneLine:
-                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth, sectionHeading, sectionLevel);
                 break;
 
             case FieldLayoutKind.LineBreaks:
-                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: false);
+                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: false, sectionHeading, sectionLevel);
                 break;
 
             case FieldLayoutKind.LineBreaksDoubleSpace:
-                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: true);
+                EmitLineBreaksScalars(sb, scalarProps, valueExpr, indentLevel, doubleSpace: true, sectionHeading, sectionLevel);
                 break;
 
             case FieldLayoutKind.List:
-                EmitListScalars(sb, scalarProps, valueExpr, indentLevel);
+                EmitListScalars(sb, scalarProps, valueExpr, indentLevel, sectionHeading, sectionLevel);
                 break;
 
             default:
-                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth);
+                EmitOneLineScalars(sb, scalarProps, valueExpr, indentLevel, nestingDepth, sectionHeading, sectionLevel);
                 break;
         }
     }
@@ -47,7 +49,9 @@ internal static class FieldEmitter
         List<PropertyMetadata> scalarProps,
         string valueExpr,
         int indentLevel,
-        int nestingDepth = 0)
+        int nestingDepth = 0,
+        string? sectionHeading = null,
+        int sectionLevel = 2)
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
@@ -126,7 +130,11 @@ internal static class FieldEmitter
                 }
             }
             sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
+            sb.AppendLine($"{indent}{{");
+            if (sectionHeading != null)
+                sb.AppendLine($"{indent}    writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
             sb.AppendLine($"{indent}    writer.WriteCompactFields({fieldsVar});");
+            sb.AppendLine($"{indent}}}");
         }
         else
         {
@@ -140,6 +148,8 @@ internal static class FieldEmitter
                 fields.Add($"new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr})");
             }
 
+            if (sectionHeading != null)
+                sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
             sb.AppendLine($"{indent}writer.WriteCompactFields({string.Join(", ", fields)});");
         }
     }
@@ -149,10 +159,30 @@ internal static class FieldEmitter
         List<PropertyMetadata> scalarProps,
         string valueExpr,
         int indentLevel,
-        bool doubleSpace)
+        bool doubleSpace,
+        string? sectionHeading = null,
+        int sectionLevel = 2)
     {
         var indent = new string(' ', indentLevel * 4);
         var methodName = doubleSpace ? "WriteField" : "WriteFieldNoBreak";
+
+        // For LineBreaks layout, all fields are emitted individually so we need a different
+        // strategy for section headings: use a builder flag when any field is conditional,
+        // or emit heading unconditionally when all fields always render.
+        bool anyConditional = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
+            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
+
+        string? renderedVar = null;
+        if (sectionHeading != null && anyConditional)
+        {
+            renderedVar = "__sectionRendered";
+            sb.AppendLine($"{indent}var {renderedVar} = false;");
+        }
+        else if (sectionHeading != null)
+        {
+            sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
+        }
 
         foreach (var prop in scalarProps)
         {
@@ -193,55 +223,104 @@ internal static class FieldEmitter
                 }
             }
 
+            // For nullable value types and strings, the condition is emitted inline;
+            // we need to wrap the write call in a block to insert the heading guard.
+            bool isInlineConditional = prop.IsNullableValueType || prop.Kind == PropertyKind.String
+                || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+
             if (prop.ValueFormatterTypeName != null)
             {
                 if (prop.IsNullableValueType)
                 {
                     sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
-                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", new {prop.ValueFormatterTypeName}().Format({propAccess}.Value));");
+                    if (renderedVar != null)
+                    {
+                        sb.AppendLine($"{emitIndent}{{");
+                        EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                        sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", new {prop.ValueFormatterTypeName}().Format({propAccess}.Value));");
+                        sb.AppendLine($"{emitIndent}}}");
+                    }
+                    else
+                    {
+                        sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", new {prop.ValueFormatterTypeName}().Format({propAccess}.Value));");
+                    }
                 }
                 else
                 {
+                    EmitHeadingOnceIfNeeded(sb, renderedVar, sectionHeading, sectionLevel, emitIndent);
                     sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", new {prop.ValueFormatterTypeName}().Format({propAccess}));");
                 }
             }
             else if (prop.IsNullableValueType)
             {
                 sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}{{");
+                    EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                }
                 if (prop.Kind == PropertyKind.Boolean)
                 {
+                    var writeIndent = renderedVar != null ? emitIndent + "    " : emitIndent + "    ";
                     if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
                     {
-                        sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
+                        sb.AppendLine($"{writeIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
                     }
                     else
                     {
-                        sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                        sb.AppendLine($"{writeIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
                     }
                 }
                 else if (prop.CustomFormat != null)
                 {
-                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
+                    var writeIndent = renderedVar != null ? emitIndent + "    " : emitIndent + "    ";
+                    sb.AppendLine($"{writeIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
                 }
                 else
                 {
-                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                    var writeIndent = renderedVar != null ? emitIndent + "    " : emitIndent + "    ";
+                    sb.AppendLine($"{writeIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.Value);");
+                }
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}}}");
                 }
             }
             else if (prop.Kind == PropertyKind.String)
             {
                 var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
-                sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr});");
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}{{");
+                    EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr});");
+                    sb.AppendLine($"{emitIndent}}}");
+                }
+                else
+                {
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr});");
+                }
             }
             else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
             {
                 var countProp = prop.IsArray ? "Length" : "Count";
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)});");
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}{{");
+                    EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)});");
+                    sb.AppendLine($"{emitIndent}}}");
+                }
+                else
+                {
+                    sb.AppendLine($"{emitIndent}    writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)});");
+                }
             }
             else if (prop.Kind == PropertyKind.Boolean)
             {
+                EmitHeadingOnceIfNeeded(sb, renderedVar, sectionHeading, sectionLevel, emitIndent);
                 if (prop.BoolTrueValue != null && prop.BoolFalseValue != null)
                 {
                     sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess} ? \"{EmitHelpers.EscapeString(prop.BoolTrueValue)}\" : \"{EmitHelpers.EscapeString(prop.BoolFalseValue)}\");");
@@ -253,10 +332,12 @@ internal static class FieldEmitter
             }
             else if (prop.CustomFormat != null)
             {
+                EmitHeadingOnceIfNeeded(sb, renderedVar, sectionHeading, sectionLevel, emitIndent);
                 sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}.ToString(\"{EmitHelpers.EscapeString(prop.CustomFormat)}\", System.Globalization.CultureInfo.InvariantCulture));");
             }
             else
             {
+                EmitHeadingOnceIfNeeded(sb, renderedVar, sectionHeading, sectionLevel, emitIndent);
                 sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
             }
 
@@ -275,9 +356,26 @@ internal static class FieldEmitter
         StringBuilder sb,
         List<PropertyMetadata> scalarProps,
         string valueExpr,
-        int indentLevel)
+        int indentLevel,
+        string? sectionHeading = null,
+        int sectionLevel = 2)
     {
         var indent = new string(' ', indentLevel * 4);
+
+        bool anyConditional = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
+            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
+
+        string? renderedVar = null;
+        if (sectionHeading != null && anyConditional)
+        {
+            renderedVar = "__sectionRendered";
+            sb.AppendLine($"{indent}var {renderedVar} = false;");
+        }
+        else if (sectionHeading != null)
+        {
+            sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
+        }
 
         foreach (var prop in scalarProps)
         {
@@ -322,25 +420,56 @@ internal static class FieldEmitter
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
                 valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess}.HasValue)");
-                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}{{");
+                    EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                    sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                    sb.AppendLine($"{emitIndent}}}");
+                }
+                else
+                {
+                    sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                }
             }
             else if (prop.Kind == PropertyKind.String)
             {
                 var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
-                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}{{");
+                    EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                    sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                    sb.AppendLine($"{emitIndent}}}");
+                }
+                else
+                {
+                    sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                }
             }
             else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
             {
                 var countProp = prop.IsArray ? "Length" : "Count";
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
-                sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                if (renderedVar != null)
+                {
+                    sb.AppendLine($"{emitIndent}{{");
+                    EmitHeadingOnce(sb, renderedVar, sectionHeading!, sectionLevel, emitIndent + "    ");
+                    sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                    sb.AppendLine($"{emitIndent}}}");
+                }
+                else
+                {
+                    sb.AppendLine($"{emitIndent}    writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
+                }
             }
             else
             {
                 var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
                 valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+                EmitHeadingOnceIfNeeded(sb, renderedVar, sectionHeading, sectionLevel, emitIndent);
                 sb.AppendLine($"{emitIndent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
 
@@ -353,5 +482,22 @@ internal static class FieldEmitter
                 sb.AppendLine($"{indent}}}");
             }
         }
+    }
+
+    /// <summary>
+    /// Emits a heading-once guard: if the flag is false, write the heading and set it to true.
+    /// </summary>
+    private static void EmitHeadingOnce(StringBuilder sb, string renderedVar, string heading, int level, string indent)
+    {
+        sb.AppendLine($"{indent}if (!{renderedVar}) {{ writer.WriteHeading({level}, \"{EmitHelpers.EscapeString(heading)}\"); {renderedVar} = true; }}");
+    }
+
+    /// <summary>
+    /// Convenience: emits heading-once guard only when renderedVar is set (conditional section heading).
+    /// </summary>
+    private static void EmitHeadingOnceIfNeeded(StringBuilder sb, string? renderedVar, string? heading, int level, string indent)
+    {
+        if (renderedVar != null)
+            EmitHeadingOnce(sb, renderedVar, heading!, level, indent);
     }
 }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -233,9 +233,18 @@ internal static class SerializerEmitter
     {
         var indent = new string(' ', indentLevel * 4);
 
-        // Separate scalars from non-scalars for field layout handling
-        var scalarProps = new List<PropertyMetadata>();
-        var nonScalarProps = new List<PropertyMetadata>();
+        // Separate into three groups:
+        // 1. ungroupedScalars — scalars without [MarkoutSection] (auto fields)
+        // 2. scalarSectionGroups — scalars WITH [MarkoutSection], grouped by SectionName
+        // 3. compoundProps — collections, trees, nested objects (unchanged)
+        var ungroupedScalars = new List<PropertyMetadata>();
+        var scalarSectionGroups = new List<(string SectionName, List<PropertyMetadata> Props, PropertyMetadata FirstProp)>();
+        var scalarSectionLookup = new Dictionary<string, List<PropertyMetadata>>();
+        var compoundProps = new List<PropertyMetadata>();
+
+        // Track section ordering by first-occurrence index across all section types
+        var sectionOrder = new List<(string SectionName, bool IsScalar)>();
+        var seenSections = new HashSet<string>();
 
         foreach (var prop in properties)
         {
@@ -246,34 +255,146 @@ internal static class SerializerEmitter
             if (!autoFields && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
                 continue;
 
-            if ((EmitHelpers.IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)) && !prop.IsSection)
-                scalarProps.Add(prop);
+            bool isScalarKind = EmitHelpers.IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+
+            if (isScalarKind && !prop.IsSection)
+            {
+                ungroupedScalars.Add(prop);
+            }
+            else if (isScalarKind && prop.IsSection)
+            {
+                var sectionName = prop.SectionName ?? prop.DisplayName;
+                if (!scalarSectionLookup.TryGetValue(sectionName, out var group))
+                {
+                    group = new List<PropertyMetadata>();
+                    scalarSectionLookup[sectionName] = group;
+                    scalarSectionGroups.Add((sectionName, group, prop));
+                }
+                group.Add(prop);
+
+                if (seenSections.Add(sectionName))
+                    sectionOrder.Add((sectionName, true));
+            }
             else
-                nonScalarProps.Add(prop);
+            {
+                compoundProps.Add(prop);
+                if (prop.IsSection)
+                {
+                    var sectionName = prop.SectionName ?? prop.DisplayName;
+                    if (seenSections.Add(sectionName))
+                        sectionOrder.Add((sectionName, false));
+                }
+            }
         }
 
-        // Emit scalars based on layout
-        if (autoFields && scalarProps.Count > 0)
+        // Emit ungrouped scalars (unchanged)
+        if (autoFields && ungroupedScalars.Count > 0)
         {
-            FieldEmitter.EmitScalarsWithLayout(sb, scalarProps, valueExpr, indentLevel, fieldLayout, nestingDepth);
+            FieldEmitter.EmitScalarsWithLayout(sb, ungroupedScalars, valueExpr, indentLevel, fieldLayout, nestingDepth);
         }
 
-        // Emit non-scalar properties (sections, arrays, etc.)
-        foreach (var prop in nonScalarProps)
+        // Build lookup for compound section props by name for ordered emission
+        var compoundSectionProps = new Dictionary<string, List<PropertyMetadata>>();
+        var compoundNonSectionProps = new List<PropertyMetadata>();
+        foreach (var prop in compoundProps)
         {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-            var effectiveSectionLevel = prop.IsSection 
-                ? System.Math.Max(prop.SectionLevel, baseHeadingLevel) 
-                : baseHeadingLevel;
-
             if (prop.IsSection)
             {
-                EmitSectionProperty(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
-                continue;
+                var sectionName = prop.SectionName ?? prop.DisplayName;
+                if (!compoundSectionProps.TryGetValue(sectionName, out var list))
+                {
+                    list = new List<PropertyMetadata>();
+                    compoundSectionProps[sectionName] = list;
+                }
+                list.Add(prop);
             }
+            else
+            {
+                compoundNonSectionProps.Add(prop);
+            }
+        }
 
-            // Non-section property handling
+        // Emit sections in declaration order (interleaving scalar and compound sections)
+        foreach (var (sectionName, isScalar) in sectionOrder)
+        {
+            if (isScalar)
+            {
+                var group = scalarSectionGroups.First(g => g.SectionName == sectionName);
+                EmitScalarSectionGroup(sb, group.Props, group.FirstProp, sectionName, valueExpr, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
+            }
+            else
+            {
+                if (compoundSectionProps.TryGetValue(sectionName, out var props))
+                {
+                    foreach (var prop in props)
+                    {
+                        var propAccess = $"{valueExpr}.{prop.Name}";
+                        var effectiveSectionLevel = System.Math.Max(prop.SectionLevel, baseHeadingLevel);
+                        EmitSectionProperty(sb, prop, propAccess, indent, indentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
+                    }
+                }
+            }
+        }
+
+        // Emit remaining compound non-section properties
+        foreach (var prop in compoundNonSectionProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
             EmitNonSectionProperty(sb, prop, propAccess, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout);
+        }
+    }
+
+    private static void EmitScalarSectionGroup(
+        StringBuilder sb,
+        List<PropertyMetadata> props,
+        PropertyMetadata firstProp,
+        string sectionName,
+        string valueExpr,
+        string indent,
+        int indentLevel,
+        int baseHeadingLevel,
+        int nestingDepth,
+        FieldLayoutKind fieldLayout,
+        string? rootValueExpr = null,
+        string? rootTypeName = null)
+    {
+        var effectiveSectionLevel = System.Math.Max(firstProp.SectionLevel, baseHeadingLevel);
+
+        // Emit ShowWhenProperty guard if configured (from first property's section config)
+        var showWhenIndent = indent;
+        var showWhenIndentLevel = indentLevel;
+        if (firstProp.SectionShowWhenProperty != null && rootValueExpr != null)
+        {
+            sb.AppendLine($"{indent}if ({rootValueExpr}.{firstProp.SectionShowWhenProperty})");
+            sb.AppendLine($"{indent}{{");
+            showWhenIndent = indent + "    ";
+            showWhenIndentLevel = indentLevel + 1;
+        }
+
+        // Emit per-section hook at top level only
+        if (rootValueExpr != null && rootTypeName != null)
+        {
+            var safeName = new string(sectionName.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+            var skipVar = $"__skipSection{safeName}";
+            sb.AppendLine($"{showWhenIndent}var {skipVar} = false;");
+            sb.AppendLine($"{showWhenIndent}OnBeforeSection{safeName}(writer, {rootValueExpr}, ref {skipVar});");
+            sb.AppendLine($"{showWhenIndent}if (!{skipVar})");
+            sb.AppendLine($"{showWhenIndent}{{");
+
+            FieldEmitter.EmitScalarsWithLayout(sb, props, valueExpr, showWhenIndentLevel + 1, fieldLayout, nestingDepth,
+                sectionHeading: sectionName, sectionLevel: effectiveSectionLevel);
+
+            sb.AppendLine($"{showWhenIndent}}}");
+        }
+        else
+        {
+            FieldEmitter.EmitScalarsWithLayout(sb, props, valueExpr, showWhenIndentLevel, fieldLayout, nestingDepth,
+                sectionHeading: sectionName, sectionLevel: effectiveSectionLevel);
+        }
+
+        if (firstProp.SectionShowWhenProperty != null && rootValueExpr != null)
+        {
+            sb.AppendLine($"{indent}}}");
         }
     }
 
@@ -643,6 +764,8 @@ internal static class SerializerEmitter
         if (prop.IsSection)
         {
             var sectionName = prop.SectionName ?? prop.DisplayName;
+            if (EmitHelpers.IsScalarKind(prop.Kind))
+                return $"H{prop.SectionLevel} Section \"{sectionName}\" (field)";
             if (prop.Kind == PropertyKind.FieldCollection)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (field table)";
             if (prop.Kind == PropertyKind.ComplexArray)

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -242,8 +242,9 @@ internal static class SerializerEmitter
         var scalarSectionLookup = new Dictionary<string, List<PropertyMetadata>>();
         var compoundProps = new List<PropertyMetadata>();
 
-        // Track section ordering by first-occurrence index across all section types
-        var sectionOrder = new List<(string SectionName, bool IsScalar)>();
+        // Track emit ordering by first-occurrence index across all compound property types
+        // SectionName=null for non-section compound props (emitted inline in declaration order)
+        var emitOrder = new List<(string? SectionName, bool IsScalar, PropertyMetadata? NonSectionProp)>();
         var seenSections = new HashSet<string>();
 
         foreach (var prop in properties)
@@ -273,7 +274,7 @@ internal static class SerializerEmitter
                 group.Add(prop);
 
                 if (seenSections.Add(sectionName))
-                    sectionOrder.Add((sectionName, true));
+                    emitOrder.Add((sectionName, true, null));
             }
             else
             {
@@ -282,7 +283,11 @@ internal static class SerializerEmitter
                 {
                     var sectionName = prop.SectionName ?? prop.DisplayName;
                     if (seenSections.Add(sectionName))
-                        sectionOrder.Add((sectionName, false));
+                        emitOrder.Add((sectionName, false, null));
+                }
+                else
+                {
+                    emitOrder.Add((null, false, prop));
                 }
             }
         }
@@ -295,7 +300,6 @@ internal static class SerializerEmitter
 
         // Build lookup for compound section props by name for ordered emission
         var compoundSectionProps = new Dictionary<string, List<PropertyMetadata>>();
-        var compoundNonSectionProps = new List<PropertyMetadata>();
         foreach (var prop in compoundProps)
         {
             if (prop.IsSection)
@@ -308,23 +312,24 @@ internal static class SerializerEmitter
                 }
                 list.Add(prop);
             }
-            else
-            {
-                compoundNonSectionProps.Add(prop);
-            }
         }
 
-        // Emit sections in declaration order (interleaving scalar and compound sections)
-        foreach (var (sectionName, isScalar) in sectionOrder)
+        // Emit compound properties in declaration order (sections, scalar sections, and non-sections interleaved)
+        foreach (var (sectionName, isScalar, nonSectionProp) in emitOrder)
         {
-            if (isScalar)
+            if (nonSectionProp != null)
+            {
+                var propAccess = $"{valueExpr}.{nonSectionProp.Name}";
+                EmitNonSectionProperty(sb, nonSectionProp, propAccess, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout);
+            }
+            else if (isScalar)
             {
                 var group = scalarSectionGroups.First(g => g.SectionName == sectionName);
-                EmitScalarSectionGroup(sb, group.Props, group.FirstProp, sectionName, valueExpr, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
+                EmitScalarSectionGroup(sb, group.Props, group.FirstProp, sectionName!, valueExpr, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
             }
             else
             {
-                if (compoundSectionProps.TryGetValue(sectionName, out var props))
+                if (compoundSectionProps.TryGetValue(sectionName!, out var props))
                 {
                     foreach (var prop in props)
                     {
@@ -334,13 +339,6 @@ internal static class SerializerEmitter
                     }
                 }
             }
-        }
-
-        // Emit remaining compound non-section properties
-        foreach (var prop in compoundNonSectionProps)
-        {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-            EmitNonSectionProperty(sb, prop, propAccess, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout);
         }
     }
 

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -234,10 +234,10 @@ internal static class SerializerEmitter
         var indent = new string(' ', indentLevel * 4);
 
         // Separate into three groups:
-        // 1. ungroupedScalars — scalars without [MarkoutSection] (auto fields)
+        // 1. rootScalars — scalars without [MarkoutSection] (auto fields at document root)
         // 2. scalarSectionGroups — scalars WITH [MarkoutSection], grouped by SectionName
         // 3. compoundProps — collections, trees, nested objects (unchanged)
-        var ungroupedScalars = new List<PropertyMetadata>();
+        var rootScalars = new List<PropertyMetadata>();
         var scalarSectionGroups = new List<(string SectionName, List<PropertyMetadata> Props, PropertyMetadata FirstProp)>();
         var scalarSectionLookup = new Dictionary<string, List<PropertyMetadata>>();
         var compoundProps = new List<PropertyMetadata>();
@@ -259,7 +259,7 @@ internal static class SerializerEmitter
 
             if (isScalarKind && !prop.IsSection)
             {
-                ungroupedScalars.Add(prop);
+                rootScalars.Add(prop);
             }
             else if (isScalarKind && prop.IsSection)
             {
@@ -287,10 +287,10 @@ internal static class SerializerEmitter
             }
         }
 
-        // Emit ungrouped scalars (unchanged)
-        if (autoFields && ungroupedScalars.Count > 0)
+        // Emit root scalars (unchanged)
+        if (autoFields && rootScalars.Count > 0)
         {
-            FieldEmitter.EmitScalarsWithLayout(sb, ungroupedScalars, valueExpr, indentLevel, fieldLayout, nestingDepth);
+            FieldEmitter.EmitScalarsWithLayout(sb, rootScalars, valueExpr, indentLevel, fieldLayout, nestingDepth);
         }
 
         // Build lookup for compound section props by name for ordered emission

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -1250,6 +1250,26 @@ public class SerializerTests
     }
 
     [Fact]
+    public void Serialize_ScalarSection_FieldCollectionBeforeSectionsPreservesOrder()
+    {
+        var view = new FieldCollectionBeforeSections
+        {
+            Name = "TestPkg",
+            Summary = [new("Version", "1.0"), new("Type", "Library")],
+            Downloads = 500,
+            Stars = 10
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        // Summary (non-section field collection) should appear before the Stats section
+        var summaryIdx = mdf.IndexOf("Version: 1.0");
+        var statsIdx = mdf.IndexOf("## Stats");
+        Assert.True(summaryIdx >= 0, "Summary fields should be present");
+        Assert.True(statsIdx >= 0, "Stats section should be present");
+        Assert.True(summaryIdx < statsIdx, "Summary should appear before Stats section");
+    }
+
+    [Fact]
     public void Serialize_PartialHooks_OnSerializingAndOnSerializedCalled()
     {
         PackageWithSectionsMarkoutTypeInfo.OnSerializingCalled = false;
@@ -1955,12 +1975,30 @@ public class ScalarSectionLineBreaks
     public long? PackageSize { get; set; }
 }
 
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class FieldCollectionBeforeSections
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    public List<MarkoutField> Summary { get; set; } = [];
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Downloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Stars { get; set; }
+}
+
 [MarkoutContext(typeof(PackageWithScalarSection))]
 [MarkoutContext(typeof(MultiSectionView))]
 [MarkoutContext(typeof(MixedSectionView))]
 [MarkoutContext(typeof(ConditionalScalarSection))]
 [MarkoutContext(typeof(FormattedScalarSection))]
 [MarkoutContext(typeof(ScalarSectionLineBreaks))]
+[MarkoutContext(typeof(FieldCollectionBeforeSections))]
 public partial class ScalarSectionTestContext : MarkoutSerializerContext
 {
 }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -1076,6 +1076,179 @@ public class SerializerTests
         Assert.Contains("| Return Type |", mdf);
     }
 
+    // --- Scalar section tests ---
+
+    [Fact]
+    public void Serialize_ScalarSection_RendersHeadingAndFields()
+    {
+        var pkg = new PackageWithScalarSection
+        {
+            Name = "MyPackage",
+            TotalDownloads = 1000,
+            VersionDownloads = 200,
+            VersionCount = 5
+        };
+        var mdf = MarkoutSerializer.Serialize(pkg, ScalarSectionTestContext.Default);
+
+        Assert.Contains("# MyPackage", mdf);
+        Assert.Contains("## Statistics", mdf);
+        Assert.Contains("Total Downloads", mdf);
+        Assert.Contains("1000", mdf);
+        Assert.Contains("Version Downloads", mdf);
+        Assert.Contains("Version Count", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_SkipNullHidesEntireSection()
+    {
+        var pkg = new PackageWithScalarSection
+        {
+            Name = "MyPackage",
+            TotalDownloads = null,
+            VersionDownloads = null,
+            VersionCount = null
+        };
+        var mdf = MarkoutSerializer.Serialize(pkg, ScalarSectionTestContext.Default);
+
+        Assert.Contains("# MyPackage", mdf);
+        Assert.DoesNotContain("Statistics", mdf);
+        Assert.DoesNotContain("Total Downloads", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_MultipleSectionGroups()
+    {
+        var view = new MultiSectionView
+        {
+            Name = "TestView",
+            Author = "Alice",
+            License = "MIT",
+            Downloads = 100,
+            Stars = 50
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.Contains("## Info", mdf);
+        Assert.Contains("Author: Alice", mdf);
+        Assert.Contains("License: MIT", mdf);
+        Assert.Contains("## Stats", mdf);
+        Assert.Contains("Downloads: 100", mdf);
+        Assert.Contains("Stars: 50", mdf);
+
+        // Info should come before Stats
+        var infoIdx = mdf.IndexOf("## Info", StringComparison.Ordinal);
+        var statsIdx = mdf.IndexOf("## Stats", StringComparison.Ordinal);
+        Assert.True(infoIdx < statsIdx);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_MixedWithCollectionSection()
+    {
+        var view = new MixedSectionView
+        {
+            Name = "MixedView",
+            Downloads = 100,
+            Stars = 50,
+            Dependencies = new List<SimpleDep>
+            {
+                new() { Id = "Dep1", Version = "1.0" }
+            }
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.Contains("## Stats", mdf);
+        Assert.Contains("Downloads: 100", mdf);
+        Assert.Contains("## Dependencies", mdf);
+        Assert.Contains("Dep1", mdf);
+
+        // Stats should come before Dependencies (declaration order)
+        var statsIdx = mdf.IndexOf("## Stats", StringComparison.Ordinal);
+        var depsIdx = mdf.IndexOf("## Dependencies", StringComparison.Ordinal);
+        Assert.True(statsIdx < depsIdx);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_ShowWhenPropertyWrapsGroup()
+    {
+        var view = new ConditionalScalarSection
+        {
+            Name = "TestView",
+            ShowStats = false,
+            Downloads = 100,
+            Stars = 50
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.DoesNotContain("Stats", mdf);
+        Assert.DoesNotContain("Downloads", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_ShowWhenPropertyTrue()
+    {
+        var view = new ConditionalScalarSection
+        {
+            Name = "TestView",
+            ShowStats = true,
+            Downloads = 100,
+            Stars = 50
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.Contains("## Stats", mdf);
+        Assert.Contains("Downloads: 100", mdf);
+        Assert.Contains("Stars: 50", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_FormatterAndLinkWork()
+    {
+        var view = new FormattedScalarSection
+        {
+            Name = "TestView",
+            Downloads = 50,
+            Repository = "https://github.com/test"
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.Contains("## Stats", mdf);
+        Assert.Contains("100", mdf); // DoubleFormatter: 50 * 2
+        Assert.Contains("[https://github.com/test](https://github.com/test)", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_LineBreaksLayout()
+    {
+        var view = new ScalarSectionLineBreaks
+        {
+            Name = "TestView",
+            TotalDownloads = 1000,
+            PackageSize = 2048
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.Contains("## Stats", mdf);
+        Assert.Contains("Total Downloads", mdf);
+        Assert.Contains("1000", mdf);
+        Assert.Contains("Package Size", mdf);
+        Assert.Contains("2048", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_LineBreaksAllNull_HidesSection()
+    {
+        var view = new ScalarSectionLineBreaks
+        {
+            Name = "TestView",
+            TotalDownloads = null,
+            PackageSize = null
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        Assert.DoesNotContain("Stats", mdf);
+        Assert.DoesNotContain("Total Downloads", mdf);
+    }
+
     [Fact]
     public void Serialize_PartialHooks_OnSerializingAndOnSerializedCalled()
     {
@@ -1671,5 +1844,123 @@ public class LinkProjectListView
 [MarkoutContext(typeof(LinkProjectListView))]
 [MarkoutContext(typeof(LinkProjectRow))]
 public partial class LinkTestContext : MarkoutSerializerContext
+{
+}
+
+// --- Scalar section test types ---
+
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class PackageWithScalarSection
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Total Downloads")]
+    public long? TotalDownloads { get; set; }
+
+    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Version Downloads")]
+    public long? VersionDownloads { get; set; }
+
+    [MarkoutSection(Name = "Statistics")]
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Version Count")]
+    public int? VersionCount { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class MultiSectionView
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Info")]
+    public string? Author { get; set; }
+
+    [MarkoutSection(Name = "Info")]
+    public string? License { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Downloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Stars { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class MixedSectionView
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Downloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Stars { get; set; }
+
+    [MarkoutSection(Name = "Dependencies")]
+    public List<SimpleDep>? Dependencies { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class ConditionalScalarSection
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+    public bool ShowStats { get; set; }
+
+    [MarkoutSection(Name = "Stats", ShowWhenProperty = nameof(ShowStats))]
+    public int Downloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    public int Stars { get; set; }
+}
+
+public class DoubleFormatter : IMarkoutValueFormatter<long>
+{
+    public string Format(long value) => $"{value * 2}";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class FormattedScalarSection
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutValueFormatter(typeof(DoubleFormatter))]
+    public long Downloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutLink]
+    public string? Repository { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false, FieldLayout = FieldLayout.LineBreaks)]
+public class ScalarSectionLineBreaks
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Total Downloads")]
+    public long? TotalDownloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    [MarkoutPropertyName("Package Size")]
+    public long? PackageSize { get; set; }
+}
+
+[MarkoutContext(typeof(PackageWithScalarSection))]
+[MarkoutContext(typeof(MultiSectionView))]
+[MarkoutContext(typeof(MixedSectionView))]
+[MarkoutContext(typeof(ConditionalScalarSection))]
+[MarkoutContext(typeof(FormattedScalarSection))]
+[MarkoutContext(typeof(ScalarSectionLineBreaks))]
+public partial class ScalarSectionTestContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

- Non-section compound properties (e.g. `List<MarkoutField>` without `[MarkoutSection]`) were emitted after all sections instead of in their declaration position
- This caused section-exclusion state in `MarkoutWriter` to leak into subsequent non-section output when `ExcludeSections` was set
- Discovered via dotnet-inspect smoke test: quiet mode excluded all sections, and the `Summary` field collection (declared before sections) was suppressed because it rendered after the last excluded section

## Test plan

- [x] New test: `Serialize_ScalarSection_FieldCollectionBeforeSectionsPreservesOrder` — verifies non-section field collection renders before sections
- [x] All 233 Markout tests pass
- [x] All 253 dotnet-inspect tests pass
- [x] Smoke test: `dotnet run -- package System.Text.Json 10.0.0 -v:q` renders Summary line

🤖 Generated with [Claude Code](https://claude.com/claude-code)