### PR TITLE
Fix declaration order for non-section compound properties

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -242,8 +242,9 @@ internal static class SerializerEmitter
         var scalarSectionLookup = new Dictionary<string, List<PropertyMetadata>>();
         var compoundProps = new List<PropertyMetadata>();
 
-        // Track section ordering by first-occurrence index across all section types
-        var sectionOrder = new List<(string SectionName, bool IsScalar)>();
+        // Track emit ordering by first-occurrence index across all compound property types
+        // SectionName=null for non-section compound props (emitted inline in declaration order)
+        var emitOrder = new List<(string? SectionName, bool IsScalar, PropertyMetadata? NonSectionProp)>();
         var seenSections = new HashSet<string>();
 
         foreach (var prop in properties)
@@ -273,7 +274,7 @@ internal static class SerializerEmitter
                 group.Add(prop);
 
                 if (seenSections.Add(sectionName))
-                    sectionOrder.Add((sectionName, true));
+                    emitOrder.Add((sectionName, true, null));
             }
             else
             {
@@ -282,7 +283,11 @@ internal static class SerializerEmitter
                 {
                     var sectionName = prop.SectionName ?? prop.DisplayName;
                     if (seenSections.Add(sectionName))
-                        sectionOrder.Add((sectionName, false));
+                        emitOrder.Add((sectionName, false, null));
+                }
+                else
+                {
+                    emitOrder.Add((null, false, prop));
                 }
             }
         }
@@ -295,7 +300,6 @@ internal static class SerializerEmitter
 
         // Build lookup for compound section props by name for ordered emission
         var compoundSectionProps = new Dictionary<string, List<PropertyMetadata>>();
-        var compoundNonSectionProps = new List<PropertyMetadata>();
         foreach (var prop in compoundProps)
         {
             if (prop.IsSection)
@@ -308,23 +312,24 @@ internal static class SerializerEmitter
                 }
                 list.Add(prop);
             }
-            else
-            {
-                compoundNonSectionProps.Add(prop);
-            }
         }
 
-        // Emit sections in declaration order (interleaving scalar and compound sections)
-        foreach (var (sectionName, isScalar) in sectionOrder)
+        // Emit compound properties in declaration order (sections, scalar sections, and non-sections interleaved)
+        foreach (var (sectionName, isScalar, nonSectionProp) in emitOrder)
         {
-            if (isScalar)
+            if (nonSectionProp != null)
+            {
+                var propAccess = $"{valueExpr}.{nonSectionProp.Name}";
+                EmitNonSectionProperty(sb, nonSectionProp, propAccess, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout);
+            }
+            else if (isScalar)
             {
                 var group = scalarSectionGroups.First(g => g.SectionName == sectionName);
-                EmitScalarSectionGroup(sb, group.Props, group.FirstProp, sectionName, valueExpr, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
+                EmitScalarSectionGroup(sb, group.Props, group.FirstProp, sectionName!, valueExpr, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout, rootValueExpr, rootTypeName);
             }
             else
             {
-                if (compoundSectionProps.TryGetValue(sectionName, out var props))
+                if (compoundSectionProps.TryGetValue(sectionName!, out var props))
                 {
                     foreach (var prop in props)
                     {
@@ -334,13 +339,6 @@ internal static class SerializerEmitter
                     }
                 }
             }
-        }
-
-        // Emit remaining compound non-section properties
-        foreach (var prop in compoundNonSectionProps)
-        {
-            var propAccess = $"{valueExpr}.{prop.Name}";
-            EmitNonSectionProperty(sb, prop, propAccess, indent, indentLevel, baseHeadingLevel, nestingDepth, fieldLayout);
         }
     }
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -1250,6 +1250,89 @@ public class SerializerTests
     }
 
     [Fact]
+    public void Serialize_ScalarSection_FieldCollectionBeforeSectionsPreservesOrder()
+    {
+        var view = new FieldCollectionBeforeSections
+        {
+            Name = "TestPkg",
+            Summary = [new("Version", "1.0"), new("Type", "Library")],
+            Downloads = 500,
+            Stars = 10
+        };
+        var mdf = MarkoutSerializer.Serialize(view, ScalarSectionTestContext.Default);
+
+        // Summary (non-section field collection) should appear before the Stats section
+        var summaryIdx = mdf.IndexOf("Version: 1.0");
+        var statsIdx = mdf.IndexOf("## Stats");
+        Assert.True(summaryIdx >= 0, "Summary fields should be present");
+        Assert.True(statsIdx >= 0, "Stats section should be present");
+        Assert.True(summaryIdx < statsIdx, "Summary should appear before Stats section");
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_ExcludeAllSections_FieldCollectionStillRenders()
+    {
+        var view = new FieldCollectionBeforeSections
+        {
+            Name = "TestPkg",
+            Summary = [new("Version", "1.0"), new("Type", "Library")],
+            Downloads = 500,
+            Stars = 10
+        };
+        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { ExcludeSections = ["Stats"] });
+        var mdf = context.Serialize(view);
+
+        // Non-section field collection should render even when all sections are excluded
+        Assert.Contains("Version: 1.0", mdf);
+        Assert.Contains("Type: Library", mdf);
+        // Section should be excluded
+        Assert.DoesNotContain("## Stats", mdf);
+        Assert.DoesNotContain("Downloads", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_ExcludeScalarSection_OtherSectionsRender()
+    {
+        var view = new MixedSectionView
+        {
+            Name = "TestPkg",
+            Downloads = 500,
+            Stars = 10,
+            Dependencies = [new SimpleDep { Id = "Dep1", Version = "1.0" }]
+        };
+        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { ExcludeSections = ["Stats"] });
+        var mdf = context.Serialize(view);
+
+        // Scalar section should be excluded
+        Assert.DoesNotContain("## Stats", mdf);
+        Assert.DoesNotContain("Downloads", mdf);
+        // Collection section should still render
+        Assert.Contains("## Dependencies", mdf);
+        Assert.Contains("Dep1", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ScalarSection_IncludeScalarSection_OnlyThatSectionRenders()
+    {
+        var view = new MixedSectionView
+        {
+            Name = "TestPkg",
+            Downloads = 500,
+            Stars = 10,
+            Dependencies = [new SimpleDep { Id = "Dep1", Version = "1.0" }]
+        };
+        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { IncludeSections = ["Stats"] });
+        var mdf = context.Serialize(view);
+
+        // Scalar section should render
+        Assert.Contains("## Stats", mdf);
+        Assert.Contains("Downloads: 500", mdf);
+        // Collection section should be excluded
+        Assert.DoesNotContain("## Dependencies", mdf);
+        Assert.DoesNotContain("Dep1", mdf);
+    }
+
+    [Fact]
     public void Serialize_PartialHooks_OnSerializingAndOnSerializedCalled()
     {
         PackageWithSectionsMarkoutTypeInfo.OnSerializingCalled = false;
@@ -1955,12 +2038,30 @@ public class ScalarSectionLineBreaks
     public long? PackageSize { get; set; }
 }
 
+[MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
+public class FieldCollectionBeforeSections
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    public List<MarkoutField> Summary { get; set; } = [];
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Downloads { get; set; }
+
+    [MarkoutSection(Name = "Stats")]
+    [MarkoutSkipNull]
+    public int? Stars { get; set; }
+}
+
 [MarkoutContext(typeof(PackageWithScalarSection))]
 [MarkoutContext(typeof(MultiSectionView))]
 [MarkoutContext(typeof(MixedSectionView))]
 [MarkoutContext(typeof(ConditionalScalarSection))]
 [MarkoutContext(typeof(FormattedScalarSection))]
 [MarkoutContext(typeof(ScalarSectionLineBreaks))]
+[MarkoutContext(typeof(FieldCollectionBeforeSections))]
 public partial class ScalarSectionTestContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

- Non-section compound properties (e.g. `List<MarkoutField>` without `[MarkoutSection]`) were emitted after all sections instead of in their declaration position
- This caused `MarkoutWriter` section-exclusion state to leak into subsequent non-section output when `ExcludeSections` was set
- Discovered via dotnet-inspect CI: quiet mode excluded all sections, and the `Summary` field collection (declared before sections) was suppressed
- Bumps version to 0.5.1

## New tests

- `FieldCollectionBeforeSectionsPreservesOrder` — non-section field collection renders before sections
- `ExcludeAllSections_FieldCollectionStillRenders` — non-section content survives section exclusion
- `ExcludeScalarSection_OtherSectionsRender` — exclude scalar section, collection section still renders
- `IncludeScalarSection_OnlyThatSectionRenders` — include filter works with scalar sections

## Test plan

- [x] All 236 Markout tests pass
- [x] All 253 dotnet-inspect tests pass (via ProjectReference)
- [x] Smoke: `dotnet-inspect package System.Text.Json 10.0.0 -v:q` renders Summary line

🤖 Generated with [Claude Code](https://claude.com/claude-code)