### PR TITLE
Set package author to Richard Lander

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Authors>Richard Lander</Authors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">

--- a/src/Markout.Demo/Markout.Demo.csproj
+++ b/src/Markout.Demo/Markout.Demo.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>markout-demo</ToolCommandName>
     <VersionPrefix>0.1.1</VersionPrefix>


### PR DESCRIPTION
Adds `<Authors>Richard Lander</Authors>` to `Directory.Build.props` so all packages use the correct author instead of defaulting to the package ID. Removes the duplicate from `Markout.Demo.csproj`.