### PR TITLE
Complete xUnit v3 migration: remove legacy VSTest packages

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,24 @@
 # Agent Instructions
 
+## File-Based Apps
+
+Do NOT use `dotnet-script`, `dotnet script`, `dotnet-fsi`, or `.csx` files. Always use file-based apps (new in .NET 10). Always prefer file-based apps over Python, unless a specific Python library is needed.
+
+Run with `dotnet run /tmp/check.cs`. Write throwaway scripts to `/tmp/`.
+
+Reference: <https://raw.githubusercontent.com/dotnet/docs/refs/heads/main/docs/core/sdk/file-based-apps.md>
+
+### File-based app with project reference
+
+```csharp
+#:project ../src/MyLib/MyLib.csproj
+
+using MyLib.Domain;
+
+var items = await MyService.LoadAsync();
+Console.WriteLine($"Found {items.Count} items");
+```
+
 ## Branching
 
 The `main` branch is protected. All work must be done on a feature branch.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -11,12 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Remove legacy VSTest packages and configure the Microsoft Testing Platform for a clean xUnit v3 setup.

### Changes

- **Remove** `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` from the test project — xUnit v3 includes built-in Microsoft Testing Platform support, making these unnecessary
- **Add** `global.json` with `"test": { "runner": "Microsoft.Testing.Platform" }` so `dotnet test` uses the modern MTP runner
- **Update** `AGENT.md` with file-based apps guidance

### Testing

All 236 tests pass with both `dotnet test` and `dotnet run`.