### PR TITLE
Use xunit v3 self-hosted run pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: dotnet build -c Release -p:OfficialBuild=true --no-restore
 
       - name: Test
-        run: dotnet test -c Release --no-build --verbosity normal
+        run: dotnet run --project tests/Markout.Tests -c Release
 
       - name: Pack
         run: dotnet pack -c Release -p:OfficialBuild=true --no-build

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "test": {
-    "runner": "Microsoft.Testing.Platform"
-  }
-}

--- a/tests/Markout.Tests/BuildResultsTests.cs
+++ b/tests/Markout.Tests/BuildResultsTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/CompileTimeErrorTests.cs
+++ b/tests/Markout.Tests/CompileTimeErrorTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/FormatAttributeTests.cs
+++ b/tests/Markout.Tests/FormatAttributeTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/FormatExamplesTests.cs
+++ b/tests/Markout.Tests/FormatExamplesTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/GeneratedCodeTests.cs
+++ b/tests/Markout.Tests/GeneratedCodeTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Linq;
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/ListRenderingStrategyTests.cs
+++ b/tests/Markout.Tests/ListRenderingStrategyTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
     <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
                       OutputItemType="Analyzer"

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/NullableAndTitleTests.cs
+++ b/tests/Markout.Tests/NullableAndTitleTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/PivotTableTests.cs
+++ b/tests/Markout.Tests/PivotTableTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/RenderingStrategyTests.cs
+++ b/tests/Markout.Tests/RenderingStrategyTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/SectionConstantsTests.cs
+++ b/tests/Markout.Tests/SectionConstantsTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -1,5 +1,4 @@
 using Markout;
-using Xunit;
 
 namespace Markout.Tests;
 


### PR DESCRIPTION
xUnit v3 test projects are executables and can be run directly with `dotnet run` instead of requiring `dotnet test` with MTP runner configuration.

## Changes

- **Remove `global.json`** — MTP runner config is unnecessary with `dotnet run`
- **Add `<Using Include="Xunit" />`** to test csproj as a global using
- **Remove per-file `using Xunit;`** directives from all 13 test files
- **Switch CI** from `dotnet test` to `dotnet run --project`

Aligns with the pattern used in [dotnet-inspect](https://github.com/richlander/dotnet-inspect).