### PR TITLE
Rename shapes for consistency, icon→badge, bump to 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,17 +68,20 @@ jobs:
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli
 
+      - name: Authenticate GitHub Packages
+        run: dotnet nuget update source github-richlander --username richlander --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --configfile nuget.config
+
       - name: Restore
         run: dotnet restore
 
       - name: Build
-        run: dotnet build -c Release -p:OfficialBuild=true -p:ExcludeAnsi=true --no-restore
+        run: dotnet build -c Release -p:OfficialBuild=true --no-restore
 
       - name: Test
-        run: dotnet run --project tests/Markout.Tests -c Release -p:ExcludeAnsi=true
+        run: dotnet run --project tests/Markout.Tests -c Release
 
       - name: Pack
-        run: dotnet pack -c Release -p:OfficialBuild=true -p:ExcludeAnsi=true --no-build
+        run: dotnet pack -c Release -p:OfficialBuild=true --no-build
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,13 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build -c Release -p:OfficialBuild=true --no-restore
+        run: dotnet build -c Release -p:OfficialBuild=true -p:ExcludeAnsi=true --no-restore
 
       - name: Test
-        run: dotnet run --project tests/Markout.Tests -c Release
+        run: dotnet run --project tests/Markout.Tests -c Release -p:ExcludeAnsi=true
 
       - name: Pack
-        run: dotnet pack -c Release -p:OfficialBuild=true --no-build
+        run: dotnet pack -c Release -p:OfficialBuild=true -p:ExcludeAnsi=true --no-build
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,12 +1,12 @@
 # Backlog
 
-## ~~CodeSection — code blocks as section content~~ ✅ Done
+## ~~CodeSection — code regions as section content~~ ✅ Done
 
 ## ~~Callout / Admonition~~ ✅ Done
 
 ## Conditional column visibility
 
-A `CodeSection` record type recognized by the source generator, allowing code blocks
+A `CodeSection` record type recognized by the source generator, allowing code regions
 to appear as properties in serializable types — including inside nested subsection items.
 
 ```csharp
@@ -14,11 +14,11 @@ record CodeSection(string Language, string Content);
 ```
 
 When used as a property on a `[MarkoutSerializable]` type, the generator emits
-`WriteCodeBlockStart(language)` / `WriteParagraph(content)` / `WriteCodeBlockEnd()`.
+`WriteCodeStart(language)` / `WriteParagraph(content)` / `WriteCodeEnd()`.
 
 ### Use case: Constructor overloads in dotnet-inspect
 
-`RenderConstructorEmphasis` manually writes H3 + code block + parameter table per
+`RenderConstructorEmphasis` manually writes H3 + code region + parameter table per
 overload. With CodeSection + nested serializable types, this becomes declarative:
 
 ```csharp
@@ -33,16 +33,16 @@ public class ConstructorOverload
 }
 ```
 
-Also eliminates the repeated Heading + CodeBlock pattern in IL, source, lowered C#,
+Also eliminates the repeated Heading + Code pattern in IL, source, lowered C#,
 and samples rendering (4+ instances in `ApiOutputFormatter`).
 
 ### Implementation notes
 
 - New `PropertyKind.CodeSection` in source generator
 - Add `CodeSection` to `KnownTypeSymbols`
-- Emit `WriteCodeBlockStart`/`WriteParagraph`/`WriteCodeBlockEnd` sequence
-- No new shape flag needed — uses existing `CodeBlocks` shape
-- Also add `List<CodeSection>` recognition for types with multiple code blocks
+- Emit `WriteCodeStart`/`WriteParagraph`/`WriteCodeEnd` sequence
+- No new shape flag needed — uses existing `Code` shape
+- Also add `List<CodeSection>` recognition for types with multiple code regions
 
 ## Conditional column visibility
 

--- a/docs/comparison-report.md
+++ b/docs/comparison-report.md
@@ -336,7 +336,7 @@ public override void Serialize(MarkoutWriter writer, Package value)
         __fields.Add(new MarkoutField("Name", value.Name));
     // ...
     if (__fields.Count > 0)
-        writer.WriteCompactFields(__fields);
+        writer.WriteFieldList(__fields);
     
     // Arrays
     if (value.Frameworks != null)
@@ -375,11 +375,11 @@ if (!string.IsNullOrEmpty(value.Name))
     __fields.Add(new MarkoutField("Name", value.Name));
 ```
 
-**Recommendation:** For types where all scalars are non-nullable value types, emit direct `WriteCompactFields(params ReadOnlySpan<MarkoutField>)` calls:
+**Recommendation:** For types where all scalars are non-nullable value types, emit direct `WriteFieldList(params ReadOnlySpan<MarkoutField>)` calls:
 
 ```csharp
 // Optimized path for all-non-nullable scalars
-writer.WriteCompactFields(
+writer.WriteFieldList(
     new MarkoutField("Count", value.Count.ToString(CultureInfo.InvariantCulture)),
     new MarkoutField("Price", value.Price.ToString(CultureInfo.InvariantCulture)));
 ```
@@ -543,7 +543,7 @@ This would preserve the closed type system while allowing specific extension poi
 
 ```csharp
 // If all scalars are non-nullable non-string, use params overload
-writer.WriteCompactFields(
+writer.WriteFieldList(
     new MarkoutField("Id", value.Id),
     new MarkoutField("Count", value.Count));
 ```
@@ -636,7 +636,7 @@ context.SyntaxProvider
 [MarkoutContextOptions(
     DefaultFieldLayout = FieldLayout.LineBreaks,
     BoldFieldNames = true,
-    IncludeIcons = true)]
+    IncludeBadges = true)]
 [MarkoutContext(typeof(Report))]
 public partial class ReportContext : MarkoutSerializerContext { }
 ```
@@ -648,7 +648,7 @@ This bakes options into generated code, avoiding runtime options objects.
 **Pattern:** LoggerMessage uses `LoggerMessage.Define<>()` for simple cases, custom structs for complex cases.
 
 **Application to Markout:**
-- **Simple types** (all non-nullable scalars, no sections): Emit direct `WriteCompactFields(params ...)` call
+- **Simple types** (all non-nullable scalars, no sections): Emit direct `WriteFieldList(params ...)` call
 - **Complex types** (nullable, sections, nested): Use current List builder pattern
 
 #### 6. Multi-File Emission (from STJ)
@@ -834,7 +834,7 @@ enum PropertyRenderingShape
     TableCell             = 0x02,  // Can render in table column
     TableRows             = 0x04,  // Can render as table (collection of scalars)
     Section               = 0x08,  // Can render as H2+ section
-    CompactField          = 0x10,  // Can render in pipe-separated line
+    FieldList          = 0x10,  // Can render in pipe-separated line
     TreeRenderable        = 0x20,  // Can render as tree structure
     DynamicFields         = 0x40,  // Is List<MarkoutField>
 }
@@ -854,7 +854,7 @@ This pattern keeps code manageable—each generator only needs to know about its
 Stage 1: NullCheck         → if (value == null) return;
 Stage 2: Title             → writer.WriteHeading(1, ...)
 Stage 3: Description       → writer.WriteParagraph(...)
-Stage 4: CompactFields     → writer.WriteCompactFields(...)
+Stage 4: FieldList     → writer.WriteFieldList(...)
 Stage 5: ScalarFields      → writer.WriteField(...) per property
 Stage 6: Sections          → writer.WriteHeading(2, ...) per section
 Stage 7: Collections       → tables, arrays, trees
@@ -1225,8 +1225,8 @@ This pattern cannot be expressed with current Markout attributes.
 | `WriteListItem(text)` | ~15 calls | Bullet items |
 | `WriteArray(label, items)` | ~5 calls | Lists of strings |
 | `WriteTree(nodes)` | 1 call | Assembly reference tree |
-| `WriteCompactFields(fields)` | 1 call | Pipe-separated display |
-| `WriteCodeBlockStart/End` | 2 calls | Code samples |
+| `WriteFieldList(fields)` | 1 call | Pipe-separated display |
+| `WriteCodeStart/End` | 2 calls | Code samples |
 
 The most common operations are conditional (`if (value != null)`) writes of fields and table rows—precisely what the source generator cannot express.
 
@@ -1415,7 +1415,7 @@ Today, `MarkoutWriter` handles some of this ad hoc:
 - `_inTable` state prevents invalid nesting (throws on missing `WriteTableStart`)
 - `_sectionExcluded` suppresses output in excluded sections
 
-But there is **no `_inCodeBlock` tracking**, and no mechanism for a custom formatter to know what context it's writing into.
+But there is **no `_inCode` tracking**, and no mechanism for a custom formatter to know what context it's writing into.
 
 ### Current State in MarkoutWriter
 
@@ -1426,7 +1426,7 @@ private bool _sectionExcluded;  // ✓ Section filtering
 private bool _needsBlankLine;   // ✓ Spacing
 
 // State NOT tracked:
-// _inCodeBlock               // ✗ Code fence context
+// _inCode               // ✗ Code fence context
 // _inListItem                // ✗ List context (indentation)
 // _nestingDepth              // ✗ General nesting
 ```
@@ -1443,7 +1443,7 @@ public enum MarkoutRenderContext
 {
     Block,       // Top-level or section body — anything is valid
     Table,       // Inside a table — no block elements, pipes escaped
-    CodeBlock,   // Inside a code fence — content is literal, no Markdown
+    Code,   // Inside a code fence — content is literal, no Markdown
     InlineCode,  // Inside backticks — content is literal
     ListItem,    // Inside a list item — block elements need indentation
 }
@@ -1452,12 +1452,12 @@ public sealed class MarkoutWriter
 {
     public MarkoutRenderContext CurrentContext { get; private set; }
 
-    public void WriteCodeBlockStart(string? language = null)
+    public void WriteCodeStart(string? language = null)
     {
-        if (CurrentContext == MarkoutRenderContext.CodeBlock)
+        if (CurrentContext == MarkoutRenderContext.Code)
             throw new InvalidOperationException("Cannot nest code fences.");
         // ...
-        CurrentContext = MarkoutRenderContext.CodeBlock;
+        CurrentContext = MarkoutRenderContext.Code;
     }
 }
 ```
@@ -1510,10 +1510,10 @@ The source generator knows at compile time whether a property appears in a table
 For the code-fence-in-code-fence problem specifically, the writer could use longer fence sequences (Markdown supports ``````, etc.):
 
 ```csharp
-public void WriteCodeBlockStart(string? language = null)
+public void WriteCodeStart(string? language = null)
 {
     // If already in a code block, use a longer fence
-    var fence = CurrentContext == MarkoutRenderContext.CodeBlock
+    var fence = CurrentContext == MarkoutRenderContext.Code
         ? "````" : "```";
     // ...
 }
@@ -1525,7 +1525,7 @@ However, this only solves one specific case and doesn't generalize.
 
 **Combine Approaches 1 and 2:**
 
-1. **Track context in `MarkoutWriter`** — add `CurrentContext` property and `_inCodeBlock` state. This is a small, backwards-compatible change that immediately prevents invalid nesting for all callers (not just custom formatters).
+1. **Track context in `MarkoutWriter`** — add `CurrentContext` property and `_inCode` state. This is a small, backwards-compatible change that immediately prevents invalid nesting for all callers (not just custom formatters).
 
 2. **Design `IMarkoutFormattable` to write through the writer** — not return strings. This is the key insight from STJ's `Utf8JsonWriter`/`JsonConverter` design: the writer is the enforcement boundary.
 
@@ -1595,7 +1595,7 @@ The internal naming (`scalarProps`, `IsScalarKind`) is acceptable — it correct
 | `FieldLayout` | (keep) | Already correct — it describes how a field list is laid out |
 | `MarkoutField` | (keep) | Good name — suggests KVP |
 | `EmitScalarsWithLayout` | `EmitFieldListWithLayout` | Internal, but clearer intent |
-| `WriteCompactFields` | (keep) | Describes the `OneLine` layout rendering |
+| `WriteFieldList` | (keep) | Describes the `OneLine` layout rendering |
 | `WriteField` | (keep) | Describes the `LineBreaksDoubleSpace` layout (one field at a time) |
 | `WriteFieldNoBreak` | (keep) | Describes the `LineBreaks` layout |
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -896,10 +896,10 @@ writer.WriteTableRow("Widget B", "Electronics", "$49.99");
 writer.WriteTableEnd();
 ```
 
-### Compact Fields
+### Field List
 
 ```csharp
-writer.WriteCompactFields(
+writer.WriteFieldList(
     new MarkoutField("Name", "Widget"),
     new MarkoutField("Price", "$29.99"),
     new MarkoutField("Stock", "Yes")
@@ -907,12 +907,12 @@ writer.WriteCompactFields(
 // Name: Widget | Price: $29.99 | Stock: Yes
 ```
 
-### Code Blocks
+### Code
 
 ```csharp
-writer.WriteCodeBlockStart("json");
+writer.WriteCodeStart("json");
 writer.WriteParagraph("{ \"key\": \"value\" }");
-writer.WriteCodeBlockEnd();
+writer.WriteCodeEnd();
 ```
 
 > From the [WriterUsage](../samples/Serialization/WriterUsage.cs) sample.
@@ -923,7 +923,7 @@ writer.WriteCodeBlockEnd();
 |-----------|--------|---------|
 | `[MarkoutSerializable]` | Class/Struct | **Optional.** Customizes type serialization. Properties: `TitleProperty`, `TitleContextProperty`, `DescriptionProperty`, `AutoFields`, `FieldLayout`. Not needed for simple types — registration via `[MarkoutContext]` is sufficient. |
 | `[MarkoutContext(typeof(T))]` | Context class | **Required.** Registers a type with a serializer context. Apply multiple times for multiple types. |
-| `[MarkoutContextOptions]` | Context class | Sets default options on a context. Properties: `BoldFieldNames`, `IncludeIcons`, `IncludeDescription`, `SuppressTableWarnings`. |
+| `[MarkoutContextOptions]` | Context class | Sets default options on a context. Properties: `BoldFieldNames`, `IncludeBadges`, `IncludeDescription`, `SuppressTableWarnings`. |
 | `[MarkoutPropertyName("...")]` | Property | Sets the display name for a field or column. |
 | `[MarkoutIgnore]` | Property | Excludes the property from all output. |
 | `[MarkoutIgnoreInTable]` | Property | Excludes the property in table context only. |

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="github-richlander" value="https://nuget.pkg.github.com/richlander/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Markout.Ansi.Spectre/SpectreWriter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreWriter.cs
@@ -206,15 +206,15 @@ public class SpectreWriter : MarkoutWriter
         HasContent = true;
     }
 
-    // ── Code blocks ──
+    // ── Code ──
 
     /// <inheritdoc/>
-    public override void WriteCodeBlockStart(string? language = null)
+    public override void WriteCodeStart(string? language = null)
     {
-        if (InCodeBlock)
-            throw new InvalidOperationException("Cannot nest code blocks. End the current code block before starting a new one.");
+        if (InCode)
+            throw new InvalidOperationException("Cannot nest code regions. End the current code region before starting a new one.");
 
-        InCodeBlock = true;
+        InCode = true;
 
         if (SectionExcluded)
             return;
@@ -224,12 +224,12 @@ public class SpectreWriter : MarkoutWriter
     }
 
     /// <inheritdoc/>
-    public override void WriteCodeBlockEnd()
+    public override void WriteCodeEnd()
     {
-        if (!InCodeBlock)
-            throw new InvalidOperationException("Cannot end a code block without starting one first.");
+        if (!InCode)
+            throw new InvalidOperationException("Cannot end a code region without starting one first.");
 
-        InCodeBlock = false;
+        InCode = false;
 
         if (SectionExcluded)
             return;
@@ -349,10 +349,10 @@ public class SpectreWriter : MarkoutWriter
         HasContent = true;
     }
 
-    // ── Compact fields ──
+    // ── Field list ──
 
     /// <inheritdoc/>
-    public override void WriteCompactFields(params MarkoutField[] fields)
+    public override void WriteFieldList(params MarkoutField[] fields)
     {
         if (SectionExcluded || fields.Length == 0)
             return;
@@ -374,7 +374,7 @@ public class SpectreWriter : MarkoutWriter
     }
 
     /// <inheritdoc/>
-    public override void WriteCompactFields(IReadOnlyList<MarkoutField> fields)
+    public override void WriteFieldList(IReadOnlyList<MarkoutField> fields)
     {
         if (SectionExcluded || fields.Count == 0)
             return;
@@ -392,20 +392,6 @@ public class SpectreWriter : MarkoutWriter
 
         _console.WriteLine();
         NeedsBlankLine = true;
-        HasContent = true;
-    }
-
-    // ── Simple pairs ──
-
-    /// <inheritdoc/>
-    public override void WriteSimplePair(string name, string value, int nameWidth = 32)
-    {
-        if (SectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        WriteMarkup($"[grey]{Esc(name.PadRight(nameWidth))}[/]");
-        _console.WriteLine(value);
         HasContent = true;
     }
 
@@ -562,19 +548,19 @@ public class SpectreWriter : MarkoutWriter
         // Dim box-drawing characters
         WriteMarkup($"[grey]{Esc(prefix)}{Esc(isLast ? "└─ " : "├─ ")}[/]");
 
-        // Icon
-        if (node.Icon != null && Options.IncludeIcons)
+        // Badge
+        if (node.Badge != null && Options.IncludeBadges)
         {
-            _console.Write(new Text(node.Icon + " "));
+            _console.Write(new Text(node.Badge + " "));
         }
 
-        // Label colored by depth
+        // Text colored by depth
         if (depth == 0)
-            WriteMarkupLine($"[bold cyan]{Esc(node.Label)}[/]");
+            WriteMarkupLine($"[bold cyan]{Esc(node.Text)}[/]");
         else if (depth == 1)
-            _console.WriteLine(node.Label);
+            _console.WriteLine(node.Text);
         else
-            WriteMarkupLine($"[grey]{Esc(node.Label)}[/]");
+            WriteMarkupLine($"[grey]{Esc(node.Text)}[/]");
 
         HasContent = true;
 

--- a/src/Markout.Ansi/AnsiWriter.cs
+++ b/src/Markout.Ansi/AnsiWriter.cs
@@ -207,15 +207,15 @@ public class AnsiWriter : MarkoutWriter
         HasContent = true;
     }
 
-    // ── Code blocks ──
+    // ── Code ──
 
     /// <inheritdoc/>
-    public override void WriteCodeBlockStart(string? language = null)
+    public override void WriteCodeStart(string? language = null)
     {
-        if (InCodeBlock)
-            throw new InvalidOperationException("Cannot nest code blocks. End the current code block before starting a new one.");
+        if (InCode)
+            throw new InvalidOperationException("Cannot nest code regions. End the current code region before starting a new one.");
 
-        InCodeBlock = true;
+        InCode = true;
 
         if (SectionExcluded)
             return;
@@ -226,12 +226,12 @@ public class AnsiWriter : MarkoutWriter
     }
 
     /// <inheritdoc/>
-    public override void WriteCodeBlockEnd()
+    public override void WriteCodeEnd()
     {
-        if (!InCodeBlock)
-            throw new InvalidOperationException("Cannot end a code block without starting one first.");
+        if (!InCode)
+            throw new InvalidOperationException("Cannot end a code region without starting one first.");
 
-        InCodeBlock = false;
+        InCode = false;
 
         if (SectionExcluded)
             return;
@@ -362,10 +362,10 @@ public class AnsiWriter : MarkoutWriter
         HasContent = true;
     }
 
-    // ── Compact fields ──
+    // ── Field list ──
 
     /// <inheritdoc/>
-    public override void WriteCompactFields(params MarkoutField[] fields)
+    public override void WriteFieldList(params MarkoutField[] fields)
     {
         if (SectionExcluded || fields.Length == 0)
             return;
@@ -392,7 +392,7 @@ public class AnsiWriter : MarkoutWriter
     }
 
     /// <inheritdoc/>
-    public override void WriteCompactFields(IReadOnlyList<MarkoutField> fields)
+    public override void WriteFieldList(IReadOnlyList<MarkoutField> fields)
     {
         if (SectionExcluded || fields.Count == 0)
             return;
@@ -415,22 +415,6 @@ public class AnsiWriter : MarkoutWriter
 
         Writer.WriteLine();
         NeedsBlankLine = true;
-        HasContent = true;
-    }
-
-    // ── Simple pairs ──
-
-    /// <inheritdoc/>
-    public override void WriteSimplePair(string name, string value, int nameWidth = 32)
-    {
-        if (SectionExcluded)
-            return;
-
-        EnsureBlankLineIfNeeded();
-        _terminal.SetColor(TerminalColor.DarkGray);
-        Writer.Write(name.PadRight(nameWidth));
-        _terminal.ResetColor();
-        Writer.WriteLine(value);
         HasContent = true;
     }
 
@@ -637,27 +621,27 @@ public class AnsiWriter : MarkoutWriter
         Writer.Write(isLast ? "└─ " : "├─ ");
         _terminal.ResetColor();
 
-        // Icon (as-is) + label colored by depth
-        if (node.Icon != null && Options.IncludeIcons)
+        // Badge (as-is) + text colored by depth
+        if (node.Badge != null && Options.IncludeBadges)
         {
-            Writer.Write(node.Icon);
+            Writer.Write(node.Badge);
             Writer.Write(' ');
         }
 
         if (depth == 0)
         {
             _terminal.SetColor(TerminalColor.Cyan);
-            Writer.WriteLine(AnsiCodes.MakeBold(node.Label));
+            Writer.WriteLine(AnsiCodes.MakeBold(node.Text));
             _terminal.ResetColor();
         }
         else if (depth == 1)
         {
-            Writer.WriteLine(node.Label);
+            Writer.WriteLine(node.Text);
         }
         else
         {
             _terminal.SetColor(TerminalColor.DarkGray);
-            Writer.WriteLine(node.Label);
+            Writer.WriteLine(node.Text);
             _terminal.ResetColor();
         }
 

--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -161,9 +161,9 @@ public static class Demos
         writer.WriteParagraph("This demo shows `List<List<T>>` rendered as a tree. Each shoe shows its reviews, which would be unsupported in table format.");
         
         writer.WriteHeading(2, "Products with Reviews");
-        writer.WriteCodeBlockStart();
+        writer.WriteCodeStart();
         writer.WriteTree(tree);
-        writer.WriteCodeBlockEnd();
+        writer.WriteCodeEnd();
         writer.Flush();
     }
 }

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -133,7 +133,7 @@ internal static class FieldEmitter
             sb.AppendLine($"{indent}{{");
             if (sectionHeading != null)
                 sb.AppendLine($"{indent}    writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
-            sb.AppendLine($"{indent}    writer.WriteCompactFields({fieldsVar});");
+            sb.AppendLine($"{indent}    writer.WriteFieldList({fieldsVar});");
             sb.AppendLine($"{indent}}}");
         }
         else
@@ -150,7 +150,7 @@ internal static class FieldEmitter
 
             if (sectionHeading != null)
                 sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
-            sb.AppendLine($"{indent}writer.WriteCompactFields({string.Join(", ", fields)});");
+            sb.AppendLine($"{indent}writer.WriteFieldList({string.Join(", ", fields)});");
         }
     }
 

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -138,15 +138,15 @@ internal static class SerializerEmitter
         sb.AppendLine("{");
 
         // Constructor accepting options
-        if (context.BoldFieldNames != null || context.IncludeIcons != null || context.IncludeDescription != null)
+        if (context.BoldFieldNames != null || context.IncludeBadges != null || context.IncludeDescription != null)
         {
             // Generate default constructor that applies compile-time options
             sb.AppendLine($"    public {context.ClassName}() : base(new global::Markout.MarkoutWriterOptions");
             sb.AppendLine("    {");
             if (context.BoldFieldNames != null)
                 sb.AppendLine($"        BoldFieldNames = {(context.BoldFieldNames.Value ? "true" : "false")},");
-            if (context.IncludeIcons != null)
-                sb.AppendLine($"        IncludeIcons = {(context.IncludeIcons.Value ? "true" : "false")},");
+            if (context.IncludeBadges != null)
+                sb.AppendLine($"        IncludeBadges = {(context.IncludeBadges.Value ? "true" : "false")},");
             if (context.IncludeDescription != null)
                 sb.AppendLine($"        IncludeDescription = {(context.IncludeDescription.Value ? "true" : "false")},");
             sb.AppendLine("    }) { }");
@@ -569,9 +569,9 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}if ({propAccess}.Content != null)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteHeading({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
-            sb.AppendLine($"{indent}    writer.WriteCodeBlockStart({propAccess}.Language);");
+            sb.AppendLine($"{indent}    writer.WriteCodeStart({propAccess}.Language);");
             sb.AppendLine($"{indent}    writer.WriteParagraph({propAccess}.Content);");
-            sb.AppendLine($"{indent}    writer.WriteCodeBlockEnd();");
+            sb.AppendLine($"{indent}    writer.WriteCodeEnd();");
             sb.AppendLine($"{indent}}}");
         }
         else if (prop.Kind == PropertyKind.NestedObject && prop.ElementProperties != null)
@@ -616,7 +616,7 @@ internal static class SerializerEmitter
 
             case PropertyKind.FieldCollection:
                 sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                sb.AppendLine($"{indent}    writer.WriteCompactFields({propAccess});");
+                sb.AppendLine($"{indent}    writer.WriteFieldList({propAccess});");
                 break;
 
             case PropertyKind.Tree:
@@ -637,9 +637,9 @@ internal static class SerializerEmitter
             case PropertyKind.CodeSection:
                 sb.AppendLine($"{indent}if ({propAccess}.Content != null)");
                 sb.AppendLine($"{indent}{{");
-                sb.AppendLine($"{indent}    writer.WriteCodeBlockStart({propAccess}.Language);");
+                sb.AppendLine($"{indent}    writer.WriteCodeStart({propAccess}.Language);");
                 sb.AppendLine($"{indent}    writer.WriteParagraph({propAccess}.Content);");
-                sb.AppendLine($"{indent}    writer.WriteCodeBlockEnd();");
+                sb.AppendLine($"{indent}    writer.WriteCodeEnd();");
                 sb.AppendLine($"{indent}}}");
                 break;
 
@@ -867,13 +867,13 @@ internal static class SerializerEmitter
             PropertyKind.ComplexArray => prop.ElementHasNestedContent 
                 ? "Subsections" 
                 : "Table",
-            PropertyKind.FieldCollection => "Compact fields",
+            PropertyKind.FieldCollection => "Field list",
             PropertyKind.NestedObject => "Fields",
             PropertyKind.Formattable => "Custom (IMarkoutFormattable)",
             PropertyKind.Tree => "Tree",
             PropertyKind.BarChart => "Bar chart",
             PropertyKind.LabeledList => "Labeled list",
-            PropertyKind.CodeSection => "Code block",
+            PropertyKind.CodeSection => "Code",
             PropertyKind.Callout => "Callout",
             PropertyKind.Distribution => "Distribution chart",
             _ => "Field"

--- a/src/Markout.SourceGeneration/Parser/ContextMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/ContextMetadata.cs
@@ -12,19 +12,19 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
     public string ClassName { get; }
     public IReadOnlyList<TypeMetadata> Types { get; }
     public bool? BoldFieldNames { get; }
-    public bool? IncludeIcons { get; }
+    public bool? IncludeBadges { get; }
     public bool? IncludeDescription { get; }
     public bool SuppressTableWarnings { get; }
 
     public ContextMetadata(string @namespace, string className, IReadOnlyList<TypeMetadata> types,
-        bool? boldFieldNames = null, bool? includeIcons = null, bool? includeDescription = null,
+        bool? boldFieldNames = null, bool? includeBadges = null, bool? includeDescription = null,
         bool suppressTableWarnings = false)
     {
         Namespace = @namespace;
         ClassName = className;
         Types = types;
         BoldFieldNames = boldFieldNames;
-        IncludeIcons = includeIcons;
+        IncludeBadges = includeBadges;
         IncludeDescription = includeDescription;
         SuppressTableWarnings = suppressTableWarnings;
     }
@@ -36,7 +36,7 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
         return Namespace == other.Namespace &&
                ClassName == other.ClassName &&
                BoldFieldNames == other.BoldFieldNames &&
-               IncludeIcons == other.IncludeIcons &&
+               IncludeBadges == other.IncludeBadges &&
                IncludeDescription == other.IncludeDescription &&
                SuppressTableWarnings == other.SuppressTableWarnings &&
                SequenceEqual(Types, other.Types);
@@ -49,7 +49,7 @@ internal sealed class ContextMetadata : IEquatable<ContextMetadata>
         {
             var hash = (Namespace?.GetHashCode() ?? 0) * 397 ^ (ClassName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (BoldFieldNames?.GetHashCode() ?? 0);
-            hash = hash * 397 ^ (IncludeIcons?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (IncludeBadges?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (IncludeDescription?.GetHashCode() ?? 0);
             hash = hash * 397 ^ SuppressTableWarnings.GetHashCode();
             foreach (var type in Types)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -47,7 +47,7 @@ internal static class TypeParser
 
         // Parse [MarkoutContextOptions] attribute (before processing types, as options affect type parsing)
         bool? boldFieldNames = null;
-        bool? includeIcons = null;
+        bool? includeBadges = null;
         bool? includeDescription = null;
         bool suppressTableWarnings = false;
         var optionsAttr = classSymbol.GetAttributes()
@@ -58,8 +58,8 @@ internal static class TypeParser
             {
                 if (named.Key == "BoldFieldNames" && named.Value.Value is bool bf)
                     boldFieldNames = bf;
-                else if (named.Key == "IncludeIcons" && named.Value.Value is bool ii)
-                    includeIcons = ii;
+                else if (named.Key == "IncludeBadges" && named.Value.Value is bool ii)
+                    includeBadges = ii;
                 else if (named.Key == "IncludeDescription" && named.Value.Value is bool id)
                     includeDescription = id;
                 else if (named.Key == "SuppressTableWarnings" && named.Value.Value is bool stw)
@@ -83,7 +83,7 @@ internal static class TypeParser
             ? string.Empty
             : classSymbol.ContainingNamespace.ToDisplayString();
 
-        return new ContextMetadata(ns, classSymbol.Name, types, boldFieldNames, includeIcons, includeDescription, suppressTableWarnings);
+        return new ContextMetadata(ns, classSymbol.Name, types, boldFieldNames, includeBadges, includeDescription, suppressTableWarnings);
     }
 
     private static TypeMetadata? ParseTypeSymbol(
@@ -450,7 +450,7 @@ internal static class TypeParser
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.DateTimeOffset))
             return (PropertyKind.DateTimeOffset, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
 
-        // CodeSection type - renders as code block
+        // CodeSection type - renders as code region
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.CodeSection))
             return (PropertyKind.CodeSection, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
 

--- a/src/Markout/Attributes/MarkoutContextOptionsAttribute.cs
+++ b/src/Markout/Attributes/MarkoutContextOptionsAttribute.cs
@@ -8,7 +8,7 @@ namespace Markout;
 /// </summary>
 /// <example>
 ///   <code>
-///   [MarkoutContextOptions(BoldFieldNames = true, IncludeIcons = false)]
+///   [MarkoutContextOptions(BoldFieldNames = true, IncludeBadges = false)]
 ///   [MarkoutContext(typeof(MyType))]
 ///   public partial class MyContext : MarkoutSerializerContext { }
 ///   </code>
@@ -23,10 +23,10 @@ public sealed class MarkoutContextOptionsAttribute : Attribute
     public bool BoldFieldNames { get; set; }
 
     /// <summary>
-    /// Gets or sets whether to include icons in tree nodes.
+    /// Gets or sets whether to include badges in tree nodes.
     /// Default is true.
     /// </summary>
-    public bool IncludeIcons { get; set; } = true;
+    public bool IncludeBadges { get; set; } = true;
 
     /// <summary>
     /// Gets or sets whether to include the description paragraph.

--- a/src/Markout/CodeSection.cs
+++ b/src/Markout/CodeSection.cs
@@ -1,10 +1,10 @@
 namespace Markout;
 
 /// <summary>
-/// Represents a code block with a language identifier and content.
+/// Represents a code region with a language identifier and content.
 /// Recognized by the source generator as a property type that emits
-/// <see cref="MarkoutWriter.WriteCodeBlockStart"/>/<see cref="MarkoutWriter.WriteCodeBlockEnd"/> sequences.
+/// <see cref="MarkoutWriter.WriteCodeStart"/>/<see cref="MarkoutWriter.WriteCodeEnd"/> sequences.
 /// </summary>
-/// <param name="Language">The language identifier (e.g., "csharp", "json"). Null for plain code blocks.</param>
+/// <param name="Language">The language identifier (e.g., "csharp", "json"). Null for plain code regions.</param>
 /// <param name="Content">The code content.</param>
 public readonly record struct CodeSection(string? Language, string Content);

--- a/src/Markout/MarkdownWriter.cs
+++ b/src/Markout/MarkdownWriter.cs
@@ -5,7 +5,7 @@ namespace Markout;
 /// <summary>
 /// A MarkoutWriter that renders output as Markdown.
 /// Produces # headings, **bold** field names, | pipe tables |, - bullet lists,
-/// ``` code blocks, and trailing double-space hard line breaks.
+/// ``` code regions, and trailing double-space hard line breaks.
 /// </summary>
 public class MarkdownWriter : MarkoutWriter
 {
@@ -143,14 +143,14 @@ public class MarkdownWriter : MarkoutWriter
     }
 
     /// <inheritdoc/>
-    public override void WriteCodeBlockStart(string? language = null)
+    public override void WriteCodeStart(string? language = null)
     {
-        if (InCodeBlock)
-            throw new InvalidOperationException("Cannot nest code blocks. End the current code block before starting a new one.");
+        if (InCode)
+            throw new InvalidOperationException("Cannot nest code regions. End the current code region before starting a new one.");
 
         if (SectionExcluded)
         {
-            InCodeBlock = true;
+            InCode = true;
             return;
         }
 
@@ -159,17 +159,17 @@ public class MarkdownWriter : MarkoutWriter
         if (!string.IsNullOrEmpty(language))
             Writer.Write(language);
         Writer.WriteLine();
-        InCodeBlock = true;
+        InCode = true;
         HasContent = true;
     }
 
     /// <inheritdoc/>
-    public override void WriteCodeBlockEnd()
+    public override void WriteCodeEnd()
     {
-        if (!InCodeBlock)
-            throw new InvalidOperationException("Cannot end a code block without starting one first.");
+        if (!InCode)
+            throw new InvalidOperationException("Cannot end a code region without starting one first.");
 
-        InCodeBlock = false;
+        InCode = false;
 
         if (SectionExcluded)
             return;

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.5.1</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutRenderContext.cs
+++ b/src/Markout/MarkoutRenderContext.cs
@@ -13,13 +13,13 @@ public enum MarkoutRenderContext
 
     /// <summary>
     /// Inside a table. Only inline content and escaped values are valid.
-    /// Block-level elements (headings, code blocks, lists) are not allowed.
+    /// Block-level elements (headings, code regions, lists) are not allowed.
     /// </summary>
     Table,
 
     /// <summary>
-    /// Inside a fenced code block. Content is rendered literally, not as Markdown.
-    /// Nested code fences are not allowed.
+    /// Inside a code region. Content is rendered literally, not as Markdown.
+    /// Nested code regions are not allowed.
     /// </summary>
-    CodeBlock
+    Code
 }

--- a/src/Markout/MarkoutShape.cs
+++ b/src/Markout/MarkoutShape.cs
@@ -20,8 +20,8 @@ public enum MarkoutShape
     /// <summary>Key-value fields (scalar and formatted).</summary>
     Fields = 4,
 
-    /// <summary>Compact multi-field layout.</summary>
-    CompactFields = 8,
+    /// <summary>Multi-field summary line.</summary>
+    FieldList = 8,
 
     /// <summary>Tables (streaming and batch).</summary>
     Tables = 16,
@@ -32,11 +32,8 @@ public enum MarkoutShape
     /// <summary>Tree structures (TreeNode hierarchies).</summary>
     Trees = 64,
 
-    /// <summary>Code blocks (fenced regions).</summary>
-    CodeBlocks = 128,
-
-    /// <summary>Simple name-value pairs.</summary>
-    SimplePairs = 256,
+    /// <summary>Code regions.</summary>
+    Code = 128,
 
     /// <summary>Horizontal bar charts.</summary>
     BarCharts = 512,
@@ -51,5 +48,5 @@ public enum MarkoutShape
     Distributions = 4096,
 
     /// <summary>All shapes supported.</summary>
-    All = Headings | Paragraphs | Fields | CompactFields | Tables | Lists | Trees | CodeBlocks | SimplePairs | BarCharts | LabeledLists | Callouts | Distributions
+    All = Headings | Paragraphs | Fields | FieldList | Tables | Lists | Trees | Code | BarCharts | LabeledLists | Callouts | Distributions
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -22,7 +22,7 @@ public class MarkoutWriter
     private bool _needsBlankLine;
     private bool _hasContent;
     private bool _inTable;
-    private bool _inCodeBlock;
+    private bool _inCode;
     private string? _currentSectionName;
     private bool _sectionExcluded;
     private int _tableRowCount;
@@ -102,9 +102,9 @@ public class MarkoutWriter
     public bool IncludeDescription => _options.IncludeDescription;
 
     /// <summary>
-    /// Gets whether to include icons in tree nodes.
+    /// Gets whether to include badges in tree nodes.
     /// </summary>
-    public bool IncludeIcons => _options.IncludeIcons;
+    public bool IncludeBadges => _options.IncludeBadges;
 
     /// <summary>
     /// Gets the shapes this writer supports. Unsupported shapes produce a
@@ -116,7 +116,7 @@ public class MarkoutWriter
     /// Gets the current rendering context, indicating what Markdown constructs are valid.
     /// </summary>
     public MarkoutRenderContext CurrentContext =>
-        _inCodeBlock ? MarkoutRenderContext.CodeBlock :
+        _inCode ? MarkoutRenderContext.Code :
         _inTable ? MarkoutRenderContext.Table :
         MarkoutRenderContext.Block;
 
@@ -146,9 +146,9 @@ public class MarkoutWriter
     protected bool InTable { get => _inTable; set => _inTable = value; }
 
     /// <summary>
-    /// Gets or sets whether output is currently inside a code block.
+    /// Gets or sets whether output is currently inside a code region.
     /// </summary>
-    protected bool InCodeBlock { get => _inCodeBlock; set => _inCodeBlock = value; }
+    protected bool InCode { get => _inCode; set => _inCode = value; }
 
     /// <summary>
     /// Gets whether the current section is excluded by filtering.
@@ -311,17 +311,17 @@ public class MarkoutWriter
     }
 
     /// <summary>
-    /// Starts a code block with optional language specifier.
+    /// Starts a code region with optional language specifier.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if already inside a code block.</exception>
-    public virtual void WriteCodeBlockStart(string? language = null)
+    /// <exception cref="InvalidOperationException">Thrown if already inside a code region.</exception>
+    public virtual void WriteCodeStart(string? language = null)
     {
-        if (_inCodeBlock)
-            throw new InvalidOperationException("Cannot nest code blocks. End the current code block before starting a new one.");
+        if (_inCode)
+            throw new InvalidOperationException("Cannot nest code regions. End the current code region before starting a new one.");
 
-        _inCodeBlock = true;
+        _inCode = true;
 
-        if (_sectionExcluded || ShapeUnsupported(MarkoutShape.CodeBlocks))
+        if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Code))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -329,15 +329,15 @@ public class MarkoutWriter
     }
 
     /// <summary>
-    /// Ends a code block.
+    /// Ends a code region.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if not inside a code block.</exception>
-    public virtual void WriteCodeBlockEnd()
+    /// <exception cref="InvalidOperationException">Thrown if not inside a code region.</exception>
+    public virtual void WriteCodeEnd()
     {
-        if (!_inCodeBlock)
-            throw new InvalidOperationException("Cannot end a code block without starting one first.");
+        if (!_inCode)
+            throw new InvalidOperationException("Cannot end a code region without starting one first.");
 
-        _inCodeBlock = false;
+        _inCode = false;
 
         if (_sectionExcluded)
             return;
@@ -464,16 +464,16 @@ public class MarkoutWriter
     /// <param name="fields">Fields to write.</param>
     /// <example>
     /// <code>
-    /// writer.WriteCompactFields(
+    /// writer.WriteFieldList(
     ///     new MarkoutField("Type", "Library"),
     ///     new MarkoutField("TFM", "net8.0"),
     ///     new MarkoutField("Updated", "2026-01-15"));
     /// // Output: Type: Library | TFM: net8.0 | Updated: 2026-01-15
     /// </code>
     /// </example>
-    public virtual void WriteCompactFields(params MarkoutField[] fields)
+    public virtual void WriteFieldList(params MarkoutField[] fields)
     {
-        if (_sectionExcluded || fields.Length == 0 || ShapeUnsupported(MarkoutShape.CompactFields))
+        if (_sectionExcluded || fields.Length == 0 || ShapeUnsupported(MarkoutShape.FieldList))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -497,9 +497,9 @@ public class MarkoutWriter
     /// Useful for compact summary lines with essential metadata.
     /// </summary>
     /// <param name="fields">Fields to write.</param>
-    public virtual void WriteCompactFields(IReadOnlyList<MarkoutField> fields)
+    public virtual void WriteFieldList(IReadOnlyList<MarkoutField> fields)
     {
-        if (_sectionExcluded || fields.Count == 0 || ShapeUnsupported(MarkoutShape.CompactFields))
+        if (_sectionExcluded || fields.Count == 0 || ShapeUnsupported(MarkoutShape.FieldList))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -592,8 +592,8 @@ public class MarkoutWriter
     /// </summary>
     public virtual void WriteTableStart(params string[] headers)
     {
-        if (_inCodeBlock)
-            throw new InvalidOperationException("Cannot start a table inside a code block.");
+        if (_inCode)
+            throw new InvalidOperationException("Cannot start a table inside a code region.");
 
         _inTable = true;
         _tableRowCount = 0;
@@ -769,20 +769,6 @@ public class MarkoutWriter
     }
 
     /// <summary>
-    /// Writes a simple pair (two values separated by whitespace).
-    /// </summary>
-    public virtual void WriteSimplePair(string name, string value, int nameWidth = 32)
-    {
-        if (_sectionExcluded || ShapeUnsupported(MarkoutShape.SimplePairs))
-            return;
-
-        EnsureBlankLineIfNeeded();
-        _writer.Write(name.PadRight(nameWidth));
-        _writer.WriteLine(value);
-        _hasContent = true;
-    }
-
-    /// <summary>
     /// Writes a tree node with optional prefix for hierarchy.
     /// </summary>
     /// <param name="text">The node text.</param>
@@ -821,12 +807,12 @@ public class MarkoutWriter
         EnsureBlankLineIfNeeded();
         _writer.Write(prefix);
         _writer.Write(isLast ? "└─ " : "├─ ");
-        if (node.Icon != null && _options.IncludeIcons)
+        if (node.Badge != null && _options.IncludeBadges)
         {
-            _writer.Write(node.Icon);
+            _writer.Write(node.Badge);
             _writer.Write(' ');
         }
-        _writer.WriteLine(node.Label);
+        _writer.WriteLine(node.Text);
         _hasContent = true;
         
         if (node.Children != null && node.Children.Count > 0)

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -6,7 +6,7 @@ namespace Markout;
 public class MarkoutWriterOptions
 {
     private bool _isReadOnly;
-    private bool _includeIcons = true;
+    private bool _includeBadges = true;
     private bool _includeDescription = true;
     private bool _boldFieldNames;
     private bool _prettyTables;
@@ -27,15 +27,15 @@ public class MarkoutWriterOptions
     }
 
     /// <summary>
-    /// Whether to include icons in tree nodes. Default is true.
+    /// Whether to include badges in tree nodes. Default is true.
     /// </summary>
-    public bool IncludeIcons
+    public bool IncludeBadges
     {
-        get => _includeIcons;
+        get => _includeBadges;
         set
         {
             ThrowIfReadOnly();
-            _includeIcons = value;
+            _includeBadges = value;
         }
     }
 

--- a/src/Markout/OneLineWriter.cs
+++ b/src/Markout/OneLineWriter.cs
@@ -3,7 +3,7 @@ namespace Markout;
 /// <summary>
 /// A writer that produces compact columnar output (docker-style).
 /// Tables use space-padded columns with uppercase headers.
-/// Suppresses headings, fields, paragraphs, and code blocks.
+/// Suppresses headings, fields, paragraphs, and code.
 /// </summary>
 public class OneLineWriter : MarkoutWriter
 {

--- a/src/Markout/TreeNode.cs
+++ b/src/Markout/TreeNode.cs
@@ -12,67 +12,67 @@ public class TreeNode
     /// <summary>
     /// The display text for this node.
     /// </summary>
-    public string Label { get; set; }
-    
+    public string Text { get; set; }
+
     /// <summary>
-    /// Optional icon to display before the label (e.g., "📁", "🚢").
+    /// Optional badge to display before the text (e.g., "📁", "🚢").
     /// </summary>
-    public string? Icon { get; set; }
-    
+    public string? Badge { get; set; }
+
     /// <summary>
     /// Child nodes, if any.
     /// </summary>
     public List<TreeNode>? Children { get; set; }
-    
+
     /// <summary>
     /// Creates a tree node with an optional list of children.
     /// </summary>
-    public TreeNode(string label, IEnumerable<TreeNode>? children = null)
+    public TreeNode(string text, IEnumerable<TreeNode>? children = null)
     {
-        Label = label;
+        Text = text;
         Children = children?.ToList();
     }
-    
+
     /// <summary>
-    /// Creates a tree node with an icon and optional list of children.
+    /// Creates a tree node with a badge and optional list of children.
     /// </summary>
-    public TreeNode(string label, string? icon, IEnumerable<TreeNode>? children = null)
+    public TreeNode(string text, string? badge, IEnumerable<TreeNode>? children = null)
     {
-        Label = label;
-        Icon = icon;
+        Text = text;
+        Badge = badge;
         Children = children?.ToList();
     }
-    
+
     /// <summary>
     /// Creates a tree node with string children (convenience for leaf nodes).
     /// </summary>
-    public TreeNode(string label, IEnumerable<string>? children)
+    public TreeNode(string text, IEnumerable<string>? children)
     {
-        Label = label;
+        Text = text;
         Children = children?.Select(c => new TreeNode(c)).ToList();
     }
-    
+
     /// <summary>
-    /// Creates a tree node with an icon and string children.
+    /// Creates a tree node with a badge and string children.
     /// </summary>
-    public TreeNode(string label, string? icon, IEnumerable<string>? children)
+    public TreeNode(string text, string? badge, IEnumerable<string>? children)
     {
-        Label = label;
-        Icon = icon;
+        Text = text;
+        Badge = badge;
         Children = children?.Select(c => new TreeNode(c)).ToList();
     }
-    
+
     /// <summary>
     /// Creates a leaf node with no children.
     /// </summary>
-    public TreeNode(string label) : this(label, (IEnumerable<TreeNode>?)null)
+    public TreeNode(string text) : this(text, (IEnumerable<TreeNode>?)null)
     {
     }
-    
+
     /// <summary>
-    /// Creates a leaf node with an icon and no children.
+    /// Creates a leaf node with a badge and no children.
     /// </summary>
-    public TreeNode(string label, string? icon) : this(label, icon, (IEnumerable<TreeNode>?)null)
+    public TreeNode(string text, string? badge) : this(text, badge, (IEnumerable<TreeNode>?)null)
     {
     }
 }

--- a/tests/Markout.Tests/AnsiWriterTests.cs
+++ b/tests/Markout.Tests/AnsiWriterTests.cs
@@ -230,13 +230,13 @@ public class AnsiWriterTests
         Assert.Contains("net10.0", output);
     }
 
-    // ── Compact fields ──
+    // ── Field list ──
 
     [Fact]
-    public void WriteCompactFields_RendersBoldKeysWithSeparator()
+    public void WriteFieldList_RendersBoldKeysWithSeparator()
     {
         var (writer, terminal) = Create();
-        writer.WriteCompactFields(
+        writer.WriteFieldList(
             new MarkoutField("Type", "Library"),
             new MarkoutField("TFM", "net8.0"));
 
@@ -247,33 +247,19 @@ public class AnsiWriterTests
         Assert.Contains("TFM", output);
     }
 
-    // ── Code blocks ──
+    // ── Code ──
 
     [Fact]
-    public void WriteCodeBlock_RendersDimText()
+    public void WriteCode_RendersDimText()
     {
         var (writer, terminal) = Create();
-        writer.WriteCodeBlockStart("csharp");
+        writer.WriteCodeStart("csharp");
         writer.WriteParagraph("var x = 1;");
-        writer.WriteCodeBlockEnd();
+        writer.WriteCodeEnd();
 
         var output = terminal.Output;
         Assert.Contains("var x = 1;", output);
         Assert.Contains($"\x1b[{(int)TerminalColor.DarkGray}m", output); // Dim
-    }
-
-    // ── Simple pairs ──
-
-    [Fact]
-    public void WriteSimplePair_RendersDimName()
-    {
-        var (writer, terminal) = Create();
-        writer.WriteSimplePair("Package", "1.0.0", 20);
-
-        var output = terminal.Output;
-        Assert.Contains("Package", output);
-        Assert.Contains("1.0.0", output);
-        Assert.Contains($"\x1b[{(int)TerminalColor.DarkGray}m", output);
     }
 
     // ── Section filtering ──

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -155,20 +155,6 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void WriteSimplePair_WritesTwoColumnData()
-    {
-        var writer = new MarkoutWriter();
-        writer.WriteSimplePair("Microsoft.CSharp", "4.7.0", 32);
-        writer.WriteSimplePair("System.Memory", "4.5.5", 32);
-
-        var expected = """
-            Microsoft.CSharp                4.7.0
-            System.Memory                   4.5.5
-            """;
-        Assert.Equal(expected, writer.ToString());
-    }
-
-    [Fact]
     public void MultipleElements_AddsBlankLinesBetweenSections()
     {
         var writer = new MarkdownWriter();
@@ -261,19 +247,19 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void WriteCompactFields_SingleField_WritesSinglePair()
+    public void WriteFieldList_SingleField_WritesSinglePair()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCompactFields(new MarkoutField("Type", "Library"));
+        writer.WriteFieldList(new MarkoutField("Type", "Library"));
 
         Assert.Equal("Type: Library", writer.ToString());
     }
 
     [Fact]
-    public void WriteCompactFields_MultipleFields_WritesPipeSeparated()
+    public void WriteFieldList_MultipleFields_WritesPipeSeparated()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCompactFields(
+        writer.WriteFieldList(
             new MarkoutField("Type", "Library"),
             new MarkoutField("TFM", "net8.0"),
             new MarkoutField("Updated", "2026-01-15"));
@@ -282,19 +268,19 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void WriteCompactFields_EmptyFields_WritesNothing()
+    public void WriteFieldList_EmptyFields_WritesNothing()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCompactFields();
+        writer.WriteFieldList();
 
         Assert.Equal("", writer.ToString());
     }
 
     [Fact]
-    public void WriteCompactFields_NullValue_WritesEmptyString()
+    public void WriteFieldList_NullValue_WritesEmptyString()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCompactFields(
+        writer.WriteFieldList(
             new MarkoutField("Status", null),
             new MarkoutField("Count", "5"));
 
@@ -302,11 +288,11 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void WriteCompactFields_AfterHeading_AddsBlankLine()
+    public void WriteFieldList_AfterHeading_AddsBlankLine()
     {
         var writer = new MarkdownWriter();
         writer.WriteHeading(1, "Package 1.0.0");
-        writer.WriteCompactFields(
+        writer.WriteFieldList(
             new MarkoutField("Type", "Library"),
             new MarkoutField("TFM", "net8.0"));
 
@@ -393,9 +379,9 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void WriteTree_WithIncludeIconsFalse_OmitsIcons()
+    public void WriteTree_WithIncludeBadgesFalse_OmitsIcons()
     {
-        var options = new MarkoutWriterOptions { IncludeIcons = false };
+        var options = new MarkoutWriterOptions { IncludeBadges = false };
         var writer = new MarkoutWriter(options);
         var nodes = new List<TreeNode>
         {
@@ -447,7 +433,7 @@ public class MarkoutWriterTests
     {
         var options = new MarkoutWriterOptions();
 
-        Assert.True(options.IncludeIcons);
+        Assert.True(options.IncludeBadges);
         Assert.True(options.IncludeDescription);
         Assert.False(options.BoldFieldNames);
         Assert.Null(options.IncludeSections);
@@ -468,7 +454,7 @@ public class MarkoutWriterTests
         options.MakeReadOnly();
 
         Assert.Throws<InvalidOperationException>(() => options.BoldFieldNames = false);
-        Assert.Throws<InvalidOperationException>(() => options.IncludeIcons = false);
+        Assert.Throws<InvalidOperationException>(() => options.IncludeBadges = false);
         Assert.Throws<InvalidOperationException>(() => options.IncludeDescription = false);
         Assert.Throws<InvalidOperationException>(() => options.IncludeSections = ["First"]);
         Assert.Throws<InvalidOperationException>(() => options.ExcludeSections = ["Second"]);
@@ -518,35 +504,35 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void CurrentContext_InCodeBlock_ReturnsCodeBlock()
+    public void CurrentContext_InCode_ReturnsCode()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCodeBlockStart("csharp");
-        Assert.Equal(MarkoutRenderContext.CodeBlock, writer.CurrentContext);
-        writer.WriteCodeBlockEnd();
+        writer.WriteCodeStart("csharp");
+        Assert.Equal(MarkoutRenderContext.Code, writer.CurrentContext);
+        writer.WriteCodeEnd();
         Assert.Equal(MarkoutRenderContext.Block, writer.CurrentContext);
     }
 
     [Fact]
-    public void WriteCodeBlockStart_Nested_Throws()
+    public void WriteCodeStart_Nested_Throws()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCodeBlockStart();
-        Assert.Throws<InvalidOperationException>(() => writer.WriteCodeBlockStart());
+        writer.WriteCodeStart();
+        Assert.Throws<InvalidOperationException>(() => writer.WriteCodeStart());
     }
 
     [Fact]
-    public void WriteCodeBlockEnd_WithoutStart_Throws()
+    public void WriteCodeEnd_WithoutStart_Throws()
     {
         var writer = new MarkoutWriter();
-        Assert.Throws<InvalidOperationException>(() => writer.WriteCodeBlockEnd());
+        Assert.Throws<InvalidOperationException>(() => writer.WriteCodeEnd());
     }
 
     [Fact]
-    public void WriteTableStart_InCodeBlock_Throws()
+    public void WriteTableStart_InCode_Throws()
     {
         var writer = new MarkoutWriter();
-        writer.WriteCodeBlockStart();
+        writer.WriteCodeStart();
         Assert.Throws<InvalidOperationException>(() => writer.WriteTableStart("A"));
     }
 

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -20,10 +20,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
-    <ProjectReference Include="..\..\src\Markout.Ansi\Markout.Ansi.csproj" />
+    <ProjectReference Include="..\..\src\Markout.Ansi\Markout.Ansi.csproj" Condition="'$(ExcludeAnsi)' != 'true'" />
     <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ExcludeAnsi)' == 'true'">
+    <Compile Remove="AnsiWriterTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -20,14 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
-    <ProjectReference Include="..\..\src\Markout.Ansi\Markout.Ansi.csproj" Condition="'$(ExcludeAnsi)' != 'true'" />
+    <ProjectReference Include="..\..\src\Markout.Ansi\Markout.Ansi.csproj" />
     <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(ExcludeAnsi)' == 'true'">
-    <Compile Remove="AnsiWriterTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Markout.Tests/ShapeSupportTests.cs
+++ b/tests/Markout.Tests/ShapeSupportTests.cs
@@ -20,12 +20,11 @@ public class ShapeSupportTests
         Assert.True(all.HasFlag(MarkoutShape.Headings));
         Assert.True(all.HasFlag(MarkoutShape.Paragraphs));
         Assert.True(all.HasFlag(MarkoutShape.Fields));
-        Assert.True(all.HasFlag(MarkoutShape.CompactFields));
+        Assert.True(all.HasFlag(MarkoutShape.FieldList));
         Assert.True(all.HasFlag(MarkoutShape.Tables));
         Assert.True(all.HasFlag(MarkoutShape.Lists));
         Assert.True(all.HasFlag(MarkoutShape.Trees));
-        Assert.True(all.HasFlag(MarkoutShape.CodeBlocks));
-        Assert.True(all.HasFlag(MarkoutShape.SimplePairs));
+        Assert.True(all.HasFlag(MarkoutShape.Code));
         Assert.True(all.HasFlag(MarkoutShape.BarCharts));
         Assert.True(all.HasFlag(MarkoutShape.LabeledLists));
         Assert.True(all.HasFlag(MarkoutShape.Callouts));
@@ -84,7 +83,6 @@ public class ShapeSupportTests
             writer.WriteParagraph("text");
             writer.WriteField("key", "value");
             writer.WriteListItem("item");
-            writer.WriteSimplePair("a", "b");
             // Should produce no output
             Assert.Equal("", writer.ToString());
         }


### PR DESCRIPTION
## Summary

Breaking API changes for naming consistency. Shape names should describe what the data *is*, not what it *looks like*.

- **Shape renames:** `CompactFields` → `FieldList`, `CodeBlocks` → `Code`
- **Method renames:** `WriteCompactFields` → `WriteFieldList`, `WriteCodeBlockStart/End` → `WriteCodeStart/End`, `InCodeBlock` → `InCode`
- **Remove `SimplePairs`** shape and `WriteSimplePair` method entirely
- **TreeNode:** `Label` → `Text`, `Icon` → `Badge`
- **Options:** `IncludeIcons` → `IncludeBadges` (options, attributes, source generator)
- **Version bump:** 0.5.1 → 0.6.0
- **CI:** Remove `ExcludeAnsi` workaround, add GitHub Packages auth, commit `nuget.config`

## Test plan

- [x] `dotnet build -c Release` — 0 warnings
- [x] `dotnet run --project tests/Markout.Tests -c Release` — 326 tests pass
- [x] `grep` sweep confirms no stale names remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)