### PR TITLE
Switch to NuGet trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'publish'
+    permissions:
+      id-token: write   # Required for NuGet trusted publishing (OIDC)
+      actions: read      # Required to download artifacts from another run
     steps:
       - name: Download packages from CI run
         uses: actions/download-artifact@v4
@@ -31,19 +34,24 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: NuGet login (trusted publishing)
+        uses: nuget/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
         run: |
           for pkg in packages/*.nupkg; do
             name=$(basename "$pkg")
             case "$name" in
               Markout.[0-9]*)
+                echo "Publishing: $name"
                 dotnet nuget push "$pkg" \
-                  --api-key ${{ secrets.NUGET_API_KEY }} \
                   --source https://api.nuget.org/v3/index.json \
                   --skip-duplicate
                 ;;
               *)
-                echo "Skipping sample package: $name"
+                echo "Skipping: $name"
                 ;;
             esac
           done


### PR DESCRIPTION
## Summary

Replace stored `NUGET_API_KEY` with OIDC-based trusted publishing via `nuget/login@v1`. Short-lived credentials instead of long-lived API keys.

## Test plan

- [ ] Verify trusted publisher policy is configured on nuget.org
- [ ] Trigger publish workflow after merge to confirm OIDC flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)