### PR TITLE
Fix trusted publishing: explicit API key and workflow-level permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'publish'
+    environment: nuget-publish
     permissions:
       id-token: write   # Required for NuGet trusted publishing (OIDC)
       actions: read      # Required to download artifacts from another run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,15 @@ on:
         description: 'Type "publish" to confirm NuGet release'
         required: true
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'publish'
     environment: nuget-publish
-    permissions:
-      id-token: write   # Required for NuGet trusted publishing (OIDC)
-      actions: read      # Required to download artifacts from another run
     steps:
       - name: Download packages from CI run
         uses: actions/download-artifact@v4
@@ -35,8 +36,9 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: NuGet login (trusted publishing)
-        uses: nuget/login@v1
+      - name: NuGet login (OIDC → temp API key)
+        id: login
+        uses: NuGet/login@v1
         with:
           user: ${{ secrets.NUGET_USER }}
 
@@ -48,6 +50,7 @@ jobs:
               Markout.[0-9]*)
                 echo "Publishing: $name"
                 dotnet nuget push "$pkg" \
+                  --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
                   --source https://api.nuget.org/v3/index.json \
                   --skip-duplicate
                 ;;


### PR DESCRIPTION
## Summary

Follow-up to #48. Matches the working dotnet-inspect pattern:

- Move permissions to workflow level (`contents: write`, `id-token: write`)
- Add `id: login` to the NuGet login step
- Pass `--api-key ${{ steps.login.outputs.NUGET_API_KEY }}` explicitly to `dotnet nuget push`

The previous run failed because the API key wasn't being passed to the push command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)