### PR TITLE
Add [MarkoutValueMap] attribute, bump to 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Latest LTS: 10.0
 - **`[MarkoutIgnoreInTable]`** - Excludes a property only in table context (silences MARKOUT001 warning)
 - **`[MarkoutSection(Name = "...")]`** - Groups property under an H2 section (scalars grouped by name, collections as tables/lists)
 - **`[MarkoutBoolFormat]`** - Custom true/false display values
+- **`[MarkoutValueMap("key=badge", ...)]`** - Maps string values to badge-prefixed output (e.g., `"class"` → `"📦 class"`)
 - **`[MarkoutContext(typeof(...))]`** - Registers types for source generation
 
 ## Field Collections

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -526,6 +526,23 @@ When `IsVerified` is `false`, `VerifiedBy` is not rendered — even if it has a 
 
 > From the [AdvancedFeatures](../samples/Serialization/AdvancedFeatures.cs) sample.
 
+### Value Maps
+
+Use `[MarkoutValueMap]` to prepend a badge to string values based on a lookup:
+
+```csharp
+[MarkoutSerializable]
+public class CveItem
+{
+    public string Id { get; set; } = "";
+
+    [MarkoutValueMap("CRITICAL=🔴", "HIGH=🟠", "MEDIUM=🟡", "LOW=🟢")]
+    public string Severity { get; set; } = "";
+}
+```
+
+Each entry is `"value=badge"`. When the property value matches a key, the badge is prepended with a space: `"🔴 CRITICAL"`. Unmatched values pass through unchanged. Works in both field and table contexts.
+
 ## Sections and Collections
 
 Use `[MarkoutSection]` to group properties under a heading. It works on both scalar properties and collections.
@@ -939,3 +956,4 @@ writer.WriteCodeEnd();
 | `[MarkoutLink]` | Property | Renders a string as a Markdown `[url](url)` link. Set `TextProperty` for `[text](url)`. |
 | `[MarkoutMaxItems(n)]` | Property | Limits collection rendering to `n` items. Set `EllipsisFormat` to customize the overflow message. |
 | `[MarkoutValueFormatter(typeof(...))]` | Property | Uses a custom `IMarkoutValueFormatter<T>` to format the value. |
+| `[MarkoutValueMap("k=v", ...)]` | Property | Maps string values to badge-prefixed output. Each entry is `"value=badge"`. Unmatched values pass through unchanged. |

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -431,6 +431,7 @@ public class ActorDetailRow
 public class ShowRow
 {
     public string Title { get; set; } = "";
+    [MarkoutValueMap("TV Series=📺", "Movie=🎬", "TV Miniseries=📺")]
     public string Type { get; set; } = "";
     public string Years { get; set; } = "";
 

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -45,10 +45,11 @@ internal static class EmitHelpers
         // DisplayFormat wraps the final value
         if (prop.DisplayFormat != null)
         {
-            return $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.DisplayFormat)}\", {access})";
+            var fmtExpr = $"string.Format(System.Globalization.CultureInfo.InvariantCulture, \"{EscapeString(prop.DisplayFormat)}\", {access})";
+            return WrapWithValueMap(prop, fmtExpr);
         }
 
-        return prop.Kind switch
+        var result = prop.Kind switch
         {
             PropertyKind.Boolean => $"({access} ? \"yes\" : \"no\")",
             PropertyKind.String => $"{propAccess} ?? \"\"",
@@ -59,6 +60,7 @@ internal static class EmitHelpers
             PropertyKind.Enum => $"{access}.ToString()",
             _ => $"{propAccess}?.ToString() ?? \"\""
         };
+        return WrapWithValueMap(prop, result);
     }
 
     private static string WrapWithDisplayFormat(PropertyMetadata prop, string innerExpr)
@@ -118,6 +120,7 @@ internal static class EmitHelpers
     {
         var propAccess = $"{itemExpr}.{prop.Name}";
         var result = GetTableCellValueCore(prop, propAccess, itemExpr);
+        result = WrapWithValueMap(prop, result);
         return WrapWithLink(prop, result, itemExpr);
     }
 
@@ -214,6 +217,27 @@ internal static class EmitHelpers
 
         // [url](url) — bare link
         return $"$\"[{{{innerExpr}}}]({{{innerExpr}}})\"";
+    }
+
+    /// <summary>
+    /// Wraps a string value expression with a value-map switch expression that prepends a badge.
+    /// Unmatched values pass through unchanged.
+    /// </summary>
+    public static string WrapWithValueMap(PropertyMetadata prop, string innerExpr)
+    {
+        if (prop.ValueMap == null || prop.ValueMap.Count == 0)
+            return innerExpr;
+
+        // Generate: ((value) switch { "key1" => "badge1 " + value, "key2" => "badge2 " + value, _ => value })
+        // Parenthesize innerExpr to avoid precedence issues (e.g. ?? vs switch)
+        var arms = new StringBuilder();
+        foreach (var (key, badge) in prop.ValueMap)
+        {
+            arms.Append($"\"{EscapeString(key)}\" => \"{EscapeString(badge)} \" + {innerExpr}, ");
+        }
+        arms.Append($"_ => {innerExpr}");
+
+        return $"(({innerExpr}) switch {{ {arms} }})";
     }
 
     public static string GetCollectionCountCheck(PropertyMetadata prop, string propAccess)

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -85,7 +85,8 @@ internal static class FieldEmitter
                 }
                 else if (prop.Kind == PropertyKind.String)
                 {
-                    var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
+                    var valueStr = EmitHelpers.WrapWithValueMap(prop, propAccess);
+                    valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                     sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
@@ -288,7 +289,8 @@ internal static class FieldEmitter
             }
             else if (prop.Kind == PropertyKind.String)
             {
-                var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
+                var valueStr = EmitHelpers.WrapWithValueMap(prop, propAccess);
+                valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
                 if (renderedVar != null)
                 {
@@ -434,7 +436,8 @@ internal static class FieldEmitter
             }
             else if (prop.Kind == PropertyKind.String)
             {
-                var valueStr = EmitHelpers.WrapWithLink(prop, propAccess, valueExpr);
+                var valueStr = EmitHelpers.WrapWithValueMap(prop, propAccess);
+                valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
                 sb.AppendLine($"{emitIndent}if ({propAccess} != null)");
                 if (renderedVar != null)
                 {

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -148,6 +148,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? ShowWhenProperty { get; }
     public bool IsLink { get; }
     public string? LinkTextProperty { get; }
+    public IReadOnlyList<(string Key, string Value)>? ValueMap { get; }
 
     public PropertyMetadata(
         string name,
@@ -188,7 +189,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? tableDisplayFormat = null,
         string? showWhenProperty = null,
         bool isLink = false,
-        string? linkTextProperty = null)
+        string? linkTextProperty = null,
+        IReadOnlyList<(string Key, string Value)>? valueMap = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -229,6 +231,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         ShowWhenProperty = showWhenProperty;
         IsLink = isLink;
         LinkTextProperty = linkTextProperty;
+        ValueMap = valueMap;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -273,6 +276,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                ShowWhenProperty == other.ShowWhenProperty &&
                IsLink == other.IsLink &&
                LinkTextProperty == other.LinkTextProperty &&
+               ValueMapEqual(ValueMap, other.ValueMap) &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -302,6 +306,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (ShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ IsLink.GetHashCode();
             hash = hash * 397 ^ (LinkTextProperty?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (ValueMap?.Count ?? 0);
             return hash;
         }
     }
@@ -313,6 +318,16 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         if (a.Count != b.Count) return false;
         for (int i = 0; i < a.Count; i++)
             if (!a[i].Equals(b[i])) return false;
+        return true;
+    }
+
+    private static bool ValueMapEqual(IReadOnlyList<(string Key, string Value)>? a, IReadOnlyList<(string Key, string Value)>? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return a is null && b is null;
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+            if (a[i].Key != b[i].Key || a[i].Value != b[i].Value) return false;
         return true;
     }
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -28,6 +28,7 @@ internal static class TypeParser
     private const string MarkoutValueFormatterAttribute = "Markout.MarkoutValueFormatterAttribute";
     private const string MarkoutShowWhenAttribute = "Markout.MarkoutShowWhenAttribute";
     private const string MarkoutLinkAttribute = "Markout.MarkoutLinkAttribute";
+    private const string MarkoutValueMapAttribute = "Markout.MarkoutValueMapAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -349,6 +350,30 @@ internal static class TypeParser
             }
         }
 
+        // Parse [MarkoutValueMap] attribute
+        IReadOnlyList<(string Key, string Value)>? valueMap = null;
+        var valueMapAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutValueMapAttribute);
+        if (valueMapAttr != null && valueMapAttr.ConstructorArguments.Length > 0)
+        {
+            var entries = new List<(string Key, string Value)>();
+            var arg = valueMapAttr.ConstructorArguments[0];
+            if (arg.Kind == TypedConstantKind.Array)
+            {
+                foreach (var item in arg.Values)
+                {
+                    if (item.Value is string entry)
+                    {
+                        var eqIdx = entry.IndexOf('=');
+                        if (eqIdx > 0)
+                            entries.Add((entry.Substring(0, eqIdx), entry.Substring(eqIdx + 1)));
+                    }
+                }
+            }
+            if (entries.Count > 0)
+                valueMap = entries;
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -415,7 +440,8 @@ internal static class TypeParser
             tableDisplayFormat,
             showWhenProperty,
             isLink,
-            linkTextProperty);
+            linkTextProperty,
+            valueMap);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutValueMapAttribute.cs
+++ b/src/Markout/Attributes/MarkoutValueMapAttribute.cs
@@ -1,0 +1,34 @@
+namespace Markout;
+
+/// <summary>
+/// Maps string property values to badge-prefixed output.
+/// Each entry is a "value=badge" pair. When the property value matches a key,
+/// the badge is prepended: <c>"badge value"</c>. Unmatched values pass through unchanged.
+/// </summary>
+/// <remarks>
+/// Applies to string properties in both field and table contexts.
+/// </remarks>
+/// <example>
+/// <code>
+/// [MarkoutValueMap("class=📦", "struct=🔲", "interface=🔌", "enum=🔢")]
+/// public string Kind { get; set; } = "";
+/// // "class" renders as "📦 class", "record" renders as "record"
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutValueMapAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the value map entries, each in "value=badge" format.
+    /// </summary>
+    public string[] Entries { get; }
+
+    /// <summary>
+    /// Creates a value map from "value=badge" pairs.
+    /// </summary>
+    /// <param name="entries">One or more "value=badge" strings.</param>
+    public MarkoutValueMapAttribute(params string[] entries)
+    {
+        Entries = entries;
+    }
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -1390,6 +1390,46 @@ public class SerializerTests
         Assert.Contains("Assemblies", mdf);
         Assert.Contains("Test.dll", mdf);
     }
+
+    // --- ValueMap tests ---
+
+    [Fact]
+    public void Serialize_ValueMap_PrependsBadge()
+    {
+        var item = new CveItem { Id = "CVE-2025-001", Severity = "CRITICAL" };
+        var mdf = MarkoutSerializer.Serialize(item, ValueMapTestContext.Default);
+
+        Assert.Contains("🔴 CRITICAL", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ValueMap_UnmappedValuePassesThrough()
+    {
+        var item = new CveItem { Id = "CVE-2025-002", Severity = "UNKNOWN" };
+        var mdf = MarkoutSerializer.Serialize(item, ValueMapTestContext.Default);
+
+        Assert.Contains("UNKNOWN", mdf);
+        Assert.DoesNotContain("🔴", mdf);
+        Assert.DoesNotContain("🟠", mdf);
+    }
+
+    [Fact]
+    public void Serialize_ValueMap_InTableContext()
+    {
+        var report = new CveReport
+        {
+            Title = "Security Report",
+            Items =
+            [
+                new() { Id = "CVE-2025-001", Severity = "HIGH" },
+                new() { Id = "CVE-2025-002", Severity = "LOW" }
+            ]
+        };
+        var mdf = MarkoutSerializer.Serialize(report, ValueMapTestContext.Default);
+
+        Assert.Contains("🟠 HIGH", mdf);
+        Assert.Contains("🟢 LOW", mdf);
+    }
 }
 
 [MarkoutSerializable]
@@ -2062,5 +2102,32 @@ public class FieldCollectionBeforeSections
 [MarkoutContext(typeof(ScalarSectionLineBreaks))]
 [MarkoutContext(typeof(FieldCollectionBeforeSections))]
 public partial class ScalarSectionTestContext : MarkoutSerializerContext
+{
+}
+
+// --- ValueMap test types ---
+
+[MarkoutSerializable]
+public class CveItem
+{
+    public string Id { get; set; } = "";
+
+    [MarkoutValueMap("CRITICAL=🔴", "HIGH=🟠", "MEDIUM=🟡", "LOW=🟢")]
+    public string Severity { get; set; } = "";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class CveReport
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Vulnerabilities")]
+    public List<CveItem>? Items { get; set; }
+}
+
+[MarkoutContext(typeof(CveItem))]
+[MarkoutContext(typeof(CveReport))]
+public partial class ValueMapTestContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary
- Adds `[MarkoutValueMap("key=badge", ...)]` attribute that maps string property values to badge-prefixed output
- Works in both field and table contexts via source-generated switch expressions
- Bumps version to 0.6.1 (needed by dotnet-inspect which already uses this feature)
- Adds `[MarkoutValueMap]` to CanadianContent sample's `ShowRow.Type` (📺/🎬 badges)
- 329 tests pass, 0 warnings

## Test plan
- [x] Unit tests: badge prepend, unmapped passthrough, table context
- [x] Build: 0 warnings
- [x] All 329 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)