### PR TITLE
Add Markout.Templates — template engine, table formatting, and CLI tool

### DIFF
--- a/Markout.sln
+++ b/Markout.sln
@@ -25,6 +25,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateDemo", "samples\Tem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownTable.Formatting", "src\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj", "{320DD635-60CE-446F-B4B6-D22B062CEE46}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "markout-template", "tools\markout-template\markout-template.csproj", "{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +147,18 @@ Global
 		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x64.Build.0 = Release|Any CPU
 		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x86.ActiveCfg = Release|Any CPU
 		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x86.Build.0 = Release|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Debug|x64.Build.0 = Debug|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Debug|x86.Build.0 = Debug|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Release|x64.ActiveCfg = Release|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Release|x64.Build.0 = Release|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Release|x86.ActiveCfg = Release|Any CPU
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -153,5 +169,6 @@ Global
 		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{868726C4-8E35-4141-A7E0-9B9A6EF0608A} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{320DD635-60CE-446F-B4B6-D22B062CEE46} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{D33ECC5D-DC1C-4EEA-BA7A-06C56C65A798} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 EndGlobal

--- a/Markout.sln
+++ b/Markout.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Markout.Templates", "src\Ma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Markout.Templates.Tests", "tests\Markout.Templates.Tests\Markout.Templates.Tests.csproj", "{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateDemo", "samples\TemplateDemo\TemplateDemo.csproj", "{868726C4-8E35-4141-A7E0-9B9A6EF0608A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,18 @@ Global
 		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x64.Build.0 = Release|Any CPU
 		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x86.ActiveCfg = Release|Any CPU
 		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x86.Build.0 = Release|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Debug|x64.Build.0 = Debug|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Debug|x86.Build.0 = Debug|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x64.ActiveCfg = Release|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x64.Build.0 = Release|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x86.ActiveCfg = Release|Any CPU
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -123,5 +137,6 @@ Global
 		{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{2FBCC45A-444A-444D-96D4-475718EA2A1E} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{868726C4-8E35-4141-A7E0-9B9A6EF0608A} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 EndGlobal

--- a/Markout.sln
+++ b/Markout.sln
@@ -17,6 +17,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5D20
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialization", "samples\Serialization\Serialization.csproj", "{2FBCC45A-444A-444D-96D4-475718EA2A1E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Markout.Templates", "src\Markout.Templates\Markout.Templates.csproj", "{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Markout.Templates.Tests", "tests\Markout.Templates.Tests\Markout.Templates.Tests.csproj", "{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +91,30 @@ Global
 		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x64.Build.0 = Release|Any CPU
 		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x86.ActiveCfg = Release|Any CPU
 		{2FBCC45A-444A-444D-96D4-475718EA2A1E}.Release|x86.Build.0 = Release|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Debug|x64.Build.0 = Debug|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Debug|x86.Build.0 = Debug|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Release|x64.ActiveCfg = Release|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Release|x64.Build.0 = Release|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7}.Release|x86.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x64.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-7890-ABCD-EF1234567891}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,5 +122,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{A3D5F90F-F54D-41A5-AB50-8D0DA833CEE4} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{2FBCC45A-444A-444D-96D4-475718EA2A1E} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/Markout.sln
+++ b/Markout.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Markout.Templates.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateDemo", "samples\TemplateDemo\TemplateDemo.csproj", "{868726C4-8E35-4141-A7E0-9B9A6EF0608A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownTable.Formatting", "src\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj", "{320DD635-60CE-446F-B4B6-D22B062CEE46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,18 @@ Global
 		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x64.Build.0 = Release|Any CPU
 		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x86.ActiveCfg = Release|Any CPU
 		{868726C4-8E35-4141-A7E0-9B9A6EF0608A}.Release|x86.Build.0 = Release|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Debug|x64.Build.0 = Debug|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Debug|x86.Build.0 = Debug|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x64.ActiveCfg = Release|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x64.Build.0 = Release|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x86.ActiveCfg = Release|Any CPU
+		{320DD635-60CE-446F-B4B6-D22B062CEE46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,5 +152,6 @@ Global
 		{2FBCC45A-444A-444D-96D4-475718EA2A1E} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{0D4A6074-FFD5-47C3-8AED-CF354E24B2C7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{868726C4-8E35-4141-A7E0-9B9A6EF0608A} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{320DD635-60CE-446F-B4B6-D22B062CEE46} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,23 @@
 
 **Human-readable structured data serialization to Markdown**
 
-Markout serializes .NET objects to clean, readable Markdown format. Perfect for logs, reports, documentation, and any output that humans and LLMs need to read.
+Markout projects .NET objects into clean, readable documents. Perfect for logs, reports, documentation, and any output that humans and LLMs need to read.
+
+Markout offers three ways to produce documents, all rendering through the same writer pipeline:
+
+| Mode | Best for | Input |
+| ---- | -------- | ----- |
+| **Standalone API** | Direct writer calls | Code |
+| **Source generator** | Type-driven documents | Annotated classes |
+| **Templates** | Human-authored documents with data slots | `.md` template files |
+
+```
+Standalone API:    writer.WriteHeading() / WriteTable() / WriteField()  → MarkoutWriter
+Source Generator:  [MarkoutSerializable] Type → Generated TypeInfo      → MarkoutWriter
+Templates:         .md Template + Bindings → MarkoutTemplate            → MarkoutWriter
+                                                                            ↓
+                                                              Markdown, plain text, ANSI, ...
+```
 
 ## Why Markdown for Structured Output?
 
@@ -308,7 +324,77 @@ This is intentional! Markdown tables can't contain lists. Choose a transformatio
 
 📖 **See [Nested Lists Guide](docs/nested-lists-guide.md)** for complete examples and code
 
+## Templates
+
+Templates let you author document structure in Markdown and fill data slots at runtime. The same template renders to any format — Markdown, plain text, or ANSI terminal.
+
+**template.md:**
+
+```markdown
+# .NET Security Report for {{date}}
+
+The following vulnerabilities were disclosed this month.
+
+{{vuln-table}}
+
+| Level | CVSS Range | Response |
+| ----- | ---------- | -------- |
+| Critical | 9.0–10.0 | Patch immediately |
+| High | 7.0–8.9 | Patch within 30 days |
+
+{{#if commits}}
+## Commits
+
+{{commit-table}}
+{{/if}}
+```
+
+**Program.cs:**
+
+```csharp
+using Markout;
+using Markout.Templates;
+
+var template = MarkoutTemplate.Load("template.md");
+template.TableOptions = new TableFormatterOptions(); // smooth column widths
+
+template.Bind("date", "February 2026");
+template.Bind("vuln-table", vulnerabilityData);  // IMarkoutFormattable
+template.Bind("commits", hasCommits ? "yes" : null);
+template.Bind("commit-table", commitData);
+
+// Markdown output
+Console.WriteLine(template.Render(new MarkoutWriterOptions { PrettyTables = true }));
+
+// Plain text output — same template, different writer
+var plainWriter = new MarkoutWriter();
+template.Render(plainWriter);
+```
+
+Templates support:
+
+- **`{{key}}`** — inline substitution in headings and prose, or block-level data rendering
+- **`{{#if key}}`** / **`{{/if}}`** — conditional sections (included when key is bound and non-null)
+- **Pipe tables** — parsed and re-rendered through the writer's table shape, with optional statistical column-width optimization
+- **`IMarkoutFormattable`** and **`MarkoutTypeInfo<T>`** bindings for shape-aware data rendering
+
+```bash
+dotnet add package Markout.Templates
+```
+
+### Template Runner Tool
+
+A basic CLI tool is included for rendering templates with string bindings:
+
+```bash
+dotnet run --project tools/markout-template -- template.md date="February 2026" title="Report"
+```
+
+Unbound block placeholders are skipped, so you can render partial templates. Pipe `key=value` lines on stdin for additional bindings.
+
 ## Samples
+
+- **[TemplateDemo](samples/TemplateDemo)** - Document template with inline tables, conditional sections, and multi-format rendering
 
 - **[CanadianContent](samples/CanadianContent)** - Query Canadian actors and shows with searchable filters (file-based app)
 - **[DotNetReleases](samples/DotNetReleases)** - Fetch and display .NET release information from GitHub (file-based app)

--- a/samples/TemplateDemo/Program.cs
+++ b/samples/TemplateDemo/Program.cs
@@ -1,0 +1,106 @@
+using Markout;
+using Markout.Templates;
+
+// A template is a human-authored document with {{placeholders}} for data.
+// It's a peer entry path to the source generator — both render through MarkoutWriter.
+
+var template = MarkoutTemplate.Parse("""
+    # .NET Security Report for {{date}}
+
+    The following vulnerabilities were disclosed this month.
+
+    {{vuln-table}}
+
+    ## Affected Products
+
+    {{product-table}}
+
+    {{#if commits}}
+    ## Related Commits
+
+    The following commits address the vulnerabilities above.
+
+    {{commit-table}}
+    {{/if}}
+    """);
+
+// Bind inline values
+template.Bind("date", "February 2026");
+
+// Bind IMarkoutFormattable objects for block-level shape rendering
+template.Bind("vuln-table", new VulnerabilityTable());
+template.Bind("product-table", new ProductTable());
+
+// Bind a truthy value to include the conditional section
+template.Bind("commits", "yes");
+template.Bind("commit-table", new CommitTable());
+
+// Render through MarkdownWriter (default)
+Console.WriteLine("=== Markdown ===");
+Console.WriteLine(template.Render());
+
+// Render through plain-text MarkoutWriter
+Console.WriteLine("=== Plain Text ===");
+var plainWriter = new MarkoutWriter();
+template.Render(plainWriter);
+Console.WriteLine(plainWriter.ToString());
+
+// Now render WITHOUT commits (conditional section excluded)
+Console.WriteLine("=== Markdown (no commits) ===");
+var noCommits = MarkoutTemplate.Parse("""
+    # .NET Security Report for {{date}}
+
+    {{vuln-table}}
+
+    {{#if commits}}
+    ## Related Commits
+
+    {{commit-table}}
+    {{/if}}
+    """);
+noCommits.Bind("date", "February 2026");
+noCommits.Bind("vuln-table", new VulnerabilityTable());
+// Don't bind "commits" — section excluded
+Console.WriteLine(noCommits.Render());
+
+// --- Formattable types that render through the writer shape system ---
+
+class VulnerabilityTable : IMarkoutFormattable
+{
+    public void WriteTo(MarkoutWriter writer)
+    {
+        writer.WriteTableStart("CVE", "Severity", "Component");
+        writer.WriteTableRow("CVE-2026-1234", "Critical", "System.Net.Http");
+        writer.WriteTableRow("CVE-2026-1235", "High", "Microsoft.Data.SqlClient");
+        writer.WriteTableRow("CVE-2026-1236", "Medium", "System.Text.Json");
+        writer.WriteTableEnd();
+    }
+
+    public string? ToMarkoutString() => "3 vulnerabilities";
+}
+
+class ProductTable : IMarkoutFormattable
+{
+    public void WriteTo(MarkoutWriter writer)
+    {
+        writer.WriteTableStart("Product", "Version", "Status");
+        writer.WriteTableRow(".NET 9.0", "9.0.4", "Patched");
+        writer.WriteTableRow(".NET 8.0", "8.0.12", "Patched");
+        writer.WriteTableEnd();
+    }
+
+    public string? ToMarkoutString() => "2 products";
+}
+
+class CommitTable : IMarkoutFormattable
+{
+    public void WriteTo(MarkoutWriter writer)
+    {
+        writer.WriteTableStart("SHA", "Message", "Author");
+        writer.WriteTableRow("abc1234", "Fix HTTP header injection", "security-bot");
+        writer.WriteTableRow("def5678", "Patch SQL parameter handling", "security-bot");
+        writer.WriteTableEnd();
+    }
+
+    public string? ToMarkoutString() => "2 commits";
+}

--- a/samples/TemplateDemo/Program.cs
+++ b/samples/TemplateDemo/Program.cs
@@ -1,5 +1,6 @@
 using Markout;
 using Markout.Templates;
+using MarkdownTable.Formatting;
 
 // A template is a human-authored document with {{placeholders}} for data.
 // Like the source generator, templates render through the MarkoutWriter pipeline.
@@ -7,6 +8,9 @@ using Markout.Templates;
 
 var templatePath = Path.Combine(AppContext.BaseDirectory, "template.md");
 var template = MarkoutTemplate.Load(templatePath);
+
+// Enable statistical table formatting for inline pipe tables
+template.TableOptions = new TableFormatterOptions();
 
 // Bind inline values
 template.Bind("date", "February 2026");

--- a/samples/TemplateDemo/Program.cs
+++ b/samples/TemplateDemo/Program.cs
@@ -2,7 +2,7 @@ using Markout;
 using Markout.Templates;
 
 // A template is a human-authored document with {{placeholders}} for data.
-// It's a peer entry path to the source generator — both render through MarkoutWriter.
+// Like the source generator, templates render through the MarkoutWriter pipeline.
 // See template.md alongside this file.
 
 var templatePath = Path.Combine(AppContext.BaseDirectory, "template.md");

--- a/samples/TemplateDemo/Program.cs
+++ b/samples/TemplateDemo/Program.cs
@@ -3,26 +3,10 @@ using Markout.Templates;
 
 // A template is a human-authored document with {{placeholders}} for data.
 // It's a peer entry path to the source generator — both render through MarkoutWriter.
+// See template.md alongside this file.
 
-var template = MarkoutTemplate.Parse("""
-    # .NET Security Report for {{date}}
-
-    The following vulnerabilities were disclosed this month.
-
-    {{vuln-table}}
-
-    ## Affected Products
-
-    {{product-table}}
-
-    {{#if commits}}
-    ## Related Commits
-
-    The following commits address the vulnerabilities above.
-
-    {{commit-table}}
-    {{/if}}
-    """);
+var templatePath = Path.Combine(AppContext.BaseDirectory, "template.md");
+var template = MarkoutTemplate.Load(templatePath);
 
 // Bind inline values
 template.Bind("date", "February 2026");
@@ -47,20 +31,11 @@ Console.WriteLine(plainWriter.ToString());
 
 // Now render WITHOUT commits (conditional section excluded)
 Console.WriteLine("=== Markdown (no commits) ===");
-var noCommits = MarkoutTemplate.Parse("""
-    # .NET Security Report for {{date}}
-
-    {{vuln-table}}
-
-    {{#if commits}}
-    ## Related Commits
-
-    {{commit-table}}
-    {{/if}}
-    """);
+var noCommits = MarkoutTemplate.Load(templatePath);
 noCommits.Bind("date", "February 2026");
 noCommits.Bind("vuln-table", new VulnerabilityTable());
-// Don't bind "commits" — section excluded
+noCommits.Bind("product-table", new ProductTable());
+// Don't bind "commits" — conditional section excluded
 Console.WriteLine(noCommits.Render());
 
 // --- Formattable types that render through the writer shape system ---

--- a/samples/TemplateDemo/Program.cs
+++ b/samples/TemplateDemo/Program.cs
@@ -12,6 +12,9 @@ var template = MarkoutTemplate.Load(templatePath);
 // Enable statistical table formatting for inline pipe tables
 template.TableOptions = new TableFormatterOptions();
 
+// Use PrettyTables so bound tables (via IMarkoutFormattable) also get aligned columns
+var writerOptions = new MarkoutWriterOptions { PrettyTables = true };
+
 // Bind inline values
 template.Bind("date", "February 2026");
 
@@ -25,7 +28,7 @@ template.Bind("commit-table", new CommitTable());
 
 // Render through MarkdownWriter (default)
 Console.WriteLine("=== Markdown ===");
-Console.WriteLine(template.Render());
+Console.WriteLine(template.Render(writerOptions));
 
 // Render through plain-text MarkoutWriter
 Console.WriteLine("=== Plain Text ===");
@@ -36,11 +39,12 @@ Console.WriteLine(plainWriter.ToString());
 // Now render WITHOUT commits (conditional section excluded)
 Console.WriteLine("=== Markdown (no commits) ===");
 var noCommits = MarkoutTemplate.Load(templatePath);
+noCommits.TableOptions = new TableFormatterOptions();
 noCommits.Bind("date", "February 2026");
 noCommits.Bind("vuln-table", new VulnerabilityTable());
 noCommits.Bind("product-table", new ProductTable());
 // Don't bind "commits" — conditional section excluded
-Console.WriteLine(noCommits.Render());
+Console.WriteLine(noCommits.Render(writerOptions));
 
 // --- Formattable types that render through the writer shape system ---
 

--- a/samples/TemplateDemo/TemplateDemo.csproj
+++ b/samples/TemplateDemo/TemplateDemo.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="..\..\src\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj" />
     <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />

--- a/samples/TemplateDemo/TemplateDemo.csproj
+++ b/samples/TemplateDemo/TemplateDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
+    <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="true" />
+  </ItemGroup>
+</Project>

--- a/samples/TemplateDemo/TemplateDemo.csproj
+++ b/samples/TemplateDemo/TemplateDemo.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="template.md" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
     <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"

--- a/samples/TemplateDemo/template.md
+++ b/samples/TemplateDemo/template.md
@@ -18,6 +18,7 @@ The following vulnerabilities were disclosed this month.
 | Low | 0.1–3.9 | Risk-accepted |
 
 {{#if commits}}
+
 ## Related Commits
 
 The following commits address the vulnerabilities above.

--- a/samples/TemplateDemo/template.md
+++ b/samples/TemplateDemo/template.md
@@ -8,6 +8,15 @@ The following vulnerabilities were disclosed this month.
 
 {{product-table}}
 
+## Severity Definitions
+
+| Level | CVSS Range | Response |
+| ----- | ---------- | -------- |
+| Critical | 9.0–10.0 | Patch immediately |
+| High | 7.0–8.9 | Patch within 30 days |
+| Medium | 4.0–6.9 | Patch at next cycle |
+| Low | 0.1–3.9 | Risk-accepted |
+
 {{#if commits}}
 ## Related Commits
 

--- a/samples/TemplateDemo/template.md
+++ b/samples/TemplateDemo/template.md
@@ -1,0 +1,17 @@
+# .NET Security Report for {{date}}
+
+The following vulnerabilities were disclosed this month.
+
+{{vuln-table}}
+
+## Affected Products
+
+{{product-table}}
+
+{{#if commits}}
+## Related Commits
+
+The following commits address the vulnerabilities above.
+
+{{commit-table}}
+{{/if}}

--- a/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
+++ b/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
@@ -1,0 +1,220 @@
+namespace MarkdownTable.Formatting;
+
+/// <summary>
+/// Calculates optimal column widths for markdown pipe tables using
+/// statistical analysis with percentile-based outlier handling.
+/// </summary>
+/// <remarks>
+/// Implements the A/B/C/D algorithm from smooth-markdown-table:
+/// <list type="bullet">
+///   <item>A: Minimum constraint — header width + cell padding</item>
+///   <item>B: Percentile width — Pth percentile of effective content lengths</item>
+///   <item>C: Tolerance-adjusted — longest content within B × tolerance</item>
+///   <item>D: Final target — max(A, B, C), capped at MaxColumnWidth</item>
+/// </list>
+/// Accumulated position tracking ensures earlier column overflows
+/// propagate correctly to later columns.
+/// </remarks>
+public static class ColumnWidthCalculator
+{
+    private const int CellPadding = 2; // leading space + trailing space
+
+    /// <summary>
+    /// Calculates target column widths for the given table data.
+    /// </summary>
+    /// <param name="headers">Header row values.</param>
+    /// <param name="rows">Data row values.</param>
+    /// <param name="options">Formatting options.</param>
+    /// <returns>Target width for each column (content width, excluding padding and pipes).</returns>
+    public static int[] Calculate(string[] headers, IReadOnlyList<string[]> rows, TableFormatterOptions? options = null)
+    {
+        options ??= new TableFormatterOptions();
+
+        if (options.AutoTune)
+            return CalculateAutoTuned(headers, rows, options);
+
+        return CalculateWithParameters(headers, rows, options.Percentile, options.Tolerance,
+            options.ShadowThreshold, options.MaxColumnWidth);
+    }
+
+    private static int[] CalculateWithParameters(string[] headers, IReadOnlyList<string[]> rows,
+        double percentile, double tolerance, int shadowThreshold, int maxColumnWidth)
+    {
+        int columnCount = headers.Length;
+        var targetWidths = new int[columnCount];
+
+        // Build full table (header + data) for analysis
+        int totalRows = 1 + rows.Count;
+        var allWidths = new int[totalRows][];
+        allWidths[0] = new int[columnCount];
+        for (int col = 0; col < columnCount; col++)
+            allWidths[0][col] = headers[col].Length;
+
+        for (int row = 0; row < rows.Count; row++)
+        {
+            allWidths[row + 1] = new int[columnCount];
+            for (int col = 0; col < columnCount; col++)
+                allWidths[row + 1][col] = col < rows[row].Length ? rows[row][col].Length : 0;
+        }
+
+        // Track accumulated positions for overflow propagation
+        var defaultEndPositions = new int[columnCount];
+        var rowEndPositions = new int[totalRows][];
+        for (int r = 0; r < totalRows; r++)
+            rowEndPositions[r] = new int[columnCount];
+
+        for (int col = 0; col < columnCount; col++)
+        {
+            bool lastColumn = col == columnCount - 1;
+
+            // A: Minimum constraint — header must fit
+            int headerWidth = allWidths[0][col];
+            int A = headerWidth + CellPadding;
+            int shadowValue = Math.Max(A, shadowThreshold);
+
+            // Default start position for this column
+            int defaultStart = col == 0 ? 0 : defaultEndPositions[col - 1] + 1; // +1 for pipe
+
+            // Calculate effective lengths per row
+            var effectiveLengths = new List<int>(totalRows);
+            for (int row = 0; row < totalRows; row++)
+            {
+                int contentWidth = allWidths[row][col];
+                int cellWidth = contentWidth + CellPadding;
+
+                int rowStart = col == 0 ? 0 : rowEndPositions[row][col - 1] + 1;
+                int rowEnd = rowStart + cellWidth;
+                rowEndPositions[row][col] = rowEnd;
+
+                // Accumulated position tracking:
+                // Non-final columns: use later position (overflow pushes right)
+                // Final column: use earlier position (enables trailing-edge alignment)
+                int effectiveStart = !lastColumn
+                    ? Math.Max(rowStart, defaultStart)
+                    : Math.Min(rowStart, defaultStart);
+                effectiveLengths.Add(rowEnd - effectiveStart);
+            }
+
+            effectiveLengths.Sort();
+
+            // B: Statistical percentile width with shadow threshold
+            int lastLength = effectiveLengths[^1];
+            int B = lastLength <= shadowValue ? lastLength : 0;
+            int C = 0;
+
+            if (B == 0 && effectiveLengths.Count > 0)
+            {
+                int percentileIndex = Math.Min((int)(effectiveLengths.Count * percentile), effectiveLengths.Count - 1);
+                B = effectiveLengths[percentileIndex];
+
+                // C: Longest content within tolerance of B
+                int toleranceLimit = (int)(B * tolerance);
+                C = effectiveLengths.LastOrDefault(l => l <= toleranceLimit);
+            }
+
+            // D: Final target
+            int D = Math.Max(Math.Max(A, B), C);
+            D = Math.Min(D, maxColumnWidth);
+
+            int defaultEnd = defaultStart + D;
+            defaultEndPositions[col] = defaultEnd;
+
+            // Content width = total width minus padding
+            targetWidths[col] = D - CellPadding;
+
+            // Update row end positions to reflect the planned width
+            for (int row = 0; row < totalRows; row++)
+            {
+                int rowStart = col == 0 ? 0 : rowEndPositions[row][col - 1] + 1;
+                int contentEnd = rowStart + allWidths[row][col] + CellPadding;
+                // Use whichever is larger: content or planned width
+                rowEndPositions[row][col] = Math.Max(contentEnd, defaultEnd);
+            }
+        }
+
+        return targetWidths;
+    }
+
+    /// <summary>
+    /// Hill-climbing auto-tune: iteratively adjusts percentile and tolerance
+    /// to achieve perfect trailing-edge alignment.
+    /// </summary>
+    private static int[] CalculateAutoTuned(string[] headers, IReadOnlyList<string[]> rows,
+        TableFormatterOptions options)
+    {
+        const int toleranceBumpsPerPercentile = 2;
+        const double toleranceIncrement = 0.2;
+        const double percentileIncrement = 0.2;
+        const int maxAttempts = 4;
+        const double outlierThreshold = 0.25;
+
+        double currentPercentile = options.Percentile;
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            for (int bump = 0; bump < toleranceBumpsPerPercentile; bump++)
+            {
+                double currentTolerance = options.Tolerance + (bump * toleranceIncrement);
+                var widths = CalculateWithParameters(headers, rows,
+                    currentPercentile, currentTolerance, options.ShadowThreshold, options.MaxColumnWidth);
+
+                if (HasPerfectAlignment(headers, rows, widths, outlierThreshold))
+                    return widths;
+            }
+
+            currentPercentile += percentileIncrement;
+        }
+
+        // Fallback: last attempted parameters
+        double fallbackTolerance = options.Tolerance + ((toleranceBumpsPerPercentile - 1) * toleranceIncrement);
+        return CalculateWithParameters(headers, rows,
+            currentPercentile - percentileIncrement, fallbackTolerance,
+            options.ShadowThreshold, options.MaxColumnWidth);
+    }
+
+    private static bool HasPerfectAlignment(string[] headers, IReadOnlyList<string[]> rows,
+        int[] targetWidths, double outlierThreshold)
+    {
+        int headerRowLength = CalculateRowLength(headers, targetWidths);
+
+        for (int r = 0; r < rows.Count; r++)
+        {
+            int rowLength = CalculateRowLength(rows[r], targetWidths);
+            if (rowLength != headerRowLength)
+                return false;
+        }
+
+        // Check for impractical outliers
+        double outlierLimit = headerRowLength * (1.0 + outlierThreshold);
+        for (int r = 0; r < rows.Count; r++)
+        {
+            int naturalLength = CalculateNaturalRowLength(rows[r]);
+            if (naturalLength >= outlierLimit)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int CalculateRowLength(string[] row, int[] targetWidths)
+    {
+        int length = 1; // leading pipe
+        for (int col = 0; col < targetWidths.Length; col++)
+        {
+            int contentWidth = col < row.Length ? row[col].Length : 0;
+            int cellWidth = Math.Max(contentWidth, targetWidths[col]) + CellPadding;
+            length += cellWidth + 1; // +1 for trailing pipe
+        }
+        return length;
+    }
+
+    private static int CalculateNaturalRowLength(string[] row)
+    {
+        int length = 1; // leading pipe
+        for (int col = 0; col < row.Length; col++)
+        {
+            length += row[col].Length + CellPadding + 1; // content + padding + pipe
+        }
+        return length;
+    }
+}

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>MarkdownTable.Formatting</RootNamespace>
+    <Description>Statistical column-width optimization for markdown pipe tables</Description>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+</Project>

--- a/src/MarkdownTable.Formatting/TableFormatter.cs
+++ b/src/MarkdownTable.Formatting/TableFormatter.cs
@@ -1,0 +1,79 @@
+using System.Text;
+
+namespace MarkdownTable.Formatting;
+
+/// <summary>
+/// Formats and reformats markdown pipe tables with statistical column-width optimization.
+/// </summary>
+public static class TableFormatter
+{
+    /// <summary>
+    /// Formats a table from header and row data into a markdown pipe table string.
+    /// </summary>
+    public static string Format(string[] headers, IReadOnlyList<string[]> rows, TableFormatterOptions? options = null)
+    {
+        if (headers.Length == 0)
+            return string.Empty;
+
+        var widths = ColumnWidthCalculator.Calculate(headers, rows, options);
+        return Render(headers, rows, widths);
+    }
+
+    /// <summary>
+    /// Reformats an existing markdown pipe table string with optimized column widths.
+    /// Returns the original text unchanged if it doesn't contain a valid pipe table.
+    /// </summary>
+    public static string Reformat(string text, TableFormatterOptions? options = null)
+    {
+        if (!TableParser.TryParse(text, out var headers, out var rows))
+            return text;
+
+        return Format(headers, rows, options);
+    }
+
+    /// <summary>
+    /// Renders a table with pre-calculated column widths.
+    /// </summary>
+    internal static string Render(string[] headers, IReadOnlyList<string[]> rows, int[] widths)
+    {
+        var sb = new StringBuilder();
+
+        RenderRow(sb, headers, widths);
+        RenderSeparator(sb, widths);
+
+        foreach (var row in rows)
+            RenderRow(sb, row, widths);
+
+        return sb.ToString();
+    }
+
+    private static void RenderRow(StringBuilder sb, string[] cells, int[] widths)
+    {
+        sb.Append('|');
+        for (int col = 0; col < widths.Length; col++)
+        {
+            sb.Append(' ');
+            var value = col < cells.Length ? cells[col] : "";
+            sb.Append(value);
+
+            int padding = widths[col] - value.Length;
+            if (padding > 0)
+                sb.Append(' ', padding);
+
+            sb.Append(" |");
+        }
+        sb.AppendLine();
+    }
+
+    private static void RenderSeparator(StringBuilder sb, int[] widths)
+    {
+        sb.Append('|');
+        for (int col = 0; col < widths.Length; col++)
+        {
+            sb.Append(' ');
+            sb.Append('-', widths[col]);
+            sb.Append(" |");
+        }
+        sb.AppendLine();
+    }
+}

--- a/src/MarkdownTable.Formatting/TableFormatterOptions.cs
+++ b/src/MarkdownTable.Formatting/TableFormatterOptions.cs
@@ -1,0 +1,41 @@
+namespace MarkdownTable.Formatting;
+
+/// <summary>
+/// Options for statistical table formatting.
+/// </summary>
+public class TableFormatterOptions
+{
+    /// <summary>
+    /// Percentile threshold for column width calculation (0.0–1.0).
+    /// Values at or below this percentile set the baseline width.
+    /// Default: 0.5 (median).
+    /// </summary>
+    public double Percentile { get; set; } = 0.5;
+
+    /// <summary>
+    /// Tolerance multiplier applied to the percentile width.
+    /// Content up to this multiple of the percentile width is accommodated
+    /// without overflow. Default: 1.5.
+    /// </summary>
+    public double Tolerance { get; set; } = 1.5;
+
+    /// <summary>
+    /// Shadow threshold — columns narrower than this use max-width
+    /// instead of statistical analysis. Prevents over-optimization
+    /// of narrow columns. Default: 12.
+    /// </summary>
+    public int ShadowThreshold { get; set; } = 12;
+
+    /// <summary>
+    /// Maximum allowed column width. Prevents extreme widths from
+    /// dominating the table. Default: 1000.
+    /// </summary>
+    public int MaxColumnWidth { get; set; } = 1000;
+
+    /// <summary>
+    /// When true, uses hill-climbing to find percentile/tolerance
+    /// parameters that achieve perfect trailing-edge alignment.
+    /// Default: false (use fixed parameters).
+    /// </summary>
+    public bool AutoTune { get; set; }
+}

--- a/src/MarkdownTable.Formatting/TableParser.cs
+++ b/src/MarkdownTable.Formatting/TableParser.cs
@@ -1,0 +1,111 @@
+namespace MarkdownTable.Formatting;
+
+/// <summary>
+/// Parses markdown pipe tables from text into structured header and row data.
+/// </summary>
+public static class TableParser
+{
+    /// <summary>
+    /// Attempts to parse a markdown pipe table from a sequence of lines.
+    /// Returns true if the lines represent a valid pipe table.
+    /// </summary>
+    public static bool TryParse(IReadOnlyList<string> lines, out string[] headers, out List<string[]> rows)
+    {
+        headers = [];
+        rows = [];
+
+        if (lines.Count < 2)
+            return false;
+
+        // Line 0: header row (must have pipes)
+        if (!TryParseRow(lines[0], out headers))
+            return false;
+
+        // Line 1: separator row (must be all dashes/colons/pipes)
+        if (!IsSeparatorRow(lines[1], headers.Length))
+            return false;
+
+        // Lines 2+: data rows
+        rows = new List<string[]>(lines.Count - 2);
+        for (int i = 2; i < lines.Count; i++)
+        {
+            if (TryParseRow(lines[i], out var row))
+                rows.Add(row);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to parse a pipe table from a block of text.
+    /// </summary>
+    public static bool TryParse(string text, out string[] headers, out List<string[]> rows)
+    {
+        var lines = text.Split('\n');
+        // Trim trailing empty lines
+        int end = lines.Length;
+        while (end > 0 && string.IsNullOrWhiteSpace(lines[end - 1]))
+            end--;
+
+        return TryParse(lines.AsSpan(0, end).ToArray(), out headers, out rows);
+    }
+
+    /// <summary>
+    /// Checks whether a line looks like the start of a pipe table
+    /// (contains a pipe character and is not a heading or placeholder).
+    /// </summary>
+    public static bool IsPipeTableLine(string line)
+    {
+        var trimmed = line.AsSpan().Trim();
+        return trimmed.Length > 0 && trimmed.Contains('|') && !trimmed.StartsWith("{{") && !trimmed.StartsWith("#");
+    }
+
+    private static bool TryParseRow(string line, out string[] cells)
+    {
+        cells = [];
+        var trimmed = line.Trim();
+
+        if (!trimmed.Contains('|'))
+            return false;
+
+        // Strip leading and trailing pipes
+        var span = trimmed.AsSpan();
+        if (span.StartsWith("|"))
+            span = span[1..];
+        if (span.EndsWith("|"))
+            span = span[..^1];
+
+        // Split on pipes and trim each cell
+        var parts = span.ToString().Split('|');
+        cells = new string[parts.Length];
+        for (int i = 0; i < parts.Length; i++)
+            cells[i] = parts[i].Trim();
+
+        return cells.Length > 0;
+    }
+
+    private static bool IsSeparatorRow(string line, int expectedColumns)
+    {
+        if (!TryParseRow(line, out var cells))
+            return false;
+
+        if (cells.Length != expectedColumns)
+            return false;
+
+        foreach (var cell in cells)
+        {
+            var trimmed = cell.Trim();
+            if (trimmed.Length == 0)
+                return false;
+
+            // Must be dashes, optionally with colons for alignment
+            foreach (var ch in trimmed)
+            {
+                if (ch != '-' && ch != ':')
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>Markout.Templates</RootNamespace>
+    <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
+    <Version>0.6.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Markout\Markout.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Markout\Markout.csproj" />
+    <ProjectReference Include="..\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>Markout.Templates</RootNamespace>
     <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -5,8 +5,8 @@ namespace Markout.Templates;
 /// data-driven content rendered through the Markout writer pipeline.
 /// </summary>
 /// <remarks>
-/// This is a peer entry path to the source generator. Both converge on
-/// <see cref="MarkoutWriter"/>:
+/// Like the source generator, templates render through the
+/// <see cref="MarkoutWriter"/> pipeline:
 /// <code>
 /// Source Generator:  [MarkoutSerializable] Type → Generated TypeInfo → MarkoutWriter
 /// Template Engine:   .md Template + Bindings  → MarkoutTemplate     → MarkoutWriter

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -184,6 +184,10 @@ public class MarkoutTemplate
             case BlankLineNode:
                 // The writer's spacing state handles blank lines naturally
                 break;
+
+            case TableNode table:
+                writer.WriteTable(table.Headers, table.Rows);
+                break;
         }
     }
 

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -25,6 +25,12 @@ public class MarkoutTemplate
     /// </summary>
     public TableFormatterOptions? TableOptions { get; set; }
 
+    /// <summary>
+    /// When true, unbound block placeholders are silently skipped instead of throwing.
+    /// Useful for CLI tools and partial rendering scenarios.
+    /// </summary>
+    public bool SkipUnboundPlaceholders { get; set; }
+
     private MarkoutTemplate(List<TemplateNode> nodes)
     {
         _nodes = nodes;
@@ -183,7 +189,7 @@ public class MarkoutTemplate
                 {
                     binding.Render(writer);
                 }
-                else
+                else if (!SkipUnboundPlaceholders)
                 {
                     throw new InvalidOperationException($"No binding found for placeholder '{placeholder.Key}'.");
                 }

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -1,0 +1,204 @@
+namespace Markout.Templates;
+
+/// <summary>
+/// A parsed template that combines human-authored document structure with
+/// data-driven content rendered through the Markout writer pipeline.
+/// </summary>
+/// <remarks>
+/// This is a peer entry path to the source generator. Both converge on
+/// <see cref="MarkoutWriter"/>:
+/// <code>
+/// Source Generator:  [MarkoutSerializable] Type → Generated TypeInfo → MarkoutWriter
+/// Template Engine:   .md Template + Bindings  → MarkoutTemplate     → MarkoutWriter
+/// </code>
+/// </remarks>
+public class MarkoutTemplate
+{
+    private readonly List<TemplateNode> _nodes;
+    private readonly Dictionary<string, TemplateBinding> _bindings = new(StringComparer.OrdinalIgnoreCase);
+
+    private MarkoutTemplate(List<TemplateNode> nodes)
+    {
+        _nodes = nodes;
+    }
+
+    /// <summary>
+    /// Parses template text into a <see cref="MarkoutTemplate"/>.
+    /// </summary>
+    public static MarkoutTemplate Parse(string text)
+    {
+        var nodes = TemplateParser.Parse(text);
+        return new MarkoutTemplate(nodes);
+    }
+
+    /// <summary>
+    /// Loads and parses a template from a file path.
+    /// </summary>
+    public static MarkoutTemplate Load(string path)
+    {
+        var text = File.ReadAllText(path);
+        return Parse(text);
+    }
+
+    /// <summary>
+    /// Loads and parses a template from a stream.
+    /// </summary>
+    public static MarkoutTemplate Load(Stream stream)
+    {
+        using var reader = new StreamReader(stream);
+        var text = reader.ReadToEnd();
+        return Parse(text);
+    }
+
+    /// <summary>
+    /// Binds a string value for inline substitution.
+    /// </summary>
+    public MarkoutTemplate Bind(string key, string? value)
+    {
+        _bindings[key] = new StringBinding(value);
+        return this;
+    }
+
+    /// <summary>
+    /// Binds an <see cref="IMarkoutFormattable"/> value for block-level rendering.
+    /// </summary>
+    public MarkoutTemplate Bind(string key, IMarkoutFormattable? value)
+    {
+        _bindings[key] = new FormattableBinding(value);
+        return this;
+    }
+
+    /// <summary>
+    /// Binds a source-generated type for block-level rendering through the shape system.
+    /// </summary>
+    public MarkoutTemplate Bind<T>(string key, T value, MarkoutTypeInfo<T> typeInfo)
+    {
+        _bindings[key] = new TypeInfoBinding<T>(value, typeInfo);
+        return this;
+    }
+
+    /// <summary>
+    /// Binds an arbitrary object. Used for conditional truthiness and ToString() fallback.
+    /// </summary>
+    public MarkoutTemplate BindObject(string key, object? value)
+    {
+        _bindings[key] = new ObjectBinding(value);
+        return this;
+    }
+
+    /// <summary>
+    /// Renders the template using a <see cref="MarkdownWriter"/> and returns the result as a string.
+    /// </summary>
+    public string Render()
+    {
+        var writer = new MarkdownWriter();
+        Render(writer);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Renders the template using a <see cref="MarkdownWriter"/> with the specified options
+    /// and returns the result as a string.
+    /// </summary>
+    public string Render(MarkoutWriterOptions options)
+    {
+        var writer = new MarkdownWriter(options);
+        Render(writer);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Renders the template into the specified <see cref="MarkoutWriter"/>.
+    /// </summary>
+    public void Render(MarkoutWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        int skipDepth = 0;
+
+        foreach (var node in _nodes)
+        {
+            switch (node)
+            {
+                case ConditionalStartNode conditional:
+                    if (skipDepth > 0)
+                    {
+                        skipDepth++;
+                    }
+                    else if (!IsBindingTruthy(conditional.Key))
+                    {
+                        skipDepth = 1;
+                    }
+                    break;
+
+                case ConditionalEndNode:
+                    if (skipDepth > 0)
+                        skipDepth--;
+                    break;
+
+                default:
+                    if (skipDepth > 0)
+                        break;
+
+                    RenderNode(writer, node);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders the template into the specified <see cref="TextWriter"/>
+    /// using a <see cref="MarkdownWriter"/>.
+    /// </summary>
+    public void Render(TextWriter output)
+    {
+        var writer = new MarkdownWriter(output);
+        Render(writer);
+        writer.Flush();
+    }
+
+    private void RenderNode(MarkoutWriter writer, TemplateNode node)
+    {
+        switch (node)
+        {
+            case HeadingNode heading:
+                var resolvedHeading = ResolveInline(heading.Text);
+                writer.WriteHeading(heading.Level, resolvedHeading, null);
+                break;
+
+            case ParagraphNode paragraph:
+                var resolvedText = ResolveInline(paragraph.Text);
+                writer.WriteParagraph(resolvedText);
+                break;
+
+            case PlaceholderNode placeholder:
+                if (_bindings.TryGetValue(placeholder.Key, out var binding))
+                {
+                    binding.Render(writer);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"No binding found for placeholder '{placeholder.Key}'.");
+                }
+                break;
+
+            case BlankLineNode:
+                // The writer's spacing state handles blank lines naturally
+                break;
+        }
+    }
+
+    private string ResolveInline(string text)
+    {
+        return TemplateParser.ResolveInlinePlaceholders(text, key =>
+        {
+            if (_bindings.TryGetValue(key, out var binding))
+                return binding.RenderInline();
+            return null;
+        });
+    }
+
+    private bool IsBindingTruthy(string key)
+    {
+        return _bindings.TryGetValue(key, out var binding) && binding.IsTruthy;
+    }
+}

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -1,3 +1,5 @@
+using MarkdownTable.Formatting;
+
 namespace Markout.Templates;
 
 /// <summary>
@@ -16,6 +18,12 @@ public class MarkoutTemplate
 {
     private readonly List<TemplateNode> _nodes;
     private readonly Dictionary<string, TemplateBinding> _bindings = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Options for formatting pipe tables found in the template.
+    /// When null, tables pass through to the writer with no width optimization.
+    /// </summary>
+    public TableFormatterOptions? TableOptions { get; set; }
 
     private MarkoutTemplate(List<TemplateNode> nodes)
     {
@@ -186,7 +194,19 @@ public class MarkoutTemplate
                 break;
 
             case TableNode table:
-                writer.WriteTable(table.Headers, table.Rows);
+                if (TableOptions is not null)
+                {
+                    // Use statistical width calculator to plan column widths,
+                    // then pass padded cells through WriteTable so any writer benefits
+                    var widths = ColumnWidthCalculator.Calculate(table.Headers, table.Rows, TableOptions);
+                    var paddedHeaders = PadCells(table.Headers, widths);
+                    var paddedRows = table.Rows.Select(row => PadCells(row, widths)).ToList();
+                    writer.WriteTable(paddedHeaders, paddedRows);
+                }
+                else
+                {
+                    writer.WriteTable(table.Headers, table.Rows);
+                }
                 break;
         }
     }
@@ -204,5 +224,16 @@ public class MarkoutTemplate
     private bool IsBindingTruthy(string key)
     {
         return _bindings.TryGetValue(key, out var binding) && binding.IsTruthy;
+    }
+
+    private static string[] PadCells(string[] cells, int[] widths)
+    {
+        var padded = new string[widths.Length];
+        for (int i = 0; i < widths.Length; i++)
+        {
+            var value = i < cells.Length ? cells[i] : "";
+            padded[i] = value.PadRight(widths[i]);
+        }
+        return padded;
     }
 }

--- a/src/Markout.Templates/TemplateBinding.cs
+++ b/src/Markout.Templates/TemplateBinding.cs
@@ -1,0 +1,102 @@
+namespace Markout.Templates;
+
+/// <summary>
+/// Wraps a bound value with its rendering strategy.
+/// </summary>
+public abstract class TemplateBinding
+{
+    /// <summary>
+    /// Renders this binding as block-level content through the writer.
+    /// </summary>
+    public abstract void Render(MarkoutWriter writer);
+
+    /// <summary>
+    /// Returns an inline text representation for use within headings and paragraphs.
+    /// </summary>
+    public abstract string? RenderInline();
+
+    /// <summary>
+    /// Whether this binding represents a truthy value (for conditional sections).
+    /// </summary>
+    public abstract bool IsTruthy { get; }
+}
+
+/// <summary>
+/// A binding for a simple string value. Used for inline substitution and conditional checks.
+/// </summary>
+internal sealed class StringBinding(string? value) : TemplateBinding
+{
+    public override void Render(MarkoutWriter writer)
+    {
+        if (value is not null)
+            writer.WriteParagraph(value);
+    }
+
+    public override string? RenderInline() => value;
+
+    public override bool IsTruthy => value is not null;
+}
+
+/// <summary>
+/// A binding for a type that controls its own Markout rendering.
+/// </summary>
+internal sealed class FormattableBinding(IMarkoutFormattable? value) : TemplateBinding
+{
+    public override void Render(MarkoutWriter writer)
+    {
+        value?.WriteTo(writer);
+    }
+
+    public override string? RenderInline() => value?.ToMarkoutString();
+
+    public override bool IsTruthy => value is not null;
+}
+
+/// <summary>
+/// A binding for a source-generated Markout type, rendered through its TypeInfo.
+/// </summary>
+internal sealed class TypeInfoBinding<T>(T value, MarkoutTypeInfo<T> typeInfo) : TemplateBinding
+{
+    public override void Render(MarkoutWriter writer)
+    {
+        if (value is not null)
+            typeInfo.Serialize(writer, value);
+    }
+
+    public override string? RenderInline()
+    {
+        if (value is IMarkoutFormattable formattable)
+            return formattable.ToMarkoutString();
+
+        return value?.ToString();
+    }
+
+    public override bool IsTruthy => value is not null;
+}
+
+/// <summary>
+/// A binding for an arbitrary object. Used for conditional truthiness and ToString() fallback.
+/// </summary>
+internal sealed class ObjectBinding(object? value) : TemplateBinding
+{
+    public override void Render(MarkoutWriter writer)
+    {
+        if (value is IMarkoutFormattable formattable)
+        {
+            formattable.WriteTo(writer);
+        }
+        else if (value is not null)
+        {
+            writer.WriteParagraph(value.ToString());
+        }
+    }
+
+    public override string? RenderInline() => value switch
+    {
+        IMarkoutFormattable f => f.ToMarkoutString(),
+        not null => value.ToString(),
+        _ => null
+    };
+
+    public override bool IsTruthy => value is not null;
+}

--- a/src/Markout.Templates/TemplateNode.cs
+++ b/src/Markout.Templates/TemplateNode.cs
@@ -1,0 +1,38 @@
+namespace Markout.Templates;
+
+/// <summary>
+/// A parsed element from a Markout template.
+/// </summary>
+public abstract record TemplateNode;
+
+/// <summary>
+/// An ATX heading (# through ######). Text may contain inline {{key}} placeholders.
+/// </summary>
+public record HeadingNode(int Level, string Text) : TemplateNode;
+
+/// <summary>
+/// A paragraph of prose text. May contain inline {{key}} placeholders.
+/// </summary>
+public record ParagraphNode(string Text) : TemplateNode;
+
+/// <summary>
+/// A block-level placeholder ({{key}} on its own line).
+/// Resolved by rendering a bound value through the writer.
+/// </summary>
+public record PlaceholderNode(string Key) : TemplateNode;
+
+/// <summary>
+/// Start of a conditional section ({{#if key}}).
+/// Content is included only when the key is bound to a truthy value.
+/// </summary>
+public record ConditionalStartNode(string Key) : TemplateNode;
+
+/// <summary>
+/// End of a conditional section ({{/if}}).
+/// </summary>
+public record ConditionalEndNode() : TemplateNode;
+
+/// <summary>
+/// A blank line in the template, preserved for structural spacing.
+/// </summary>
+public record BlankLineNode() : TemplateNode;

--- a/src/Markout.Templates/TemplateNode.cs
+++ b/src/Markout.Templates/TemplateNode.cs
@@ -36,3 +36,9 @@ public record ConditionalEndNode() : TemplateNode;
 /// A blank line in the template, preserved for structural spacing.
 /// </summary>
 public record BlankLineNode() : TemplateNode;
+
+/// <summary>
+/// A pipe table parsed from the template. Headers and rows are extracted
+/// so the table can be re-rendered through the writer's table shape.
+/// </summary>
+public record TableNode(string[] Headers, List<string[]> Rows) : TemplateNode;

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -1,0 +1,193 @@
+namespace Markout.Templates;
+
+/// <summary>
+/// Parses template text into a sequence of <see cref="TemplateNode"/> elements.
+/// Recognizes ATX headings, block-level placeholders, conditional sections,
+/// blank lines, and prose paragraphs with optional inline placeholders.
+/// </summary>
+public static class TemplateParser
+{
+    private const string OpenSymbol = "{{";
+    private const string CloseSymbol = "}}";
+
+    /// <summary>
+    /// Parses template text into an ordered list of nodes.
+    /// </summary>
+    public static List<TemplateNode> Parse(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        var nodes = new List<TemplateNode>();
+        List<string>? paragraphLines = null;
+
+        using var reader = new StringReader(text);
+        string? line;
+
+        while ((line = reader.ReadLine()) is not null)
+        {
+            // Blank line
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                FlushParagraph(nodes, ref paragraphLines);
+                nodes.Add(new BlankLineNode());
+                continue;
+            }
+
+            // Conditional: {{#if key}} or {{/if}}
+            if (TryParseConditional(line, out var conditionalNode))
+            {
+                FlushParagraph(nodes, ref paragraphLines);
+                nodes.Add(conditionalNode);
+                continue;
+            }
+
+            // Block-level placeholder: {{key}} as the entire line
+            if (TryParseBlockPlaceholder(line, out var key))
+            {
+                FlushParagraph(nodes, ref paragraphLines);
+                nodes.Add(new PlaceholderNode(key));
+                continue;
+            }
+
+            // ATX heading: # through ######
+            if (TryParseHeading(line, out int level, out string? headingText))
+            {
+                FlushParagraph(nodes, ref paragraphLines);
+                nodes.Add(new HeadingNode(level, headingText));
+                continue;
+            }
+
+            // Prose — accumulate into paragraph
+            paragraphLines ??= [];
+            paragraphLines.Add(line);
+        }
+
+        FlushParagraph(nodes, ref paragraphLines);
+        return nodes;
+    }
+
+    private static void FlushParagraph(List<TemplateNode> nodes, ref List<string>? lines)
+    {
+        if (lines is null || lines.Count == 0)
+            return;
+
+        var text = string.Join('\n', lines);
+        nodes.Add(new ParagraphNode(text));
+        lines = null;
+    }
+
+    private static bool TryParseBlockPlaceholder(string line, out string key)
+    {
+        var trimmed = line.AsSpan().Trim();
+
+        if (trimmed.StartsWith(OpenSymbol) && trimmed.EndsWith(CloseSymbol))
+        {
+            var inner = trimmed[2..^2].Trim();
+
+            // Must be a simple key (no spaces, no directives like #if)
+            if (inner.Length > 0 && !inner.Contains(' ') && inner[0] != '#' && inner[0] != '/')
+            {
+                key = inner.ToString();
+                return true;
+            }
+        }
+
+        key = "";
+        return false;
+    }
+
+    private static bool TryParseConditional(string line, out TemplateNode node)
+    {
+        var trimmed = line.AsSpan().Trim();
+
+        if (trimmed.StartsWith(OpenSymbol) && trimmed.EndsWith(CloseSymbol))
+        {
+            var inner = trimmed[2..^2].Trim();
+
+            if (inner.StartsWith("#if "))
+            {
+                var key = inner[4..].Trim();
+                if (key.Length > 0)
+                {
+                    node = new ConditionalStartNode(key.ToString());
+                    return true;
+                }
+            }
+            else if (inner is "/if")
+            {
+                node = new ConditionalEndNode();
+                return true;
+            }
+        }
+
+        node = default!;
+        return false;
+    }
+
+    private static bool TryParseHeading(string line, out int level, out string text)
+    {
+        var span = line.AsSpan();
+        level = 0;
+
+        while (level < span.Length && level < 6 && span[level] == '#')
+            level++;
+
+        if (level > 0 && level < span.Length && span[level] == ' ')
+        {
+            text = span[(level + 1)..].ToString();
+            return true;
+        }
+
+        level = 0;
+        text = "";
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves inline {{key}} placeholders in text using the provided lookup function.
+    /// </summary>
+    /// <summary>
+    /// Resolves inline {{key}} placeholders in text using the provided lookup function.
+    /// Returns the text with all known keys replaced and unknown keys preserved.
+    /// </summary>
+    public static string ResolveInlinePlaceholders(string text, Func<string, string?> lookup)
+    {
+        if (!text.Contains(OpenSymbol))
+            return text;
+
+        var span = text.AsSpan();
+        var result = new System.Text.StringBuilder(text.Length);
+        int pos = 0;
+
+        while (pos < span.Length)
+        {
+            int openIndex = span[pos..].IndexOf(OpenSymbol);
+
+            if (openIndex < 0)
+            {
+                result.Append(span[pos..]);
+                break;
+            }
+
+            // Append text before the placeholder
+            result.Append(span[pos..(pos + openIndex)]);
+
+            int keyStart = pos + openIndex + OpenSymbol.Length;
+            int closeIndex = span[keyStart..].IndexOf(CloseSymbol);
+
+            if (closeIndex < 0)
+            {
+                // No closing — append remainder as-is
+                result.Append(span[(pos + openIndex)..]);
+                break;
+            }
+
+            var key = span[keyStart..(keyStart + closeIndex)].Trim();
+            var replacement = lookup(key.ToString());
+            result.Append(replacement ?? $"{OpenSymbol}{key}{CloseSymbol}");
+
+            pos = keyStart + closeIndex + CloseSymbol.Length;
+        }
+
+        return result.ToString();
+    }
+}

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -1,3 +1,5 @@
+using MarkdownTable.Formatting;
+
 namespace Markout.Templates;
 
 /// <summary>
@@ -18,6 +20,7 @@ public static class TemplateParser
         ArgumentNullException.ThrowIfNull(text);
         var nodes = new List<TemplateNode>();
         List<string>? paragraphLines = null;
+        List<string>? tableLines = null;
 
         using var reader = new StringReader(text);
         string? line;
@@ -27,9 +30,23 @@ public static class TemplateParser
             // Blank line
             if (string.IsNullOrWhiteSpace(line))
             {
+                FlushTable(nodes, ref tableLines);
                 FlushParagraph(nodes, ref paragraphLines);
                 nodes.Add(new BlankLineNode());
                 continue;
+            }
+
+            // If we're accumulating table lines, check if this continues the table
+            if (tableLines is not null)
+            {
+                if (TableParser.IsPipeTableLine(line))
+                {
+                    tableLines.Add(line);
+                    continue;
+                }
+
+                // Not a table line — flush the table and fall through
+                FlushTable(nodes, ref tableLines);
             }
 
             // Conditional: {{#if key}} or {{/if}}
@@ -56,11 +73,20 @@ public static class TemplateParser
                 continue;
             }
 
+            // Pipe table start — a line with pipes that isn't a heading or placeholder
+            if (TableParser.IsPipeTableLine(line))
+            {
+                FlushParagraph(nodes, ref paragraphLines);
+                tableLines = [line];
+                continue;
+            }
+
             // Prose — accumulate into paragraph
             paragraphLines ??= [];
             paragraphLines.Add(line);
         }
 
+        FlushTable(nodes, ref tableLines);
         FlushParagraph(nodes, ref paragraphLines);
         return nodes;
     }
@@ -72,6 +98,25 @@ public static class TemplateParser
 
         var text = string.Join('\n', lines);
         nodes.Add(new ParagraphNode(text));
+        lines = null;
+    }
+
+    private static void FlushTable(List<TemplateNode> nodes, ref List<string>? lines)
+    {
+        if (lines is null || lines.Count == 0)
+            return;
+
+        if (TableParser.TryParse(lines, out var headers, out var rows))
+        {
+            nodes.Add(new TableNode(headers, rows));
+        }
+        else
+        {
+            // Not a valid table — treat as paragraph text
+            var text = string.Join('\n', lines);
+            nodes.Add(new ParagraphNode(text));
+        }
+
         lines = null;
     }
 

--- a/tests/Markout.Templates.Tests/Markout.Templates.Tests.csproj
+++ b/tests/Markout.Templates.Tests/Markout.Templates.Tests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="..\..\src\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Markout.Templates.Tests/Markout.Templates.Tests.csproj
+++ b/tests/Markout.Templates.Tests/Markout.Templates.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
+    <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Markout.Templates.Tests/MarkoutTemplateTests.cs
+++ b/tests/Markout.Templates.Tests/MarkoutTemplateTests.cs
@@ -1,0 +1,277 @@
+using Markout.Templates;
+
+namespace Markout.Templates.Tests;
+
+public class MarkoutTemplateTests
+{
+    [Fact]
+    public void Render_SimpleHeadingWithInlineBinding()
+    {
+        var template = MarkoutTemplate.Parse("# Report for {{date}}");
+        template.Bind("date", "February 2026");
+
+        var result = template.Render();
+
+        Assert.Equal("# Report for February 2026", result.TrimEnd());
+    }
+
+    [Fact]
+    public void Render_ParagraphWithInlineBinding()
+    {
+        var template = MarkoutTemplate.Parse("Hello {{name}}, welcome!");
+        template.Bind("name", "Alice");
+
+        var result = template.Render();
+
+        Assert.Equal("Hello Alice, welcome!", result.TrimEnd());
+    }
+
+    [Fact]
+    public void Render_BlockPlaceholderWithStringBinding()
+    {
+        var text = "# Title\n\n{{content}}";
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("content", "Some paragraph content.");
+
+        var result = template.Render();
+
+        Assert.Contains("# Title", result);
+        Assert.Contains("Some paragraph content.", result);
+    }
+
+    [Fact]
+    public void Render_BlockPlaceholderWithFormattableBinding()
+    {
+        var text = "# Title\n\n{{content}}";
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("content", new TestFormattable());
+
+        var result = template.Render();
+
+        Assert.Contains("# Title", result);
+        Assert.Contains("Key: Value", result);
+    }
+
+    [Fact]
+    public void Render_ConditionalSection_Included()
+    {
+        var text = "# Report\n\n{{#if extras}}\n## Extras\n\nExtra content.\n{{/if}}";
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("extras", "truthy-value");
+
+        var result = template.Render();
+
+        Assert.Contains("## Extras", result);
+        Assert.Contains("Extra content.", result);
+    }
+
+    [Fact]
+    public void Render_ConditionalSection_Excluded()
+    {
+        var text = "# Report\n\n{{#if extras}}\n## Extras\n\nExtra content.\n{{/if}}";
+        var template = MarkoutTemplate.Parse(text);
+        // Don't bind "extras" — section should be excluded
+
+        var result = template.Render();
+
+        Assert.Contains("# Report", result);
+        Assert.DoesNotContain("Extras", result);
+        Assert.DoesNotContain("Extra content.", result);
+    }
+
+    [Fact]
+    public void Render_ConditionalSection_NullExcluded()
+    {
+        var text = "# Report\n\n{{#if extras}}\n## Extras\n{{/if}}";
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("extras", (string?)null);
+
+        var result = template.Render();
+
+        Assert.DoesNotContain("Extras", result);
+    }
+
+    [Fact]
+    public void Render_NestedConditionals()
+    {
+        var text = "{{#if outer}}\nOuter\n{{#if inner}}\nInner\n{{/if}}\n{{/if}}";
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("outer", "yes");
+        // Don't bind inner
+
+        var result = template.Render();
+
+        Assert.Contains("Outer", result);
+        Assert.DoesNotContain("Inner", result);
+    }
+
+    [Fact]
+    public void Render_NestedConditionals_OuterFalse_SkipsAll()
+    {
+        var text = "{{#if outer}}\nOuter\n{{#if inner}}\nInner\n{{/if}}\n{{/if}}";
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("inner", "yes");
+        // Don't bind outer
+
+        var result = template.Render();
+
+        Assert.DoesNotContain("Outer", result);
+        Assert.DoesNotContain("Inner", result);
+    }
+
+    [Fact]
+    public void Render_UnboundPlaceholder_Throws()
+    {
+        var template = MarkoutTemplate.Parse("{{unknown}}");
+
+        Assert.Throws<InvalidOperationException>(() => template.Render());
+    }
+
+    [Fact]
+    public void Render_PlainTextWriter()
+    {
+        var template = MarkoutTemplate.Parse("# Title\n\nSome text.");
+        var writer = new MarkoutWriter();
+        template.Render(writer);
+        var result = writer.ToString();
+
+        // Plain text writer uses different heading format
+        Assert.Contains("Title", result);
+        Assert.Contains("Some text.", result);
+    }
+
+    [Fact]
+    public void Render_TextWriterOverload()
+    {
+        var template = MarkoutTemplate.Parse("# Title");
+        using var sw = new StringWriter();
+        template.Render(sw);
+        var result = sw.ToString();
+
+        Assert.Contains("# Title", result);
+    }
+
+    [Fact]
+    public void Render_FluentBindingApi()
+    {
+        var result = MarkoutTemplate.Parse("# {{title}}\n\n{{body}}")
+            .Bind("title", "Hello")
+            .Bind("body", "World.")
+            .Render();
+
+        Assert.Contains("# Hello", result);
+        Assert.Contains("World.", result);
+    }
+
+    [Fact]
+    public void Render_FullDocumentTemplate()
+    {
+        var text = """
+            # .NET CVEs for {{date}}
+
+            The following vulnerabilities were disclosed.
+
+            {{vuln-table}}
+
+            ## Products
+
+            {{product-table}}
+
+            {{#if commits}}
+            ## Commits
+
+            Commit details follow.
+
+            {{commit-table}}
+            {{/if}}
+            """;
+
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("date", "February 2026");
+        template.Bind("vuln-table", new TestTableFormattable("CVE-2026-001", "Critical"));
+        template.Bind("product-table", new TestTableFormattable(".NET 9", "Patched"));
+        template.Bind("commits", "has-commits");
+        template.Bind("commit-table", new TestTableFormattable("abc123", "Fix"));
+
+        var result = template.Render();
+
+        Assert.Contains("# .NET CVEs for February 2026", result);
+        Assert.Contains("The following vulnerabilities were disclosed.", result);
+        Assert.Contains("CVE-2026-001", result);
+        Assert.Contains(".NET 9", result);
+        Assert.Contains("## Commits", result);
+        Assert.Contains("abc123", result);
+    }
+
+    [Fact]
+    public void Render_FullDocumentTemplate_WithoutCommits()
+    {
+        var text = """
+            # .NET CVEs for {{date}}
+
+            The following vulnerabilities were disclosed.
+
+            {{vuln-table}}
+
+            {{#if commits}}
+            ## Commits
+
+            {{commit-table}}
+            {{/if}}
+            """;
+
+        var template = MarkoutTemplate.Parse(text);
+        template.Bind("date", "February 2026");
+        template.Bind("vuln-table", new TestTableFormattable("CVE-2026-001", "Critical"));
+        // Don't bind commits — conditional section excluded
+
+        var result = template.Render();
+
+        Assert.Contains("CVE-2026-001", result);
+        Assert.DoesNotContain("Commits", result);
+    }
+
+    [Fact]
+    public void Render_ObjectBinding()
+    {
+        var template = MarkoutTemplate.Parse("{{#if data}}\nHas data.\n{{/if}}");
+        template.BindObject("data", new object());
+
+        var result = template.Render();
+        Assert.Contains("Has data.", result);
+    }
+
+    [Fact]
+    public void Render_ObjectBinding_Null()
+    {
+        var template = MarkoutTemplate.Parse("{{#if data}}\nHas data.\n{{/if}}");
+        template.BindObject("data", null);
+
+        var result = template.Render();
+        Assert.DoesNotContain("Has data.", result);
+    }
+
+    // Test helpers
+
+    private class TestFormattable : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            writer.WriteField("Key", "Value");
+        }
+
+        public string? ToMarkoutString() => "Key=Value";
+    }
+
+    private class TestTableFormattable(string col1, string col2) : IMarkoutFormattable
+    {
+        public void WriteTo(MarkoutWriter writer)
+        {
+            writer.WriteTableStart("Name", "Status");
+            writer.WriteTableRow(col1, col2);
+            writer.WriteTableEnd();
+        }
+
+        public string? ToMarkoutString() => $"{col1}: {col2}";
+    }
+}

--- a/tests/Markout.Templates.Tests/MarkoutTemplateTests.cs
+++ b/tests/Markout.Templates.Tests/MarkoutTemplateTests.cs
@@ -251,6 +251,42 @@ public class MarkoutTemplateTests
         Assert.DoesNotContain("Has data.", result);
     }
 
+    [Fact]
+    public void Render_InlineTable_RenderedThroughWriter()
+    {
+        var text = """
+            # Report
+
+            | Name | Value |
+            | ---- | ----- |
+            | Alpha | 1 |
+            | Beta  | 2 |
+            """;
+
+        var template = MarkoutTemplate.Parse(text);
+        var result = template.Render();
+
+        // Table should be rendered through the writer's table shape
+        Assert.Contains("# Report", result);
+        Assert.Contains("Alpha", result);
+        Assert.Contains("Beta", result);
+        Assert.Contains("|", result);
+    }
+
+    [Fact]
+    public void Render_InlineTable_PlainText()
+    {
+        var text = "| Name | Value |\n| ---- | ----- |\n| A | 1 |";
+        var template = MarkoutTemplate.Parse(text);
+        var writer = new MarkoutWriter();
+        template.Render(writer);
+        var result = writer.ToString();
+
+        // Plain text writer renders tables without pipes
+        Assert.Contains("Name", result);
+        Assert.Contains("A", result);
+    }
+
     // Test helpers
 
     private class TestFormattable : IMarkoutFormattable

--- a/tests/Markout.Templates.Tests/TableFormatterTests.cs
+++ b/tests/Markout.Templates.Tests/TableFormatterTests.cs
@@ -1,0 +1,156 @@
+using MarkdownTable.Formatting;
+
+namespace Markout.Templates.Tests;
+
+public class TableFormatterTests
+{
+    [Fact]
+    public void Format_SimpleTable()
+    {
+        var headers = new[] { "Name", "Value" };
+        var rows = new List<string[]>
+        {
+            new[] { "Alpha", "1" },
+            new[] { "Beta", "2" },
+        };
+
+        var result = TableFormatter.Format(headers, rows);
+
+        Assert.Contains("| Name", result);
+        Assert.Contains("| Alpha", result);
+        Assert.Contains("---", result);
+    }
+
+    [Fact]
+    public void Format_UnevenColumnWidths()
+    {
+        var headers = new[] { "Short", "Much Longer Header" };
+        var rows = new List<string[]>
+        {
+            new[] { "a", "b" },
+            new[] { "longer value", "c" },
+        };
+
+        var result = TableFormatter.Format(headers, rows);
+
+        // Header should be padded to at least its own length
+        Assert.Contains("Much Longer Header", result);
+        // The separator should have dashes matching the header width
+        var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.True(lines.Length >= 3);
+    }
+
+    [Fact]
+    public void Format_EmptyHeaders_ReturnsEmpty()
+    {
+        var result = TableFormatter.Format(Array.Empty<string>(), new List<string[]>());
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void Reformat_ValidTable()
+    {
+        var input = """
+            | Name | Value |
+            | --- | --- |
+            | Alpha | 1 |
+            | Beta | 2 |
+            """;
+
+        var result = TableFormatter.Reformat(input);
+
+        Assert.Contains("Alpha", result);
+        Assert.Contains("Beta", result);
+    }
+
+    [Fact]
+    public void Reformat_NotATable_ReturnsOriginal()
+    {
+        var input = "This is just text.";
+        var result = TableFormatter.Reformat(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void Format_WithAutoTune()
+    {
+        var headers = new[] { "CVE", "Severity", "Component" };
+        var rows = new List<string[]>
+        {
+            new[] { "CVE-2026-1234", "Critical", "System.Net.Http" },
+            new[] { "CVE-2026-1235", "High", "Microsoft.Data.SqlClient" },
+            new[] { "CVE-2026-1236", "Medium", "System.Text.Json" },
+        };
+
+        var options = new TableFormatterOptions { AutoTune = true };
+        var result = TableFormatter.Format(headers, rows, options);
+
+        Assert.Contains("CVE-2026-1234", result);
+        Assert.Contains("Microsoft.Data.SqlClient", result);
+    }
+
+    [Fact]
+    public void Format_OutlierRow_HandledGracefully()
+    {
+        var headers = new[] { "Name", "Description" };
+        var rows = new List<string[]>
+        {
+            new[] { "Short", "Brief" },
+            new[] { "Also short", "Tiny" },
+            new[] { "Reasonable", "This is a very long description that far exceeds the typical column width and should be handled as an outlier by the statistical algorithm" },
+        };
+
+        var result = TableFormatter.Format(headers, rows);
+
+        // Should produce valid output without crashing
+        Assert.Contains("Short", result);
+        Assert.Contains("very long description", result);
+    }
+}
+
+public class TableParserTests
+{
+    [Fact]
+    public void TryParse_ValidTable()
+    {
+        var text = """
+            | Name | Value |
+            | ---- | ----- |
+            | A    | 1     |
+            | B    | 2     |
+            """;
+
+        Assert.True(TableParser.TryParse(text, out var headers, out var rows));
+        Assert.Equal(new[] { "Name", "Value" }, headers);
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("A", rows[0][0]);
+    }
+
+    [Fact]
+    public void TryParse_NoPipes_ReturnsFalse()
+    {
+        Assert.False(TableParser.TryParse("Not a table", out _, out _));
+    }
+
+    [Fact]
+    public void TryParse_NoSeparator_ReturnsFalse()
+    {
+        var text = """
+            | Name | Value |
+            | A    | 1     |
+            """;
+
+        // Second line doesn't have all dashes — it's a data row, not a separator
+        Assert.False(TableParser.TryParse(text, out _, out _));
+    }
+
+    [Fact]
+    public void IsPipeTableLine_Various()
+    {
+        Assert.True(TableParser.IsPipeTableLine("| Name | Value |"));
+        Assert.True(TableParser.IsPipeTableLine("| --- | --- |"));
+        Assert.False(TableParser.IsPipeTableLine("# Heading"));
+        Assert.False(TableParser.IsPipeTableLine("{{placeholder}}"));
+        Assert.False(TableParser.IsPipeTableLine("No pipes here"));
+    }
+}

--- a/tests/Markout.Templates.Tests/TemplateParserTests.cs
+++ b/tests/Markout.Templates.Tests/TemplateParserTests.cs
@@ -149,4 +149,26 @@ public class TemplateParserTests
         var para = Assert.IsType<ParagraphNode>(Assert.Single(nodes));
         Assert.Equal("#notaheading", para.Text);
     }
+
+    [Fact]
+    public void Parse_PipeTable()
+    {
+        var text = "| Name | Value |\n| ---- | ----- |\n| A    | 1     |";
+        var nodes = TemplateParser.Parse(text);
+        var table = Assert.IsType<TableNode>(Assert.Single(nodes));
+        Assert.Equal(["Name", "Value"], table.Headers);
+        Assert.Single(table.Rows);
+        Assert.Equal("A", table.Rows[0][0]);
+    }
+
+    [Fact]
+    public void Parse_TableBetweenContent()
+    {
+        var text = "# Title\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\nAfter.";
+        var nodes = TemplateParser.Parse(text);
+
+        Assert.IsType<HeadingNode>(nodes[0]);
+        Assert.Contains(nodes, n => n is TableNode);
+        Assert.Contains(nodes, n => n is ParagraphNode { Text: "After." });
+    }
 }

--- a/tests/Markout.Templates.Tests/TemplateParserTests.cs
+++ b/tests/Markout.Templates.Tests/TemplateParserTests.cs
@@ -1,0 +1,152 @@
+using Markout.Templates;
+
+namespace Markout.Templates.Tests;
+
+public class TemplateParserTests
+{
+    [Fact]
+    public void Parse_EmptyString_ReturnsEmpty()
+    {
+        var nodes = TemplateParser.Parse("");
+        Assert.Empty(nodes);
+    }
+
+    [Fact]
+    public void Parse_HeadingLevels()
+    {
+        var nodes = TemplateParser.Parse("# H1\n## H2\n### H3");
+        Assert.Equal(3, nodes.Count);
+        Assert.Equal(new HeadingNode(1, "H1"), nodes[0]);
+        Assert.Equal(new HeadingNode(2, "H2"), nodes[1]);
+        Assert.Equal(new HeadingNode(3, "H3"), nodes[2]);
+    }
+
+    [Fact]
+    public void Parse_HeadingWithInlinePlaceholder()
+    {
+        var nodes = TemplateParser.Parse("# Report for {{date}}");
+        var heading = Assert.IsType<HeadingNode>(Assert.Single(nodes));
+        Assert.Equal("Report for {{date}}", heading.Text);
+    }
+
+    [Fact]
+    public void Parse_BlockPlaceholder()
+    {
+        var nodes = TemplateParser.Parse("{{my-table}}");
+        var placeholder = Assert.IsType<PlaceholderNode>(Assert.Single(nodes));
+        Assert.Equal("my-table", placeholder.Key);
+    }
+
+    [Fact]
+    public void Parse_BlockPlaceholderWithWhitespace()
+    {
+        var nodes = TemplateParser.Parse("  {{ my-key }}  ");
+        var placeholder = Assert.IsType<PlaceholderNode>(Assert.Single(nodes));
+        Assert.Equal("my-key", placeholder.Key);
+    }
+
+    [Fact]
+    public void Parse_Paragraph()
+    {
+        var nodes = TemplateParser.Parse("This is a paragraph.\nWith two lines.");
+        var para = Assert.IsType<ParagraphNode>(Assert.Single(nodes));
+        Assert.Equal("This is a paragraph.\nWith two lines.", para.Text);
+    }
+
+    [Fact]
+    public void Parse_ParagraphsSplitByBlankLine()
+    {
+        var nodes = TemplateParser.Parse("First paragraph.\n\nSecond paragraph.");
+        Assert.Equal(3, nodes.Count);
+        Assert.IsType<ParagraphNode>(nodes[0]);
+        Assert.IsType<BlankLineNode>(nodes[1]);
+        Assert.IsType<ParagraphNode>(nodes[2]);
+    }
+
+    [Fact]
+    public void Parse_ConditionalSection()
+    {
+        var text = "{{#if commits}}\n## Commits\n{{/if}}";
+        var nodes = TemplateParser.Parse(text);
+        Assert.Equal(3, nodes.Count);
+        Assert.Equal(new ConditionalStartNode("commits"), nodes[0]);
+        Assert.Equal(new HeadingNode(2, "Commits"), nodes[1]);
+        Assert.IsType<ConditionalEndNode>(nodes[2]);
+    }
+
+    [Fact]
+    public void Parse_FullTemplate()
+    {
+        var text = """
+            # Report for {{date}}
+
+            Some intro text.
+
+            {{main-table}}
+
+            ## Details
+
+            More details here.
+
+            {{#if extras}}
+            ## Extras
+
+            {{extras-table}}
+            {{/if}}
+            """;
+
+        var nodes = TemplateParser.Parse(text);
+
+        // Verify key node types are present in order
+        Assert.IsType<HeadingNode>(nodes[0]);
+        Assert.Contains(nodes, n => n is PlaceholderNode { Key: "main-table" });
+        Assert.Contains(nodes, n => n is HeadingNode { Level: 2, Text: "Details" });
+        Assert.Contains(nodes, n => n is ConditionalStartNode { Key: "extras" });
+        Assert.Contains(nodes, n => n is PlaceholderNode { Key: "extras-table" });
+        Assert.Contains(nodes, n => n is ConditionalEndNode);
+    }
+
+    [Fact]
+    public void ResolveInlinePlaceholders_ReplacesKnownKeys()
+    {
+        var result = TemplateParser.ResolveInlinePlaceholders(
+            "Hello {{name}}, welcome to {{place}}!",
+            key => key switch
+            {
+                "name" => "Alice",
+                "place" => "Wonderland",
+                _ => null
+            });
+
+        Assert.Equal("Hello Alice, welcome to Wonderland!", result);
+    }
+
+    [Fact]
+    public void ResolveInlinePlaceholders_PreservesUnknownKeys()
+    {
+        var result = TemplateParser.ResolveInlinePlaceholders(
+            "Hello {{name}}!",
+            _ => null);
+
+        Assert.Equal("Hello {{name}}!", result);
+    }
+
+    [Fact]
+    public void ResolveInlinePlaceholders_NoPlaceholders()
+    {
+        var result = TemplateParser.ResolveInlinePlaceholders(
+            "No placeholders here.",
+            _ => "replaced");
+
+        Assert.Equal("No placeholders here.", result);
+    }
+
+    [Fact]
+    public void Parse_HashInParagraphNotHeading()
+    {
+        // '#' without a space after is not a heading
+        var nodes = TemplateParser.Parse("#notaheading");
+        var para = Assert.IsType<ParagraphNode>(Assert.Single(nodes));
+        Assert.Equal("#notaheading", para.Text);
+    }
+}

--- a/tools/markout-template/Program.cs
+++ b/tools/markout-template/Program.cs
@@ -1,0 +1,81 @@
+using Markout;
+using Markout.Templates;
+using MarkdownTable.Formatting;
+
+if (args.Length == 0 || args[0] is "-h" or "--help")
+{
+    PrintUsage();
+    return;
+}
+
+var templatePath = args[0];
+
+if (!File.Exists(templatePath))
+{
+    Console.Error.WriteLine($"Template file not found: {templatePath}");
+    return;
+}
+
+var template = MarkoutTemplate.Load(templatePath);
+template.TableOptions = new TableFormatterOptions();
+template.SkipUnboundPlaceholders = true;
+
+// Bind key=value pairs from remaining args
+for (int i = 1; i < args.Length; i++)
+{
+    var arg = args[i];
+    var eqIndex = arg.IndexOf('=');
+
+    if (eqIndex > 0)
+    {
+        var key = arg[..eqIndex];
+        var value = arg[(eqIndex + 1)..];
+        template.Bind(key, value);
+    }
+}
+
+// Bind stdin as a data source if piped
+if (!Console.IsInputRedirected)
+{
+    var options = new MarkoutWriterOptions { PrettyTables = true };
+    Console.Write(template.Render(options));
+}
+else
+{
+    // Read stdin as key=value lines (blank-line separated from template bindings)
+    using var reader = Console.In;
+    string? line;
+    while ((line = reader.ReadLine()) is not null)
+    {
+        var eqIndex = line.IndexOf('=');
+        if (eqIndex > 0)
+        {
+            var key = line[..eqIndex].Trim();
+            var value = line[(eqIndex + 1)..].Trim();
+            template.Bind(key, value);
+        }
+    }
+
+    var options = new MarkoutWriterOptions { PrettyTables = true };
+    Console.Write(template.Render(options));
+}
+
+static void PrintUsage()
+{
+    Console.WriteLine("""
+        markout-template — render a Markout template with bound values
+
+        Usage:
+          markout-template <template.md> [key=value ...]
+
+        Arguments:
+          template.md    Path to the template file
+          key=value      Bind a string value to a placeholder
+
+        Pipe key=value lines on stdin for additional bindings.
+
+        Examples:
+          markout-template report.md date="February 2026" title="Monthly Report"
+          echo "date=February 2026" | markout-template report.md
+        """);
+}

--- a/tools/markout-template/markout-template.csproj
+++ b/tools/markout-template/markout-template.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>Markout.Tools</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
+    <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="..\..\src\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds a template engine to Markout as a third entry path alongside the standalone API and source generator. Templates let you author document structure in Markdown and fill data slots at runtime, rendering through the same MarkoutWriter pipeline to any output format.

Also adds a standalone table formatting library (`MarkdownTable.Formatting`) porting the statistical column-width algorithm from smooth-markdown-table, and a basic CLI template runner tool.

## New packages

- **Markout.Templates** (0.7.0) — Template engine: parse `.md` templates, bind data, render to any format
- **MarkdownTable.Formatting** (0.1.0) — Standalone pipe table formatting with statistical column-width optimization

## Features

### Template engine
- `{{key}}` inline substitution and block-level data binding
- `{{#if key}}`/`{{/if}}` conditional sections
- Pipe tables recognized and rendered through writer's table shape
- `IMarkoutFormattable` and `MarkoutTypeInfo<T>` bindings for shape-aware rendering
- `SkipUnboundPlaceholders` option for partial rendering

### Table formatting
- A/B/C/D statistical column-width algorithm (percentile + tolerance + accumulated position)
- Auto-tune hill-climbing for optimal parameters
- `TableFormatterOptions` integration with templates
- Standalone library — no Markout dependency

### CLI tool
- `tools/markout-template` — render templates with string bindings from command line
- Supports `key=value` args and stdin piping

### README
- Updated to describe three modes: standalone API, source generator, templates

## Tests

- 45 new template tests + 312 existing = 357 total, all passing

## Commits

- 267e6c3 Add template runner tool, update README with three modes, bump version to 0.7.0
- eb87358 Enable pretty tables for all tables in TemplateDemo sample
- 31d066e Wire TableFormatterOptions into MarkoutTemplate for smooth table rendering
- 34cbd16 Add MarkdownTable.Formatting library and pipe table support in templates
- dac4d77 Clean up phrasing in doc comments
- d4094c6 Extract template to template.md file in TemplateDemo sample
- d9697b0 Add TemplateDemo sample showing multi-format rendering
- 91ba64c Add Markout.Templates — template engine for document composition
