### PR TITLE
Set Markout.Templates version to 0.1.0

### DIFF
--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>Markout.Templates</RootNamespace>
     <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
-    <Version>0.7.0</Version>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
New package should start at 0.1.0, not 0.7.0.