### PR TITLE
Update publishing for new packages and refresh demo output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
         run: dotnet build -c Release -p:OfficialBuild=true -p:ExcludeAnsi=true --no-restore
 
       - name: Test
-        run: dotnet run --project tests/Markout.Tests -c Release -p:ExcludeAnsi=true
+        run: |
+          dotnet run --project tests/Markout.Tests -c Release -p:ExcludeAnsi=true
+          dotnet run --project tests/Markout.Templates.Tests -c Release -p:ExcludeAnsi=true
 
       - name: Pack
         run: dotnet pack -c Release -p:OfficialBuild=true -p:ExcludeAnsi=true --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           for pkg in packages/*.nupkg; do
             name=$(basename "$pkg")
             case "$name" in
-              Markout.[0-9]*)
+              Markout.[0-9]*|Markout.Templates.*|Markout.Demo.*|MarkdownTable.Formatting.*)
                 echo "Publishing: $name"
                 dotnet nuget push "$pkg" \
                   --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \

--- a/.gitignore
+++ b/.gitignore
@@ -481,3 +481,4 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 artifacts/
+_worktree/

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -10,4 +10,12 @@
     <Version>0.1.0</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
 </Project>

--- a/src/Markout.Demo/Markout.Demo.csproj
+++ b/src/Markout.Demo/Markout.Demo.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>markout-demo</ToolCommandName>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <PackageId>Markout.Demo</PackageId>
     <Description>Demo app showcasing Markout markdown serialization capabilities</Description>
   </PropertyGroup>

--- a/src/Markout.Demo/output/list.md
+++ b/src/Markout.Demo/output/list.md
@@ -2,8 +2,6 @@
 
 This demo shows products as a bullet list with custom formatting.
 
-Name: Altra Running Shoes  
-
 ## Available Models
 
 - Torin 7 ($149.99)

--- a/src/Markout.Demo/output/nested.md
+++ b/src/Markout.Demo/output/nested.md
@@ -2,22 +2,18 @@
 
 This demo shows detailed products with nested features and reviews.
 
-Name: Altra Running Shoes  
-Count: 6  
-Lowest Price: 129.99  
+Count: 6 | Lowest Price: 129.99
 
 ## Products
 
 ### Torin 7
 
-Name: Torin 7  
-Category: Road  
-Price: 149.99  
+Name: Torin 7 | Category: Road | Price: 149.99
 
 #### Features
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 28mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Moderate |
@@ -26,20 +22,18 @@ Price: 149.99
 #### Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Alice | 5 | Great cushioning for long runs! |
 | Bob | 4 | Comfortable but runs a bit warm. |
 
 ### Escalante 4
 
-Name: Escalante 4  
-Category: Road  
-Price: 139.99  
+Name: Escalante 4 | Category: Road | Price: 139.99
 
 #### Features
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 24mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Light |
@@ -48,19 +42,17 @@ Price: 139.99
 #### Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Charlie | 5 | Fast and light, perfect for racing. |
 
 ### Lone Peak 8
 
-Name: Lone Peak 8  
-Category: Trail  
-Price: 144.99  
+Name: Lone Peak 8 | Category: Trail | Price: 144.99
 
 #### Features
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 25mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Moderate |
@@ -69,7 +61,7 @@ Price: 144.99
 #### Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Diana | 5 | Best trail shoe ever! |
 | Eve | 5 | Incredible grip on technical terrain. |
 | Frank | 4 | Took a few miles to break in. |
@@ -77,14 +69,12 @@ Price: 144.99
 
 ### Olympus 6
 
-Name: Olympus 6  
-Category: Trail  
-Price: 179.99  
+Name: Olympus 6 | Category: Trail | Price: 179.99
 
 #### Features
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 33mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Max |
@@ -93,19 +83,17 @@ Price: 179.99
 #### Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Grace | 5 | Max cushion for ultras! |
 
 ### Timp 5
 
-Name: Timp 5  
-Category: Trail  
-Price: 159.99  
+Name: Timp 5 | Category: Trail | Price: 159.99
 
 #### Features
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 29mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Moderate |
@@ -114,19 +102,17 @@ Price: 159.99
 #### Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Hank | 4 | Versatile trail runner. |
 
 ### Rivera 4
 
-Name: Rivera 4  
-Category: Road  
-Price: 129.99  
+Name: Rivera 4 | Category: Road | Price: 129.99
 
 #### Features
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 26mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Light |
@@ -135,5 +121,5 @@ Price: 129.99
 #### Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Ivy | 4 | Great value. |

--- a/src/Markout.Demo/output/pivot.md
+++ b/src/Markout.Demo/output/pivot.md
@@ -2,14 +2,12 @@
 
 This demo shows pivoted inventory data: rows are sizes, columns are colors.
 
-Name: Altra Torin 7  
-Price: 149.99  
-Total Units: 148  
+Price: 149.99 | Total Units: 148
 
 ## Inventory by Size
 
 | Size | Black | Green | Red |
-|------|-------|-------|-----|
+| ---- | ----- | ----- | --- |
 | 8 | 12 | 8 | 5 |
 | 9 | 18 | 15 | 10 |
 | 10 | 22 | 12 | 8 |

--- a/src/Markout.Demo/output/schema.md
+++ b/src/Markout.Demo/output/schema.md
@@ -23,8 +23,8 @@ Shoe (in table)
 ├─ Category: string → Column
 ├─ Price: decimal → Column
 ├─ InStock: bool → Column
-├─ Features: List<Markout.Demo.Feature>? → Skipped (unsupported)
-└─ Reviews: List<Markout.Demo.Review>? → Skipped (unsupported)
+├─ Features: List<Markout.Demo.Feature>? → Ignored
+└─ Reviews: List<Markout.Demo.Review>? → Ignored
 ```
 
 ## InventoryEntry

--- a/src/Markout.Demo/output/sections.md
+++ b/src/Markout.Demo/output/sections.md
@@ -2,14 +2,12 @@
 
 This demo shows a product with separate sections for specs and reviews.
 
-Name: Altra Lone Peak 8  
-Id: lone-peak-8  
-Price: 144.99  
+Id: lone-peak-8 | Price: 144.99
 
 ## Specifications
 
 | Name | Value |
-|------|-------|
+| ---- | ----- |
 | Stack Height | 25mm |
 | Heel-to-Toe Drop | 0mm |
 | Cushion | Moderate |
@@ -18,7 +16,7 @@ Price: 144.99
 ## Customer Reviews
 
 | Author | Rating | Comment |
-|--------|--------|---------|
+| ------ | ------ | ------- |
 | Diana | 5 | Best trail shoe ever! |
 | Eve | 5 | Incredible grip on technical terrain. |
 | Frank | 4 | Took a few miles to break in. |

--- a/src/Markout.Demo/output/simple.md
+++ b/src/Markout.Demo/output/simple.md
@@ -2,8 +2,4 @@
 
 This demo shows a basic product with scalar fields.
 
-Name: Altra Torin 7  
-Id: torin-7  
-Category: Road  
-Price: 149.99  
-InStock: yes  
+Id: torin-7 | Category: Road | Price: 149.99 | InStock: yes

--- a/src/Markout.Demo/output/table.md
+++ b/src/Markout.Demo/output/table.md
@@ -2,14 +2,12 @@
 
 This demo shows products as a table with a section heading.
 
-Name: Altra Running Shoes  
-Count: 6  
-Lowest Price: 129.99  
+Count: 6 | Lowest Price: 129.99
 
 ## Products
 
 | Model | Category | Price | In Stock |
-|-------|----------|-------|----------|
+| ----- | -------- | ----- | -------- |
 | Torin 7 | Road | 149.99 | yes |
 | Escalante 4 | Road | 139.99 | yes |
 | Lone Peak 8 | Trail | 144.99 | yes |

--- a/src/Markout.Demo/output/tree.md
+++ b/src/Markout.Demo/output/tree.md
@@ -1,6 +1,6 @@
 # Altra Running Shoes
 
-This demo shows List<List<T>> rendered as a tree. Each shoe shows its reviews, which would be unsupported in table format.
+This demo shows `List<List<T>>` rendered as a tree. Each shoe shows its reviews, which would be unsupported in table format.
 
 ## Products with Reviews
 

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -7,8 +7,23 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>Markout.Templates</RootNamespace>
     <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>0.1.0</Version>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\README.md"
+          Pack="true"
+          PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Markout\Markout.csproj" />


### PR DESCRIPTION
- Add OfficialBuild packaging props to **Markout.Templates** and **MarkdownTable.Formatting** (license, deterministic build, readme)
- Update release workflow to publish **Markout.Demo**, **Markout.Templates**, **MarkdownTable.Formatting** (was only publishing `Markout.[0-9]*`)
- Add template tests to CI workflow
- Regenerate demo output files to match current serializer output
- Bump Markout.Demo to 0.2.0
- Add `_worktree/` to .gitignore