### PR TITLE
Add BindFields: drive templates from markdown field files

### DIFF
--- a/src/MarkdownTable.Formatting/FieldDocument.cs
+++ b/src/MarkdownTable.Formatting/FieldDocument.cs
@@ -162,6 +162,9 @@ public sealed class FieldDocument : IDisposable
     /// <summary>Returns true if the document contains the specified key.</summary>
     public bool ContainsKey(string key) => _fields.ContainsKey(key);
 
+    /// <summary>Gets the keys of all fields in the document.</summary>
+    public IEnumerable<string> Keys => _fields.Keys;
+
     public void Dispose() { /* buffer is caller-owned */ }
 
     // --- Parsing helpers ---

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -101,6 +101,37 @@ public class MarkoutTemplate
     }
 
     /// <summary>
+    /// Binds all fields from a <see cref="FieldDocument"/> as string values.
+    /// Each field key becomes a binding; array fields are joined with ", ".
+    /// Enables templates driven by markdown field files with no C# model.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// byte[] bytes = File.ReadAllBytes("package.md");
+    /// using var doc = FieldDocument.Parse(bytes);
+    /// var result = MarkoutTemplate.Parse(template).BindFields(doc).Render();
+    /// </code>
+    /// </example>
+    public MarkoutTemplate BindFields(FieldDocument doc)
+    {
+        foreach (var key in doc.Keys)
+        {
+            _bindings[key] = new StringBinding(doc.GetString(key));
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Parses a UTF-8 byte buffer as markdown fields and binds all fields as string values.
+    /// Convenience overload that creates and disposes a <see cref="FieldDocument"/> internally.
+    /// </summary>
+    public MarkoutTemplate BindFields(byte[] utf8)
+    {
+        using var doc = FieldDocument.Parse(utf8);
+        return BindFields(doc);
+    }
+
+    /// <summary>
     /// Renders the template using a <see cref="MarkdownWriter"/> and returns the result as a string.
     /// </summary>
     public string Render()
@@ -200,18 +231,23 @@ public class MarkoutTemplate
                 break;
 
             case TableNode table:
+                var resolvedHeaders = table.Headers.Select(h => ResolveInline(h)).ToArray();
+                var resolvedRows = table.Rows
+                    .Select(row => row.Select(cell => ResolveInline(cell)).ToArray())
+                    .ToList();
+
                 if (TableOptions is not null)
                 {
                     // Use statistical width calculator to plan column widths,
                     // then pass padded cells through WriteTable so any writer benefits
-                    var widths = ColumnWidthCalculator.Calculate(table.Headers, table.Rows, TableOptions);
-                    var paddedHeaders = PadCells(table.Headers, widths);
-                    var paddedRows = table.Rows.Select(row => PadCells(row, widths)).ToList();
+                    var widths = ColumnWidthCalculator.Calculate(resolvedHeaders, resolvedRows, TableOptions);
+                    var paddedHeaders = PadCells(resolvedHeaders, widths);
+                    var paddedRows = resolvedRows.Select(row => PadCells(row, widths)).ToList();
                     writer.WriteTable(paddedHeaders, paddedRows);
                 }
                 else
                 {
-                    writer.WriteTable(table.Headers, table.Rows);
+                    writer.WriteTable(resolvedHeaders, resolvedRows);
                 }
                 break;
         }

--- a/tests/Markout.Templates.Tests/BindFieldsTests.cs
+++ b/tests/Markout.Templates.Tests/BindFieldsTests.cs
@@ -1,0 +1,154 @@
+using System.Text;
+using MarkdownTable.Formatting;
+using Markout.Templates;
+
+namespace Markout.Templates.Tests;
+
+public class BindFieldsTests
+{
+    private static byte[] Utf8(string text) => Encoding.UTF8.GetBytes(text);
+
+    [Fact]
+    public void BindFields_ScalarField_ResolvedInHeading()
+    {
+        var fields = Utf8("packageName: Newtonsoft.Json\nversion: 13.0.3");
+        var template = MarkoutTemplate.Parse("# {{packageName}} ({{version}})");
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.Equal("# Newtonsoft.Json (13.0.3)", result);
+    }
+
+    [Fact]
+    public void BindFields_ScalarField_ResolvedInParagraph()
+    {
+        var fields = Utf8("description: A high-performance JSON framework");
+        var template = MarkoutTemplate.Parse("{{description}}");
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.Contains("A high-performance JSON framework", result);
+    }
+
+    [Fact]
+    public void BindFields_ArrayField_JoinedWithComma()
+    {
+        var fields = Utf8("targetFrameworks:\n- net6.0\n- net8.0\n- net9.0");
+        var template = MarkoutTemplate.Parse("Frameworks: {{targetFrameworks}}");
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.Equal("Frameworks: net6.0, net8.0, net9.0", result);
+    }
+
+    [Fact]
+    public void BindFields_ConditionalTrue_RendersContent()
+    {
+        var fields = Utf8("hasReadme: true\nreadmeFile: README.md");
+        var template = MarkoutTemplate.Parse(
+            "{{#if hasReadme}}\nReadme: {{readmeFile}}\n{{/if}}");
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.Contains("Readme: README.md", result);
+    }
+
+    [Fact]
+    public void BindFields_ConditionalMissingKey_SkipsContent()
+    {
+        var fields = Utf8("packageName: Test");
+        var template = MarkoutTemplate.Parse(
+            "{{#if missingKey}}\nShould not appear\n{{/if}}\n\nEnd");
+        template.SkipUnboundPlaceholders = true;
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.DoesNotContain("Should not appear", result);
+        Assert.Contains("End", result);
+    }
+
+    [Fact]
+    public void BindFields_BoldFieldFormat_ParsedCorrectly()
+    {
+        var fields = Utf8("**packageName:** Newtonsoft.Json\n**version:** 13.0.3");
+        var template = MarkoutTemplate.Parse("# {{packageName}} v{{version}}");
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.Equal("# Newtonsoft.Json v13.0.3", result);
+    }
+
+    [Fact]
+    public void BindFields_FieldDocumentOverload_WorksIdentically()
+    {
+        var bytes = Utf8("name: Alice\nage: 30");
+        using var doc = FieldDocument.Parse(bytes);
+        var template = MarkoutTemplate.Parse("{{name}} is {{age}}");
+
+        var result = template.BindFields(doc).Render().TrimEnd();
+
+        Assert.Equal("Alice is 30", result);
+    }
+
+    [Fact]
+    public void BindFields_CaseInsensitiveKeys()
+    {
+        var fields = Utf8("PackageName: Test");
+        var template = MarkoutTemplate.Parse("{{packagename}}");
+
+        var result = template.BindFields(fields).Render().TrimEnd();
+
+        Assert.Contains("Test", result);
+    }
+
+    [Fact]
+    public void BindFields_ChainingWithExplicitBinds()
+    {
+        var fields = Utf8("packageName: TestPkg");
+        var template = MarkoutTemplate.Parse("# {{packageName}} — {{extra}}");
+
+        var result = template
+            .BindFields(fields)
+            .Bind("extra", "custom value")
+            .Render()
+            .TrimEnd();
+
+        Assert.Equal("# TestPkg — custom value", result);
+    }
+
+    [Fact]
+    public void BindFields_FullCacheDocument_RendersTemplate()
+    {
+        var cacheFile = Utf8(
+            "packageName: Newtonsoft.Json\n" +
+            "version: 13.0.3\n" +
+            "description: Json.NET is a popular high-performance JSON framework\n" +
+            "authors: James Newton-King\n" +
+            "license: MIT\n" +
+            "assemblyCount: 4\n" +
+            "hasReadme: true\n" +
+            "\n" +
+            "targetFrameworks:\n" +
+            "- net6.0\n" +
+            "- netstandard2.0\n");
+
+        var template = MarkoutTemplate.Parse(
+            "# {{packageName}} ({{version}})\n" +
+            "\n" +
+            "{{description}}\n" +
+            "\n" +
+            "| Property | Value |\n" +
+            "| -------- | ----- |\n" +
+            "| Authors | {{authors}} |\n" +
+            "| License | {{license}} |\n" +
+            "| Frameworks | {{targetFrameworks}} |");
+
+        var result = template.BindFields(cacheFile).Render();
+
+        Assert.Contains("# Newtonsoft.Json (13.0.3)", result);
+        Assert.Contains("Json.NET is a popular", result);
+        Assert.Contains("James Newton-King", result);
+        Assert.Contains("MIT", result);
+        Assert.Contains("net6.0, netstandard2.0", result);
+    }
+}


### PR DESCRIPTION
## Summary

`MarkoutTemplate.BindFields()` registers all fields from a `FieldDocument` (or raw `byte[]`) as string bindings, enabling templates driven by markdown field files with no C# model needed.

### Usage

```csharp
byte[] bytes = File.ReadAllBytes("package.md");
var result = MarkoutTemplate.Parse(template).BindFields(bytes).Render();
```

Where `package.md` contains:
```
packageName: Newtonsoft.Json
version: 13.0.3
authors: James Newton-King
```

And the template uses `{{packageName}}`, `{{version}}`, etc.

### Changes

- **`MarkoutTemplate.BindFields(FieldDocument)`** — iterates field keys, registers StringBindings
- **`MarkoutTemplate.BindFields(byte[])`** — convenience overload
- **`FieldDocument.Keys`** — new property for key enumeration
- **Fix: inline placeholders in table cells** — `{{key}}` inside table rows were previously not resolved
- **11 tests** covering scalar, array, conditional, table cell, and full cache document scenarios

### Bug fix

Table cells containing `{{key}}` placeholders were passed to `WriteTable` without resolution. Now all table headers and cells go through `ResolveInline()` before rendering.