### PR TITLE
Add targeted field lookup and mq field queries

### DIFF
--- a/src/MarkdownTable.Formatting/FieldDocument.cs
+++ b/src/MarkdownTable.Formatting/FieldDocument.cs
@@ -167,6 +167,248 @@ public sealed class FieldDocument : IDisposable
 
     public void Dispose() { /* buffer is caller-owned */ }
 
+    // --- Static targeted lookup (early exit, zero dictionary) ---
+
+    /// <summary>
+    /// Scans a UTF-8 byte buffer for a single field by key and returns its string value.
+    /// Stops scanning as soon as the key is found. No dictionary is built.
+    /// For best performance, place frequently-accessed fields first in the file.
+    /// </summary>
+    public static string? GetString(ReadOnlySpan<byte> utf8, ReadOnlySpan<char> key)
+    {
+        Span<byte> keyBytes = stackalloc byte[key.Length * 3];
+        int keyLen = Encoding.UTF8.GetBytes(key, keyBytes);
+        var keyUtf8 = keyBytes[..keyLen];
+
+        return ScanForField(utf8, keyUtf8, out var valueStart, out var valueEnd, out var items)
+            ? (items is not null ? string.Join(", ", items) : (valueStart < valueEnd ? Encoding.UTF8.GetString(utf8[valueStart..valueEnd]) : ""))
+            : null;
+    }
+
+    /// <summary>
+    /// Scans for a single boolean field. Returns true if the field exists and equals "true".
+    /// </summary>
+    public static bool GetBool(ReadOnlySpan<byte> utf8, ReadOnlySpan<char> key)
+    {
+        Span<byte> keyBytes = stackalloc byte[key.Length * 3];
+        int keyLen = Encoding.UTF8.GetBytes(key, keyBytes);
+        var keyUtf8 = keyBytes[..keyLen];
+
+        if (!ScanForField(utf8, keyUtf8, out var valueStart, out var valueEnd, out _))
+            return false;
+        int len = valueEnd - valueStart;
+        if (len != 4) return false;
+        return (utf8[valueStart] | 0x20) == (byte)'t'
+            && (utf8[valueStart + 1] | 0x20) == (byte)'r'
+            && (utf8[valueStart + 2] | 0x20) == (byte)'u'
+            && (utf8[valueStart + 3] | 0x20) == (byte)'e';
+    }
+
+    /// <summary>
+    /// Scans for a single integer field. Returns the parsed value, or 0 if not found.
+    /// </summary>
+    public static int GetInt32(ReadOnlySpan<byte> utf8, ReadOnlySpan<char> key)
+    {
+        Span<byte> keyBytes = stackalloc byte[key.Length * 3];
+        int keyLen = Encoding.UTF8.GetBytes(key, keyBytes);
+        var keyUtf8 = keyBytes[..keyLen];
+
+        if (!ScanForField(utf8, keyUtf8, out var valueStart, out var valueEnd, out _))
+            return 0;
+        return Utf8Parser.TryParseInt32(utf8[valueStart..valueEnd], out var value) ? value : 0;
+    }
+
+    /// <summary>
+    /// Scans for a single array field. Returns the items, or null if not found.
+    /// </summary>
+    public static string[]? GetArray(ReadOnlySpan<byte> utf8, ReadOnlySpan<char> key)
+    {
+        Span<byte> keyBytes = stackalloc byte[key.Length * 3];
+        int keyLen = Encoding.UTF8.GetBytes(key, keyBytes);
+        var keyUtf8 = keyBytes[..keyLen];
+
+        if (!ScanForField(utf8, keyUtf8, out _, out _, out var items))
+            return null;
+        return items?.ToArray();
+    }
+
+    /// <summary>
+    /// Returns true if the buffer contains a field with the specified key.
+    /// </summary>
+    public static bool ContainsKey(ReadOnlySpan<byte> utf8, ReadOnlySpan<char> key)
+    {
+        Span<byte> keyBytes = stackalloc byte[key.Length * 3];
+        int keyLen = Encoding.UTF8.GetBytes(key, keyBytes);
+        return ScanForField(utf8, keyBytes[..keyLen], out _, out _, out _);
+    }
+
+    /// <summary>
+    /// Core scanner: walks lines looking for a field whose key matches keyUtf8 (case-insensitive).
+    /// Returns true if found, with value range or array items.
+    /// </summary>
+    private static bool ScanForField(
+        ReadOnlySpan<byte> utf8,
+        ReadOnlySpan<byte> keyUtf8,
+        out int valueStart, out int valueEnd,
+        out List<string>? items)
+    {
+        valueStart = valueEnd = 0;
+        items = null;
+
+        int pos = 0;
+        if (utf8.Length >= 3 && utf8[0] == 0xEF && utf8[1] == 0xBB && utf8[2] == 0xBF)
+            pos = 3;
+
+        while (pos < utf8.Length)
+        {
+            int lineEnd = FindLineEnd(utf8, pos);
+            int trimmedEnd = lineEnd;
+            if (trimmedEnd > pos && utf8[trimmedEnd - 1] == (byte)'\r')
+                trimmedEnd--;
+
+            var line = TrimWhitespace(utf8[pos..trimmedEnd], pos, out int contentStart);
+            int nextLineStart = lineEnd < utf8.Length ? lineEnd + 1 : utf8.Length;
+
+            if (line.Length > 0)
+            {
+                ReadOnlySpan<byte> foundKey;
+                int vs, ve;
+
+                if (line[0] == (byte)'*' && line.Length >= 5 && line[1] == (byte)'*')
+                {
+                    if (TryParseBoldFieldSpan(line, contentStart, out foundKey, out vs, out ve)
+                        && KeyEquals(foundKey, keyUtf8))
+                    {
+                        return ResolveValue(utf8, vs, ve, ref nextLineStart, out valueStart, out valueEnd, out items);
+                    }
+                }
+                else if (line[0] != (byte)'-' && line[0] != (byte)'#'
+                    && line[0] != (byte)'|' && line[0] != (byte)'>'
+                    && line[0] != (byte)'`')
+                {
+                    if (TryParsePlainFieldSpan(line, contentStart, out foundKey, out vs, out ve)
+                        && KeyEquals(foundKey, keyUtf8))
+                    {
+                        return ResolveValue(utf8, vs, ve, ref nextLineStart, out valueStart, out valueEnd, out items);
+                    }
+                }
+            }
+
+            pos = nextLineStart;
+        }
+
+        return false;
+    }
+
+    private static bool ResolveValue(
+        ReadOnlySpan<byte> buffer, int vs, int ve, ref int nextLineStart,
+        out int valueStart, out int valueEnd, out List<string>? items)
+    {
+        items = null;
+        if (vs >= ve)
+        {
+            var bulletItems = CollectBulletItems(buffer, nextLineStart, out nextLineStart);
+            if (bulletItems.Count > 0)
+            {
+                items = bulletItems;
+                valueStart = valueEnd = 0;
+                return true;
+            }
+            valueStart = valueEnd = vs;
+            return true;
+        }
+        valueStart = vs;
+        valueEnd = ve;
+        return true;
+    }
+
+    /// <summary>Case-insensitive comparison of two ASCII/UTF-8 key spans.</summary>
+    private static bool KeyEquals(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if ((a[i] | 0x20) != (b[i] | 0x20))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>Like TryParseBoldField but returns key as a byte span (no string alloc).</summary>
+    private static bool TryParseBoldFieldSpan(
+        ReadOnlySpan<byte> line, int lineOffset,
+        out ReadOnlySpan<byte> key, out int valueStart, out int valueEnd)
+    {
+        key = default;
+        valueStart = valueEnd = 0;
+
+        var afterStars = line[2..];
+        int colonStarIdx = IndexOfPattern(afterStars, (byte)':', (byte)'*', (byte)'*');
+        if (colonStarIdx < 0 || colonStarIdx == 0)
+            return false;
+
+        key = line.Slice(2, colonStarIdx);
+        int afterPattern = 2 + colonStarIdx + 3;
+        int absAfterPattern = lineOffset + afterPattern;
+        if (afterPattern < line.Length && line[afterPattern] == (byte)' ')
+        {
+            afterPattern++;
+            absAfterPattern++;
+        }
+        valueStart = absAfterPattern;
+
+        int endIdx = line.Length;
+        while (endIdx > afterPattern && (line[endIdx - 1] == (byte)' ' || line[endIdx - 1] == (byte)'\t'))
+            endIdx--;
+        valueEnd = lineOffset + endIdx;
+        return true;
+    }
+
+    /// <summary>Like TryParsePlainField but returns key as a byte span (no string alloc).</summary>
+    private static bool TryParsePlainFieldSpan(
+        ReadOnlySpan<byte> line, int lineOffset,
+        out ReadOnlySpan<byte> key, out int valueStart, out int valueEnd)
+    {
+        key = default;
+        valueStart = valueEnd = 0;
+
+        for (int i = 1; i < line.Length; i++)
+        {
+            if (line[i] == (byte)':')
+            {
+                var keySpan = line[..i];
+                if (keySpan.IndexOf((byte)' ') >= 0)
+                    return false;
+
+                if (i == line.Length - 1)
+                {
+                    key = keySpan;
+                    valueStart = valueEnd = lineOffset + line.Length;
+                    return true;
+                }
+
+                if (line[i + 1] != (byte)' ')
+                {
+                    if (i + 2 < line.Length && line[i + 1] == (byte)'/' && line[i + 2] == (byte)'/')
+                        return false;
+                    continue;
+                }
+
+                key = keySpan;
+                int afterColon = i + 2;
+                valueStart = lineOffset + afterColon;
+
+                int endIdx = line.Length;
+                while (endIdx > afterColon && (line[endIdx - 1] == (byte)' ' || line[endIdx - 1] == (byte)'\t'))
+                    endIdx--;
+                valueEnd = lineOffset + endIdx;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // --- Parsing helpers ---
 
     private static void AddField(

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>MarkdownTable.Formatting</RootNamespace>
     <Description>Statistical column-width optimization for markdown pipe tables</Description>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/MarkdownTable.Query/MarkdownTable.Query.csproj
+++ b/src/MarkdownTable.Query/MarkdownTable.Query.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>MarkdownTable.Query</RootNamespace>
     <Description>Query engine for markdown pipe tables — select, filter, sort, slice</Description>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/MarkdownTable.Query/QueryEngine.cs
+++ b/src/MarkdownTable.Query/QueryEngine.cs
@@ -1,4 +1,5 @@
 using MarkdownTable.Formatting;
+using MarkdownTable.Query.Operations;
 
 namespace MarkdownTable.Query;
 
@@ -48,8 +49,16 @@ public static class QueryEngine
 
         if (table is null)
         {
+            // No table — check if the name resolves to a field
+            if (query.SectionName is not null)
+            {
+                var fieldResult = ResolveField(doc, query.SectionName, query.Operations);
+                if (fieldResult is not null)
+                    return fieldResult;
+            }
+
             var msg = query.SectionName is not null
-                ? $"No table found in section '{query.SectionName}'."
+                ? $"No table or field found for '{query.SectionName}'."
                 : "No table found in document.";
             throw new QueryExecutionException(msg);
         }
@@ -69,7 +78,7 @@ public static class QueryEngine
     }
 
     /// <summary>
-    /// Formats a query result as a string (markdown table or scalar value).
+    /// Formats a query result as a string (markdown table, scalar, or fields).
     /// </summary>
     public static string FormatResult(QueryResult result)
     {
@@ -77,8 +86,60 @@ public static class QueryEngine
         {
             ScalarResult scalar => scalar.Value,
             TableResult table => TableFormatter.Format(table.Headers, table.Rows),
+            FieldsResult fields => FormatFields(fields.Fields),
             _ => throw new InvalidOperationException("Unknown result type."),
         };
+    }
+
+    private static string FormatFields(Dictionary<string, FieldValue> fields)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var (key, value) in fields)
+        {
+            if (value.IsArray)
+            {
+                sb.AppendLine($"**{key}:**");
+                foreach (var item in value.Items)
+                    sb.AppendLine($"- {item}");
+            }
+            else
+            {
+                sb.AppendLine($"**{key}:** {value.Text}");
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static QueryResult? ResolveField(
+        MarkdownDocument doc, string name, List<ITableOperation> operations)
+    {
+        // Check top-level fields first
+        var fields = doc.Fields;
+        if (fields.TryGetValue(name, out var fieldValue))
+        {
+            if (operations.Count == 0)
+                return QueryResult.Scalar(fieldValue.Text);
+
+            // Can't apply table operations to a scalar field
+            throw new QueryExecutionException(
+                $"Cannot apply table operations to field '{name}' (scalar value).");
+        }
+
+        // Check section fields (section exists but has no table)
+        foreach (var section in doc.Sections)
+        {
+            if (string.Equals(section.Heading, name, StringComparison.OrdinalIgnoreCase)
+                && section.Fields.Count > 0)
+            {
+                if (operations.Count == 0)
+                    return new FieldsResult(section.Fields);
+
+                throw new QueryExecutionException(
+                    $"Cannot apply table operations to section '{name}' (contains fields, not a table).");
+            }
+        }
+
+        return null;
     }
 
     private static DocumentTable? ResolveTable(MarkdownDocument doc, string? sectionName)

--- a/src/MarkdownTable.Query/QueryResult.cs
+++ b/src/MarkdownTable.Query/QueryResult.cs
@@ -1,3 +1,5 @@
+using MarkdownTable.Formatting;
+
 namespace MarkdownTable.Query;
 
 /// <summary>
@@ -25,7 +27,7 @@ public sealed class TableResult : QueryResult
 }
 
 /// <summary>
-/// A scalar result containing a single value (e.g., from count).
+/// A scalar result containing a single value (e.g., from count or field access).
 /// </summary>
 public sealed class ScalarResult : QueryResult
 {
@@ -34,5 +36,18 @@ public sealed class ScalarResult : QueryResult
     public ScalarResult(string value)
     {
         Value = value;
+    }
+}
+
+/// <summary>
+/// A result containing key-value fields (e.g., from top-level field access or section fields).
+/// </summary>
+public sealed class FieldsResult : QueryResult
+{
+    public Dictionary<string, FieldValue> Fields { get; }
+
+    public FieldsResult(Dictionary<string, FieldValue> fields)
+    {
+        Fields = fields;
     }
 }

--- a/tests/MarkdownTable.Tests/FieldDocumentTests.cs
+++ b/tests/MarkdownTable.Tests/FieldDocumentTests.cs
@@ -403,4 +403,126 @@ public class FieldDocumentTests
         using var doc = ParseText("name: Alice\nname: Bob");
         Assert.Equal("Alice", doc.GetString("name"));
     }
+
+    // --- Static targeted lookup ---
+
+    private static byte[] Utf8(string text) => Encoding.UTF8.GetBytes(text);
+
+    [Fact]
+    public void Static_GetString_FindsPlainField()
+    {
+        var bytes = Utf8("packageName: Newtonsoft.Json\nversion: 13.0.3");
+        Assert.Equal("Newtonsoft.Json", FieldDocument.GetString(bytes, "packageName"));
+        Assert.Equal("13.0.3", FieldDocument.GetString(bytes, "version"));
+    }
+
+    [Fact]
+    public void Static_GetString_FindsBoldField()
+    {
+        var bytes = Utf8("**name:** Alice\n**age:** 30");
+        Assert.Equal("Alice", FieldDocument.GetString(bytes, "name"));
+    }
+
+    [Fact]
+    public void Static_GetString_ReturnsNullForMissing()
+    {
+        var bytes = Utf8("name: Alice");
+        Assert.Null(FieldDocument.GetString(bytes, "missing"));
+    }
+
+    [Fact]
+    public void Static_GetString_CaseInsensitive()
+    {
+        var bytes = Utf8("PackageName: Test");
+        Assert.Equal("Test", FieldDocument.GetString(bytes, "packagename"));
+        Assert.Equal("Test", FieldDocument.GetString(bytes, "PACKAGENAME"));
+    }
+
+    [Fact]
+    public void Static_GetBool_ReturnsTrue()
+    {
+        var bytes = Utf8("hasReadme: true");
+        Assert.True(FieldDocument.GetBool(bytes, "hasReadme"));
+    }
+
+    [Fact]
+    public void Static_GetBool_ReturnsFalseForMissing()
+    {
+        var bytes = Utf8("name: Alice");
+        Assert.False(FieldDocument.GetBool(bytes, "missing"));
+    }
+
+    [Fact]
+    public void Static_GetBool_ReturnsFalseForNonBool()
+    {
+        var bytes = Utf8("name: Alice");
+        Assert.False(FieldDocument.GetBool(bytes, "name"));
+    }
+
+    [Fact]
+    public void Static_GetInt32_ReturnsValue()
+    {
+        var bytes = Utf8("count: 42");
+        Assert.Equal(42, FieldDocument.GetInt32(bytes, "count"));
+    }
+
+    [Fact]
+    public void Static_GetInt32_ReturnsZeroForMissing()
+    {
+        var bytes = Utf8("name: Alice");
+        Assert.Equal(0, FieldDocument.GetInt32(bytes, "missing"));
+    }
+
+    [Fact]
+    public void Static_GetArray_ReturnsItems()
+    {
+        var bytes = Utf8("frameworks:\n- net6.0\n- net8.0\n- net9.0");
+        var items = FieldDocument.GetArray(bytes, "frameworks");
+        Assert.NotNull(items);
+        Assert.Equal(["net6.0", "net8.0", "net9.0"], items);
+    }
+
+    [Fact]
+    public void Static_GetArray_ReturnsNullForMissing()
+    {
+        var bytes = Utf8("name: Alice");
+        Assert.Null(FieldDocument.GetArray(bytes, "missing"));
+    }
+
+    [Fact]
+    public void Static_ContainsKey_TrueAndFalse()
+    {
+        var bytes = Utf8("name: Alice\nage: 30");
+        Assert.True(FieldDocument.ContainsKey(bytes, "name"));
+        Assert.False(FieldDocument.ContainsKey(bytes, "missing"));
+    }
+
+    [Fact]
+    public void Static_GetString_StopsAtFirstMatch()
+    {
+        // First field should be found without scanning the rest
+        var bytes = Utf8("first: found\nsecond: value\nthird: value");
+        Assert.Equal("found", FieldDocument.GetString(bytes, "first"));
+    }
+
+    [Fact]
+    public void Static_GetString_ArrayFieldReturnsJoined()
+    {
+        var bytes = Utf8("items:\n- a\n- b\n- c");
+        Assert.Equal("a, b, c", FieldDocument.GetString(bytes, "items"));
+    }
+
+    [Fact]
+    public void Static_GetString_HandlesEmptyValue()
+    {
+        var bytes = Utf8("key: ");
+        Assert.Equal("", FieldDocument.GetString(bytes, "key"));
+    }
+
+    [Fact]
+    public void Static_GetString_HandlesBom()
+    {
+        var bytes = new byte[] { 0xEF, 0xBB, 0xBF }.Concat(Utf8("name: Alice")).ToArray();
+        Assert.Equal("Alice", FieldDocument.GetString(bytes, "name"));
+    }
 }

--- a/tests/MarkdownTable.Tests/QueryEngineTests.cs
+++ b/tests/MarkdownTable.Tests/QueryEngineTests.cs
@@ -265,4 +265,119 @@ public class QueryEngineTests
         var scalar = Assert.IsType<ScalarResult>(result);
         Assert.Equal("0", scalar.Value);
     }
+
+    // --- field queries ---
+
+    private const string FieldDocument = """
+        # Package
+
+        **Name:** Newtonsoft.Json
+        **Version:** 13.0.3
+        **Signed:** yes
+
+        ## Dependencies
+
+        | File    | Arch   |
+        | ------- | ------ |
+        | Foo.dll | AnyCPU |
+        | Bar.dll | x64    |
+        """;
+
+    [Fact]
+    public void Execute_FieldAccess_ReturnsScalar()
+    {
+        var result = QueryEngine.Execute(FieldDocument, ".Name");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("Newtonsoft.Json", scalar.Value);
+    }
+
+    [Fact]
+    public void Execute_FieldAccess_CaseInsensitive()
+    {
+        var result = QueryEngine.Execute(FieldDocument, ".name");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("Newtonsoft.Json", scalar.Value);
+    }
+
+    [Fact]
+    public void Execute_FieldAccess_Version()
+    {
+        var result = QueryEngine.Execute(FieldDocument, ".Version");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("13.0.3", scalar.Value);
+    }
+
+    [Fact]
+    public void Execute_SectionTable_StillWorks()
+    {
+        var result = QueryEngine.Execute(FieldDocument, ".Dependencies | count");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("2", scalar.Value);
+    }
+
+    [Fact]
+    public void Execute_SectionTableSelect_StillWorks()
+    {
+        var result = QueryEngine.Execute(FieldDocument, ".Dependencies | .[].File");
+        var table = Assert.IsType<TableResult>(result);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal("Foo.dll", table.Rows[0][0]);
+    }
+
+    [Fact]
+    public void Execute_FieldAccess_FormatsAsScalar()
+    {
+        var result = QueryEngine.Execute(FieldDocument, ".Name");
+        Assert.Equal("Newtonsoft.Json", QueryEngine.FormatResult(result));
+    }
+
+    [Fact]
+    public void Execute_MissingFieldAndSection_Throws()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            QueryEngine.Execute(FieldDocument, ".NonExistent"));
+    }
+
+    private const string FieldsOnlyDocument = """
+        **Kind:** class
+        **Modifiers:** public static
+        **Library:** System.Text.Json.dll
+        """;
+
+    [Fact]
+    public void Execute_FieldsOnly_ScalarAccess()
+    {
+        var result = QueryEngine.Execute(FieldsOnlyDocument, ".Kind");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("class", scalar.Value);
+    }
+
+    [Fact]
+    public void Execute_FieldsOnly_NoTable_Throws()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            QueryEngine.Execute(FieldsOnlyDocument, "count"));
+    }
+
+    private const string PlainFieldDocument = """
+        packageName: Newtonsoft.Json
+        version: 13.0.3
+        hasReadme: true
+        """;
+
+    [Fact]
+    public void Execute_PlainField_ScalarAccess()
+    {
+        var result = QueryEngine.Execute(PlainFieldDocument, ".packageName");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("Newtonsoft.Json", scalar.Value);
+    }
+
+    [Fact]
+    public void Execute_PlainField_BoolValue()
+    {
+        var result = QueryEngine.Execute(PlainFieldDocument, ".hasReadme");
+        var scalar = Assert.IsType<ScalarResult>(result);
+        Assert.Equal("true", scalar.Value);
+    }
 }

--- a/tests/mq-bench/Program.cs
+++ b/tests/mq-bench/Program.cs
@@ -316,6 +316,28 @@ var fieldBenchmarks = new (string Label, string Category, Action Action)[]
             _ = doc.RootElement.GetProperty("assemblyCount").GetInt32();
         }),
 
+    // --- Targeted single-field lookup (no dictionary, early exit) ---
+    ("FDoc targeted 1st", "Targeted",
+        () =>
+        {
+            _ = FieldDocument.GetString(pkgMdBytes, "packageName");
+        }),
+    ("FDoc targeted 4th", "Targeted",
+        () =>
+        {
+            _ = FieldDocument.GetString(pkgMdBytes, "assemblyCount");
+        }),
+    ("FDoc targeted bool", "Targeted",
+        () =>
+        {
+            _ = FieldDocument.GetBool(pkgMdBytes, "hasReadme");
+        }),
+    ("FDoc targeted miss", "Targeted",
+        () =>
+        {
+            _ = FieldDocument.GetString(pkgMdBytes, "nonexistent");
+        }),
+
     // --- Full hydrate (all fields like PackageIndexCache does) ---
     ("FieldDocument hydrate", "Full Hydrate",
         () =>


### PR DESCRIPTION
## Changes

### MarkdownTable.Formatting 0.3.0
- Static targeted field lookup: `FieldDocument.GetString(byte[], key)`, `GetBool`, `GetInt32`, `GetArray`, `ContainsKey`
- Scans linearly with early exit — 0.12µs for first field (10× faster than JsonDocument)
- Span-based key matching (UTF-8, case-insensitive, zero allocation during scan)

### MarkdownTable.Query 0.2.0
- Field query support: `.Name` resolves to scalar field value when no table section matches
- `FieldsResult` type for section field rendering
- Improved error messages for missing fields/sections

### Tests
- 16 new targeted lookup tests in FieldDocumentTests
- 11 new field query tests in QueryEngineTests
- 667 total tests, all passing