### PR TITLE
Simplify TemplateDemo to use inline pipe tables

### DIFF
--- a/samples/TemplateDemo/Program.cs
+++ b/samples/TemplateDemo/Program.cs
@@ -3,32 +3,17 @@ using Markout.Templates;
 using MarkdownTable.Formatting;
 
 // A template is a human-authored document with {{placeholders}} for data.
-// Like the source generator, templates render through the MarkoutWriter pipeline.
-// See template.md alongside this file.
+// BindFields populates placeholders from a markdown field file — no C# model needed.
+// See template.md and data.md alongside this file.
 
-var templatePath = Path.Combine(AppContext.BaseDirectory, "template.md");
-var template = MarkoutTemplate.Load(templatePath);
-
-// Enable statistical table formatting for inline pipe tables
+var basePath = AppContext.BaseDirectory;
+var template = MarkoutTemplate.Load(Path.Combine(basePath, "template.md"));
 template.TableOptions = new TableFormatterOptions();
-
-// Use PrettyTables so bound tables (via IMarkoutFormattable) also get aligned columns
-var writerOptions = new MarkoutWriterOptions { PrettyTables = true };
-
-// Bind inline values
-template.Bind("date", "February 2026");
-
-// Bind IMarkoutFormattable objects for block-level shape rendering
-template.Bind("vuln-table", new VulnerabilityTable());
-template.Bind("product-table", new ProductTable());
-
-// Bind a truthy value to include the conditional section
-template.Bind("commits", "yes");
-template.Bind("commit-table", new CommitTable());
+template.BindFields(File.ReadAllBytes(Path.Combine(basePath, "data.md")));
 
 // Render through MarkdownWriter (default)
 Console.WriteLine("=== Markdown ===");
-Console.WriteLine(template.Render(writerOptions));
+Console.WriteLine(template.Render());
 
 // Render through plain-text MarkoutWriter
 Console.WriteLine("=== Plain Text ===");
@@ -36,54 +21,10 @@ var plainWriter = new MarkoutWriter();
 template.Render(plainWriter);
 Console.WriteLine(plainWriter.ToString());
 
-// Now render WITHOUT commits (conditional section excluded)
+// Render WITHOUT commits (conditional section excluded)
 Console.WriteLine("=== Markdown (no commits) ===");
-var noCommits = MarkoutTemplate.Load(templatePath);
+var noCommits = MarkoutTemplate.Load(Path.Combine(basePath, "template.md"));
 noCommits.TableOptions = new TableFormatterOptions();
-noCommits.Bind("date", "February 2026");
-noCommits.Bind("vuln-table", new VulnerabilityTable());
-noCommits.Bind("product-table", new ProductTable());
-// Don't bind "commits" — conditional section excluded
-Console.WriteLine(noCommits.Render(writerOptions));
-
-// --- Formattable types that render through the writer shape system ---
-
-class VulnerabilityTable : IMarkoutFormattable
-{
-    public void WriteTo(MarkoutWriter writer)
-    {
-        writer.WriteTableStart("CVE", "Severity", "Component");
-        writer.WriteTableRow("CVE-2026-1234", "Critical", "System.Net.Http");
-        writer.WriteTableRow("CVE-2026-1235", "High", "Microsoft.Data.SqlClient");
-        writer.WriteTableRow("CVE-2026-1236", "Medium", "System.Text.Json");
-        writer.WriteTableEnd();
-    }
-
-    public string? ToMarkoutString() => "3 vulnerabilities";
-}
-
-class ProductTable : IMarkoutFormattable
-{
-    public void WriteTo(MarkoutWriter writer)
-    {
-        writer.WriteTableStart("Product", "Version", "Status");
-        writer.WriteTableRow(".NET 9.0", "9.0.4", "Patched");
-        writer.WriteTableRow(".NET 8.0", "8.0.12", "Patched");
-        writer.WriteTableEnd();
-    }
-
-    public string? ToMarkoutString() => "2 products";
-}
-
-class CommitTable : IMarkoutFormattable
-{
-    public void WriteTo(MarkoutWriter writer)
-    {
-        writer.WriteTableStart("SHA", "Message", "Author");
-        writer.WriteTableRow("abc1234", "Fix HTTP header injection", "security-bot");
-        writer.WriteTableRow("def5678", "Patch SQL parameter handling", "security-bot");
-        writer.WriteTableEnd();
-    }
-
-    public string? ToMarkoutString() => "2 commits";
-}
+noCommits.BindFields(File.ReadAllBytes(Path.Combine(basePath, "data.md")));
+noCommits.Bind("commits", (string?)null);  // Override to exclude conditional section
+Console.WriteLine(noCommits.Render());

--- a/samples/TemplateDemo/TemplateDemo.csproj
+++ b/samples/TemplateDemo/TemplateDemo.csproj
@@ -7,13 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include="template.md" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="data.md" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markout.Templates\Markout.Templates.csproj" />
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
     <ProjectReference Include="..\..\src\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj" />
-    <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="true" />
   </ItemGroup>
 </Project>

--- a/samples/TemplateDemo/data.md
+++ b/samples/TemplateDemo/data.md
@@ -1,0 +1,30 @@
+date: February 2026
+commits: yes
+
+cve1: CVE-2026-1234
+severity1: Critical
+component1: System.Net.Http
+
+cve2: CVE-2026-1235
+severity2: High
+component2: Microsoft.Data.SqlClient
+
+cve3: CVE-2026-1236
+severity3: Medium
+component3: System.Text.Json
+
+product1: .NET 9.0
+version1: 9.0.4
+status1: Patched
+
+product2: .NET 8.0
+version2: 8.0.12
+status2: Patched
+
+sha1: abc1234
+message1: Fix HTTP header injection
+author1: security-bot
+
+sha2: def5678
+message2: Patch SQL parameter handling
+author2: security-bot

--- a/samples/TemplateDemo/template.md
+++ b/samples/TemplateDemo/template.md
@@ -2,11 +2,18 @@
 
 The following vulnerabilities were disclosed this month.
 
-{{vuln-table}}
+| CVE | Severity | Component |
+| --- | -------- | --------- |
+| {{cve1}} | {{severity1}} | {{component1}} |
+| {{cve2}} | {{severity2}} | {{component2}} |
+| {{cve3}} | {{severity3}} | {{component3}} |
 
 ## Affected Products
 
-{{product-table}}
+| Product | Version | Status |
+| ------- | ------- | ------ |
+| {{product1}} | {{version1}} | {{status1}} |
+| {{product2}} | {{version2}} | {{status2}} |
 
 ## Severity Definitions
 
@@ -23,5 +30,8 @@ The following vulnerabilities were disclosed this month.
 
 The following commits address the vulnerabilities above.
 
-{{commit-table}}
+| SHA | Message | Author |
+| --- | ------- | ------ |
+| {{sha1}} | {{message1}} | {{author1}} |
+| {{sha2}} | {{message2}} | {{author2}} |
 {{/if}}


### PR DESCRIPTION
Move vulnerability, product, and commit table data from manual `IMarkoutFormattable` C# classes into the template markdown as inline pipe tables. The template engine parses and formats these through `TableFormatterOptions`, so no C# data classes are needed.

`Program.cs` goes from 89 lines to 30 — only dynamic values (`date`, `commits` conditional) are bound in code. Removes unused source generator project reference.