### PR TITLE
Update samples to use declarative patterns and naming policies

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -338,41 +338,23 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     }
 }
 
-// --- JSON Models ---
+// --- JSON Models (camelCase naming via options) ---
 
 public class Actor
 {
-    [JsonPropertyName("name")]
     public string Name { get; set; } = "";
-
-    [JsonPropertyName("birthplace")]
     public string Birthplace { get; set; } = "";
-
-    [JsonPropertyName("birthYear")]
     public int BirthYear { get; set; }
-
-    [JsonPropertyName("citizenship")]
     public List<string> Citizenship { get; set; } = new();
-
-    [JsonPropertyName("shows")]
     public List<string> Shows { get; set; } = new();
 }
 
 public class Show
 {
-    [JsonPropertyName("title")]
     public string Title { get; set; } = "";
-
-    [JsonPropertyName("type")]
     public string Type { get; set; } = "";
-
-    [JsonPropertyName("years")]
     public string Years { get; set; } = "";
-
-    [JsonPropertyName("location")]
     public string Location { get; set; } = "";
-
-    [JsonPropertyName("canadianActors")]
     public List<string> CanadianActors { get; set; } = new();
 }
 
@@ -380,11 +362,10 @@ public class City
 {
     [JsonPropertyName("city")]
     public string CityName { get; set; } = "";
-
-    [JsonPropertyName("country")]
     public string Country { get; set; } = "";
 }
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(List<Actor>))]
 [JsonSerializable(typeof(List<Show>))]
 [JsonSerializable(typeof(List<City>))]

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -77,13 +77,15 @@ public class ReleaseRow
 [MarkoutContext(typeof(ReleaseRow))]
 public partial class ReleasesContext : MarkoutSerializerContext { }
 
-// --- JSON Models (snake_case naming via options) ---
+// --- JSON Models (snake_case naming via options, explicit for HAL _embedded) ---
 
 public class ReleaseIndex
 {
     public string? Title { get; set; }
     public string? LatestMajor { get; set; }
     public string? LatestLtsMajor { get; set; }
+
+    [JsonPropertyName("_embedded")]
     public EmbeddedReleases? Embedded { get; set; }
 }
 

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -37,7 +37,7 @@ var view = new ReleasesView
 // Serialize to markdown
 MarkoutSerializer.Serialize(view, Console.Out, ReleasesContext.Default);
 
-// --- Models ---
+// --- View Models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
 public class ReleasesView
@@ -77,40 +77,28 @@ public class ReleaseRow
 [MarkoutContext(typeof(ReleaseRow))]
 public partial class ReleasesContext : MarkoutSerializerContext { }
 
-// --- JSON Models ---
+// --- JSON Models (snake_case naming via options) ---
 
 public class ReleaseIndex
 {
-    [JsonPropertyName("title")]
     public string? Title { get; set; }
-
-    [JsonPropertyName("latest_major")]
     public string? LatestMajor { get; set; }
-
-    [JsonPropertyName("latest_lts_major")]
     public string? LatestLtsMajor { get; set; }
-
-    [JsonPropertyName("_embedded")]
     public EmbeddedReleases? Embedded { get; set; }
 }
 
 public class EmbeddedReleases
 {
-    [JsonPropertyName("releases")]
     public List<Release>? Releases { get; set; }
 }
 
 public class Release
 {
-    [JsonPropertyName("version")]
     public string Version { get; set; } = "";
-
-    [JsonPropertyName("release_type")]
     public string? ReleaseType { get; set; }
-
-    [JsonPropertyName("supported")]
     public bool Supported { get; set; }
 }
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(ReleaseIndex))]
 internal partial class ReleasesJsonContext : JsonSerializerContext { }

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using Markout;
 using Markout.Ansi.Spectre;
 using Spectre.Console;
+using TreeNode = Markout.TreeNode;
 
 var cutoff = DateTimeOffset.UtcNow.AddMonths(-6);
 
@@ -45,53 +46,54 @@ var cveDataList = (await Task.WhenAll(cveUrls.Select(async url =>
     return JsonSerializer.Deserialize(json, CveJsonContext.Default.CveData);
 }))).Where(c => c is not null).ToList();
 
-// Build CVE ID → view model lookup
-var cveItems = cveDataList
-    .SelectMany(c => c!.Disclosures ?? [])
-    .DistinctBy(d => d.Id)
-    .ToDictionary(
-        d => d.Id,
-        d => new CveItemView
+// Build CVE ID → (reference URL, severity) lookup
+var cveInfo = new Dictionary<string, (string Url, string? Severity)>();
+foreach (var d in cveDataList.SelectMany(c => c!.Disclosures ?? []))
+    cveInfo.TryAdd(d.Id, (d.References?.FirstOrDefault() ?? "", d.Cvss?.Severity));
+
+// Build tree nodes
+var tree = new List<TreeNode>();
+foreach (var (version, vi) in versionData.OrderByDescending(v => decimal.TryParse(v.Version, out var n) ? n : 0))
+{
+    if (vi is null) continue;
+    var date = DateTimeOffset.TryParse(vi.LatestPatchDate, out var d)
+        ? d.ToString("yyyy-MM-dd") : "unknown";
+
+    // Collect unique CVEs for this version across all fetched CVE data
+    var cves = cveDataList
+        .SelectMany(c => c!.ReleaseCves?.TryGetValue(version, out var ids) == true ? ids : [])
+        .Distinct()
+        .OrderBy(id => id)
+        .Select(id =>
         {
-            Id = d.Id,
-            Url = d.References?.FirstOrDefault(),
-            Severity = d.Cvss?.Severity
-        });
+            var (url, severity) = cveInfo.TryGetValue(id, out var info) ? info : ("", null);
+            var label = !string.IsNullOrEmpty(url) ? $"[{id}]({url})" : id;
+            var badge = severity?.ToUpperInvariant() switch
+            {
+                "CRITICAL" => "🔴",
+                "HIGH" => "🟠",
+                "MEDIUM" => "🟡",
+                "LOW" => "🟢",
+                _ => null
+            };
+            return new TreeNode(label, badge);
+        })
+        .ToList();
 
-// Build release views with CVE items
-var releases = versionData
-    .OrderByDescending(v => decimal.TryParse(v.Version, out var n) ? n : 0)
-    .Where(v => v.Item2 is not null)
-    .Select(v =>
-    {
-        var (version, vi) = v;
-        var lastUpdated = DateTimeOffset.TryParse(vi!.LatestPatchDate, out var d)
-            ? d.ToString("yyyy-MM-dd") : "unknown";
+    if (cves.Count == 0)
+        cves.Add(new TreeNode("None"));
 
-        var cves = cveDataList
-            .SelectMany(c => c!.ReleaseCves?.TryGetValue(version, out var ids) == true ? ids : [])
-            .Distinct()
-            .OrderBy(id => id)
-            .Select(id => cveItems.TryGetValue(id, out var item) ? item : new CveItemView { Id = id })
-            .ToList();
+    tree.Add(new TreeNode($"{version} (last updated: {date})", cves));
+}
 
-        return new ReleaseView
-        {
-            Version = version,
-            LastUpdated = lastUpdated,
-            Cves = cves
-        };
-    })
-    .ToList();
-
-// Count severity distribution from view models
-var severityCounts = cveItems.Values
+// Count severity distribution
+var severityCounts = cveInfo.Values
     .GroupBy(v => v.Severity?.ToUpperInvariant() ?? "UNKNOWN")
     .OrderByDescending(g => g.Key switch { "CRITICAL" => 0, "HIGH" => 1, "MEDIUM" => 2, "LOW" => 3, _ => 4 })
     .ToDictionary(g => g.Key, g => g.Count());
 var criticalCount = severityCounts.GetValueOrDefault("CRITICAL");
 
-// Build the view model
+// Serialize to markdown
 var view = new LatestCvesView
 {
     Title = ".NET Security Advisories",
@@ -102,13 +104,12 @@ var view = new LatestCvesView
     SeverityBreakdown = severityCounts.Count > 0
         ? [new Breakdown("By Severity", severityCounts.Select(kv => new Segment(kv.Key, kv.Value)).ToArray())]
         : null,
-    Releases = releases
+    Releases = tree
 };
-
 var writer = new SpectreWriter(AnsiConsole.Console);
 MarkoutSerializer.Serialize(view, writer, LatestCvesContext.Default);
 
-// --- View Models ---
+// --- View Model ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
 public class LatestCvesView
@@ -125,50 +126,18 @@ public class LatestCvesView
     [MarkoutIgnoreInTable]
     public IReadOnlyList<Breakdown>? SeverityBreakdown { get; set; }
 
-    [MarkoutSection(Name = "Releases")]
     [MarkoutIgnoreInTable]
-    public List<ReleaseView>? Releases { get; set; }
-}
-
-[MarkoutSerializable(TitleProperty = nameof(VersionLabel), AutoFields = false)]
-public class ReleaseView
-{
-    [MarkoutIgnore]
-    public string Version { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string LastUpdated { get; set; } = "";
-
-    [MarkoutIgnore]
-    public string VersionLabel => $".NET {Version} (last updated: {LastUpdated})";
-
-    [MarkoutSection(Name = "CVEs")]
-    public List<CveItemView>? Cves { get; set; }
-}
-
-[MarkoutSerializable]
-public class CveItemView
-{
-    [MarkoutPropertyName("CVE")]
-    [MarkoutLink(TextProperty = nameof(Id))]
-    public string? Url { get; set; }
-
-    [MarkoutIgnore]
-    public string Id { get; set; } = "";
-
-    [MarkoutValueMap("CRITICAL=🔴", "HIGH=🟠", "MEDIUM=🟡", "LOW=🟢")]
-    public string? Severity { get; set; }
+    public List<TreeNode>? Releases { get; set; }
 }
 
 [MarkoutContext(typeof(LatestCvesView))]
-[MarkoutContext(typeof(ReleaseView))]
-[MarkoutContext(typeof(CveItemView))]
 public partial class LatestCvesContext : MarkoutSerializerContext { }
 
-// --- JSON Models (snake_case naming via options) ---
+// --- JSON Models (snake_case via options; explicit for HAL _embedded/_links) ---
 
 public class ReleaseIndex
 {
+    [JsonPropertyName("_embedded")]
     public ReleaseEmbedded? Embedded { get; set; }
 }
 
@@ -181,6 +150,8 @@ public class ReleaseEntry
 {
     public string Version { get; set; } = "";
     public bool Supported { get; set; }
+
+    [JsonPropertyName("_links")]
     public EntryLinks? Links { get; set; }
 }
 
@@ -197,6 +168,8 @@ public class LinkRef
 public class VersionIndex
 {
     public string? LatestPatchDate { get; set; }
+
+    [JsonPropertyName("_embedded")]
     public PatchEmbedded? Embedded { get; set; }
 }
 
@@ -209,6 +182,8 @@ public class PatchRelease
 {
     public string? Date { get; set; }
     public bool Security { get; set; }
+
+    [JsonPropertyName("_links")]
     public PatchLinks? Links { get; set; }
 }
 

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Serialization;
 using Markout;
 using Markout.Ansi.Spectre;
 using Spectre.Console;
-using TreeNode = Markout.TreeNode;
 
 var cutoff = DateTimeOffset.UtcNow.AddMonths(-6);
 
@@ -46,54 +45,53 @@ var cveDataList = (await Task.WhenAll(cveUrls.Select(async url =>
     return JsonSerializer.Deserialize(json, CveJsonContext.Default.CveData);
 }))).Where(c => c is not null).ToList();
 
-// Build CVE ID → (reference URL, severity) lookup
-var cveInfo = new Dictionary<string, (string Url, string? Severity)>();
-foreach (var d in cveDataList.SelectMany(c => c!.Disclosures ?? []))
-    cveInfo.TryAdd(d.Id, (d.References?.FirstOrDefault() ?? "", d.Cvss?.Severity));
-
-// Build tree nodes
-var tree = new List<TreeNode>();
-foreach (var (version, vi) in versionData.OrderByDescending(v => decimal.TryParse(v.Version, out var n) ? n : 0))
-{
-    if (vi is null) continue;
-    var date = DateTimeOffset.TryParse(vi.LatestPatchDate, out var d)
-        ? d.ToString("yyyy-MM-dd") : "unknown";
-
-    // Collect unique CVEs for this version across all fetched CVE data
-    var cves = cveDataList
-        .SelectMany(c => c!.ReleaseCves?.TryGetValue(version, out var ids) == true ? ids : [])
-        .Distinct()
-        .OrderBy(id => id)
-        .Select(id =>
+// Build CVE ID → view model lookup
+var cveItems = cveDataList
+    .SelectMany(c => c!.Disclosures ?? [])
+    .DistinctBy(d => d.Id)
+    .ToDictionary(
+        d => d.Id,
+        d => new CveItemView
         {
-            var (url, severity) = cveInfo.TryGetValue(id, out var info) ? info : ("", null);
-            var label = !string.IsNullOrEmpty(url) ? $"[{id}]({url})" : id;
-            var badge = severity?.ToUpperInvariant() switch
-            {
-                "CRITICAL" => "🔴",
-                "HIGH" => "🟠",
-                "MEDIUM" => "🟡",
-                "LOW" => "🟢",
-                _ => null
-            };
-            return new TreeNode(label, badge);
-        })
-        .ToList();
+            Id = d.Id,
+            Url = d.References?.FirstOrDefault(),
+            Severity = d.Cvss?.Severity
+        });
 
-    if (cves.Count == 0)
-        cves.Add(new TreeNode("None"));
+// Build release views with CVE items
+var releases = versionData
+    .OrderByDescending(v => decimal.TryParse(v.Version, out var n) ? n : 0)
+    .Where(v => v.Item2 is not null)
+    .Select(v =>
+    {
+        var (version, vi) = v;
+        var lastUpdated = DateTimeOffset.TryParse(vi!.LatestPatchDate, out var d)
+            ? d.ToString("yyyy-MM-dd") : "unknown";
 
-    tree.Add(new TreeNode($"{version} (last updated: {date})", cves));
-}
+        var cves = cveDataList
+            .SelectMany(c => c!.ReleaseCves?.TryGetValue(version, out var ids) == true ? ids : [])
+            .Distinct()
+            .OrderBy(id => id)
+            .Select(id => cveItems.TryGetValue(id, out var item) ? item : new CveItemView { Id = id })
+            .ToList();
 
-// Count severity distribution
-var severityCounts = cveInfo.Values
+        return new ReleaseView
+        {
+            Version = version,
+            LastUpdated = lastUpdated,
+            Cves = cves
+        };
+    })
+    .ToList();
+
+// Count severity distribution from view models
+var severityCounts = cveItems.Values
     .GroupBy(v => v.Severity?.ToUpperInvariant() ?? "UNKNOWN")
     .OrderByDescending(g => g.Key switch { "CRITICAL" => 0, "HIGH" => 1, "MEDIUM" => 2, "LOW" => 3, _ => 4 })
     .ToDictionary(g => g.Key, g => g.Count());
 var criticalCount = severityCounts.GetValueOrDefault("CRITICAL");
 
-// Serialize to markdown
+// Build the view model
 var view = new LatestCvesView
 {
     Title = ".NET Security Advisories",
@@ -104,12 +102,13 @@ var view = new LatestCvesView
     SeverityBreakdown = severityCounts.Count > 0
         ? [new Breakdown("By Severity", severityCounts.Select(kv => new Segment(kv.Key, kv.Value)).ToArray())]
         : null,
-    Releases = tree
+    Releases = releases
 };
+
 var writer = new SpectreWriter(AnsiConsole.Console);
 MarkoutSerializer.Serialize(view, writer, LatestCvesContext.Default);
 
-// --- View Model ---
+// --- View Models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
 public class LatestCvesView
@@ -126,75 +125,90 @@ public class LatestCvesView
     [MarkoutIgnoreInTable]
     public IReadOnlyList<Breakdown>? SeverityBreakdown { get; set; }
 
+    [MarkoutSection(Name = "Releases")]
     [MarkoutIgnoreInTable]
-    public List<TreeNode>? Releases { get; set; }
+    public List<ReleaseView>? Releases { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(VersionLabel), AutoFields = false)]
+public class ReleaseView
+{
+    [MarkoutIgnore]
+    public string Version { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string LastUpdated { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string VersionLabel => $".NET {Version} (last updated: {LastUpdated})";
+
+    [MarkoutSection(Name = "CVEs")]
+    public List<CveItemView>? Cves { get; set; }
+}
+
+[MarkoutSerializable]
+public class CveItemView
+{
+    [MarkoutPropertyName("CVE")]
+    [MarkoutLink(TextProperty = nameof(Id))]
+    public string? Url { get; set; }
+
+    [MarkoutIgnore]
+    public string Id { get; set; } = "";
+
+    [MarkoutValueMap("CRITICAL=🔴", "HIGH=🟠", "MEDIUM=🟡", "LOW=🟢")]
+    public string? Severity { get; set; }
 }
 
 [MarkoutContext(typeof(LatestCvesView))]
+[MarkoutContext(typeof(ReleaseView))]
+[MarkoutContext(typeof(CveItemView))]
 public partial class LatestCvesContext : MarkoutSerializerContext { }
 
-// --- JSON Models ---
+// --- JSON Models (snake_case naming via options) ---
 
 public class ReleaseIndex
 {
-    [JsonPropertyName("_embedded")]
     public ReleaseEmbedded? Embedded { get; set; }
 }
 
 public class ReleaseEmbedded
 {
-    [JsonPropertyName("releases")]
     public List<ReleaseEntry>? Releases { get; set; }
 }
 
 public class ReleaseEntry
 {
-    [JsonPropertyName("version")]
     public string Version { get; set; } = "";
-
-    [JsonPropertyName("supported")]
     public bool Supported { get; set; }
-
-    [JsonPropertyName("_links")]
     public EntryLinks? Links { get; set; }
 }
 
 public class EntryLinks
 {
-    [JsonPropertyName("self")]
     public LinkRef? Self { get; set; }
 }
 
 public class LinkRef
 {
-    [JsonPropertyName("href")]
     public string Href { get; set; } = "";
 }
 
 public class VersionIndex
 {
-    [JsonPropertyName("latest_patch_date")]
     public string? LatestPatchDate { get; set; }
-
-    [JsonPropertyName("_embedded")]
     public PatchEmbedded? Embedded { get; set; }
 }
 
 public class PatchEmbedded
 {
-    [JsonPropertyName("patches")]
     public List<PatchRelease>? Patches { get; set; }
 }
 
 public class PatchRelease
 {
-    [JsonPropertyName("date")]
     public string? Date { get; set; }
-
-    [JsonPropertyName("security")]
     public bool Security { get; set; }
-
-    [JsonPropertyName("_links")]
     public PatchLinks? Links { get; set; }
 }
 
@@ -206,31 +220,23 @@ public class PatchLinks
 
 public class CveData
 {
-    [JsonPropertyName("disclosures")]
     public List<CveDisclosure>? Disclosures { get; set; }
-
-    [JsonPropertyName("release_cves")]
     public Dictionary<string, List<string>>? ReleaseCves { get; set; }
 }
 
 public class CveDisclosure
 {
-    [JsonPropertyName("id")]
     public string Id { get; set; } = "";
-
-    [JsonPropertyName("references")]
     public List<string>? References { get; set; }
-
-    [JsonPropertyName("cvss")]
     public CveCvss? Cvss { get; set; }
 }
 
 public class CveCvss
 {
-    [JsonPropertyName("severity")]
     public string? Severity { get; set; }
 }
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(ReleaseIndex))]
 [JsonSerializable(typeof(VersionIndex))]
 [JsonSerializable(typeof(CveData))]


### PR DESCRIPTION
## Summary

Updates three samples to use modern declarative patterns:

### LatestCves
- **View models with `[MarkoutValueMap]`** for severity badges instead of imperative switch
- LINQ populates `CveItemView`, `ReleaseView` instead of manual `TreeNode` construction
- `JsonSourceGenerationOptions(SnakeCaseLower)` removes 20+ `[JsonPropertyName]` attributes

Before:
```csharp
var badge = severity?.ToUpperInvariant() switch
{
    "CRITICAL" => "🔴",
    "HIGH" => "🟠",
    ...
};
return new TreeNode(label, badge);
```

After:
```csharp
[MarkoutSerializable]
public class CveItemView
{
    [MarkoutValueMap("CRITICAL=🔴", "HIGH=🟠", "MEDIUM=🟡", "LOW=🟢")]
    public string? Severity { get; set; }
}
```

### DotNetReleases
- `JsonSourceGenerationOptions(SnakeCaseLower)` — removes 8 `[JsonPropertyName]` attributes

### CanadianContent  
- `JsonSourceGenerationOptions(CamelCase)` — removes 12 `[JsonPropertyName]` attributes
- Keeps `[JsonPropertyName("city")]` where property name differs from JSON key

## Test plan

- [x] All three samples build successfully
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)