### PR TITLE
Release Markout 0.7.2 — projection support

### DIFF
--- a/docs/design/projection.md
+++ b/docs/design/projection.md
@@ -1,0 +1,200 @@
+# Projection
+
+**Projection trims markout output to specific columns and fields at runtime, without changing view models or source generation.**
+
+## The Problem
+
+Docker's `--format` flag lets users reshape CLI output using Go templates:
+
+```bash
+docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+docker images --format "{{.Repository}}:{{.Tag}}"
+```
+
+This is powerful but unfriendly. Without pre-built templates in a script or config file, you fall off a cliff — the syntax is hard to remember and easy to get wrong. Docker doesn't ship pre-canned profiles either, so most users never touch `--format` beyond copy-pasting from Stack Overflow.
+
+Markout's projection takes a different approach. Instead of a template language that reconstructs output from scratch, projection is **subtractive** — you start with the full shaped document and trim it down. You say *what data to keep*, not *how to arrange it*. The renderer still makes all visual decisions.
+
+## How It Works
+
+`MarkoutProjection` is a set of include/exclude filters at two granularities:
+
+| Granularity | Include | Exclude | Target |
+| --- | --- | --- | --- |
+| **Column** | `IncludeColumns` | `ExcludeColumns` | Table headers → cells |
+| **Field** | `IncludeFields` | `ExcludeFields` | Scalar field keys |
+
+These compose with existing section filtering (`IncludeSections` / `ExcludeSections`) to give three levels of trimming:
+
+```text
+Section  →  narrows to specific H2 blocks
+Column   →  narrows table columns within those blocks
+Field    →  narrows scalar fields within those blocks
+```
+
+### Basic Example
+
+```csharp
+var options = new MarkoutWriterOptions
+{
+    Projection = new MarkoutProjection
+    {
+        IncludeColumns = ["Name", "TFM"],
+        IncludeFields = ["Version", "License"]
+    }
+};
+
+var writer = new MarkdownWriter(options);
+// ... serialize any markout object ...
+```
+
+Tables render only the Name and TFM columns. Scalar fields render only Version and License. Everything else is silently trimmed. The same projection works identically with `OneLineWriter`, `AnsiWriter`, `MarkoutWriter`, or any custom renderer.
+
+### Column Selection and Reordering
+
+`IncludeColumns` is an ordered list, not a set. The output column order matches the list order:
+
+```csharp
+// Original table: Name | Version | TFM | Signed
+// Output:         TFM | Name
+Projection = new MarkoutProjection
+{
+    IncludeColumns = ["TFM", "Name"]
+}
+```
+
+`ExcludeColumns` removes columns but preserves the original order:
+
+```csharp
+// Original table: Name | Version | TFM | Signed
+// Output:         Name | TFM | Signed
+Projection = new MarkoutProjection
+{
+    ExcludeColumns = ["Version"]
+}
+```
+
+Column names match what you see in the table header — the display name, not the C# property name. Matching is case-insensitive by default.
+
+### Field Selection
+
+Works the same way for scalar fields (`WriteField`, `WriteFieldNoBreak`, `WriteFieldList`):
+
+```csharp
+// Only Name and License appear in output
+Projection = new MarkoutProjection
+{
+    IncludeFields = ["Name", "License"]
+}
+```
+
+Field names match the key passed to `WriteField(key, value)` — again the display name, case-insensitive.
+
+### Composition
+
+Projection composes with everything that already exists:
+
+```csharp
+var options = new MarkoutWriterOptions
+{
+    IncludeSections = new HashSet<string> { "Dependencies" },
+    Projection = new MarkoutProjection
+    {
+        IncludeColumns = ["Name", "Version"]
+    }
+};
+```
+
+Evaluation order: **section filtering → shape support → column/field projection**. Each layer narrows further. They never conflict.
+
+## Comparison with Go Templates
+
+| Aspect | Go Templates (`docker --format`) | Markout Projection |
+| --- | --- | --- |
+| **Approach** | Additive — build output from scratch | Subtractive — trim from full output |
+| **Syntax** | `"table {{.Repository}}\t{{.Tag}}"` | `IncludeColumns = ["Name", "Tag"]` |
+| **Learning curve** | Steep — must know Go template syntax | Flat — list the names you want |
+| **Renderer control** | None — you produce raw text | Full — renderer decides formatting |
+| **Reordering** | Yes, by template position | Yes, by list order |
+| **String interpolation** | Yes (`{{.Name}}:{{.Tag}}`) | No — output is always shaped |
+| **Functions** | `upper`, `lower`, `truncate`, `pad` | No — renderer handles presentation |
+| **Works across formats** | No — template produces one format | Yes — same projection for Markdown, ANSI, plain text |
+
+The tradeoff is deliberate. Go templates give you full control over the output string, but you lose structured output and renderer portability. Projection keeps the output shaped and portable, but you can't do arbitrary string interpolation. For CLI tools that render the same data in multiple formats, projection is the better fit.
+
+## Where Projection Lives in the Architecture
+
+### Source Generation: Not Involved
+
+Source generation maps C# property types to shapes at compile time (`string` → Identity, `List<T>` → Tabulation, `List<Metric>` → Measurement). It emits calls like `writer.WriteField("Name", value.Name)` and `writer.WriteTableStart("Col1", "Col2")`.
+
+**Projection doesn't change source generation.** The generated code is the same whether or not a projection is applied. Projection operates at render time, downstream of serialization.
+
+### Writer Base Class: Where Projection Happens
+
+All projection logic lives in `MarkoutWriter` — the base class that all renderers extend. This is the same level where section filtering already lives.
+
+```text
+Source Generator → emits calls → MarkoutWriter (base)
+                                    ├── section filtering (existing)
+                                    ├── column projection (new)
+                                    ├── field projection (new)
+                                    └── dispatches to virtual methods
+                                            ├── MarkdownWriter
+                                            ├── OneLineWriter
+                                            ├── AnsiWriter
+                                            └── ...
+```
+
+When `WriteTableStart(headers)` is called, the base class computes a column index map from the projection. Subsequent `WriteTableRow(values)` calls remap cells through this map before adding them to the streaming buffer. By the time `FlushStreamingTable` dispatches to the renderer subclass, the data is already projected.
+
+When `WriteField(key, value)` is called, the base class checks the projection and returns early if the field is excluded. The renderer never sees it.
+
+### Renderers: Zero Complexity
+
+**Renderer authors don't need to know about projection.** If you write a custom `MarkoutWriter` subclass, projection just works — your `FlushStreamingTable` override receives already-projected headers and rows, and excluded fields never reach your `WriteFieldName` override.
+
+This follows the same pattern as section filtering: the base class handles the decision, subclasses handle the rendering.
+
+### Shapes: Projection Applies to Identity and Tabulation
+
+Of markout's shape vocabulary, projection targets two:
+
+| Shape | Projection | Mechanism |
+| --- | --- | --- |
+| **Identity** (Fields, FieldList) | `IncludeFields` / `ExcludeFields` | Filter by key name |
+| **Tabulation** (Tables) | `IncludeColumns` / `ExcludeColumns` | Filter and reorder by header name |
+
+Other shapes (Trees, Metrics, Breakdowns, Descriptions, Code, Callouts) pass through unchanged. They don't have named sub-elements that a user would want to select individually.
+
+Section filtering remains the coarse-grained control for everything — it operates on the document structure, not individual shapes.
+
+## For LLM and Agent Consumers
+
+Projection makes markout output **token-efficient and parseable** for LLM workflows. Instead of receiving a full document and extracting what you need, you request only the fields and columns that matter.
+
+### Example: SKILL.md Paragraph
+
+```markdown
+## Output Projection
+
+Use `--columns` and `--fields` to trim output to exactly what you need:
+
+- **`--columns Name,Version`** — show only these table columns, in this order
+- **`--fields Name,License`** — show only these scalar fields
+- **`-s Dependencies --columns Name`** — combine with section filtering
+
+Prefer `--columns` over `--oneline` for token-efficient scanning.
+Prefer `--fields` over `-v:q` when you need specific values, not less detail.
+Both options work with any output format (markdown, oneline, JSON).
+```
+
+### Why This Matters for Agents
+
+1. **Predictable output shape.** An agent requesting `--columns Name,Version` knows exactly what columns appear — no parsing surprises, no version-dependent extra columns.
+
+2. **Token efficiency.** A 15-column table trimmed to 2 columns is 7× fewer tokens. For scanning large API surfaces or dependency lists, this adds up fast.
+
+3. **Composable queries.** Section filtering picks the block, column filtering picks the data within it. An agent can progressively narrow: first `-s Dependencies` to find the right section, then `--columns Name` to extract just the names.
+
+4. **Format-independent.** The same projection produces trimmed Markdown (for rendering), trimmed oneline (for grep), or trimmed plain text (for piping). An agent doesn't need different strategies per output format.

--- a/docs/design/projection.md
+++ b/docs/design/projection.md
@@ -1,6 +1,6 @@
 # Projection
 
-**Projection trims markout output to specific columns and fields at runtime, without changing view models or source generation.**
+**Projection trims markout output to specific sections, columns, and fields at runtime, without changing view models or source generation.**
 
 ## The Problem
 
@@ -17,20 +17,23 @@ Markout's projection takes a different approach. Instead of a template language 
 
 ## How It Works
 
-`MarkoutProjection` is a set of include/exclude filters at two granularities:
+`MarkoutProjection` is a set of include/exclude filters at three granularities:
 
 | Granularity | Include | Exclude | Target |
 | --- | --- | --- | --- |
+| **Section** | `IncludeSections` | — | H2 section names |
 | **Column** | `IncludeColumns` | `ExcludeColumns` | Table headers → cells |
 | **Field** | `IncludeFields` | `ExcludeFields` | Scalar field keys |
 
-These compose with existing section filtering (`IncludeSections` / `ExcludeSections`) to give three levels of trimming:
+Section, column, and field filtering compose to give three levels of trimming:
 
 ```text
-Section  →  narrows to specific H2 blocks
-Column   →  narrows table columns within those blocks
-Field    →  narrows scalar fields within those blocks
+Section  →  narrows to specific H2 blocks (content renders unfiltered)
+Column   →  narrows table columns within non-section-matched blocks
+Field    →  narrows scalar fields within non-section-matched blocks
 ```
+
+When a section name matches `IncludeSections`, the section is included and its content renders fully — column and field filtering is suspended within it. This allows a CLI flag like `-S Package` to show the entire Package section while `-S Version` filters to just that field.
 
 ### Basic Example
 
@@ -88,7 +91,23 @@ Projection = new MarkoutProjection
 }
 ```
 
-Field names match the key passed to `WriteField(key, value)` — again the display name, case-insensitive.
+Field names match the key passed to `WriteField(key, value)` — again the display name, case-insensitive. `WriteFieldTable` (Property/Value tables) also respects field projection, filtering rows by key name.
+
+### Section Selection
+
+`IncludeSections` on the projection overrides options-level section excludes, enabling a unified `--select` flag to match sections alongside fields and columns:
+
+```csharp
+// -S Package → show the entire Package section, unfiltered
+Projection = new MarkoutProjection
+{
+    IncludeSections = ["Package"],
+    IncludeColumns = ["Package"],
+    IncludeFields = ["Package"]
+}
+```
+
+When a section name matches `IncludeSections`, field and column filtering is suspended for that section — the entire section renders as-is. For non-matching sections, field and column filtering still applies. Empty sections (where all content is filtered away) are automatically suppressed — the section heading is deferred until content is actually written.
 
 ### Composition
 
@@ -105,7 +124,7 @@ var options = new MarkoutWriterOptions
 };
 ```
 
-Evaluation order: **section filtering → shape support → column/field projection**. Each layer narrows further. They never conflict.
+Evaluation order: **section filtering → projection section matching → shape support → column/field projection**. Projection section matches override options-level excludes. Within projection-matched sections, column/field filtering is bypassed.
 
 ## Comparison with Go Templates
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutProjection.cs
+++ b/src/Markout/MarkoutProjection.cs
@@ -17,7 +17,19 @@ public class MarkoutProjection
     private HashSet<string>? _excludeColumns;
     private IReadOnlyList<string>? _includeFields;
     private HashSet<string>? _excludeFields;
+    private IReadOnlyList<string>? _includeSections;
     private StringComparison _comparison = StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// If set, sections whose name matches are included even if excluded by
+    /// <see cref="MarkoutWriterOptions.IncludeSections"/>/<see cref="MarkoutWriterOptions.ExcludeSections"/>.
+    /// Content within projection-included sections is rendered without field/column filtering.
+    /// </summary>
+    public IReadOnlyList<string>? IncludeSections
+    {
+        get => _includeSections;
+        set => _includeSections = value;
+    }
 
     /// <summary>
     /// If set, only table columns whose header text matches are rendered, in the specified order.
@@ -137,6 +149,22 @@ public class MarkoutProjection
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Returns true if the given section name is included by this projection.
+    /// </summary>
+    internal bool IsSectionIncluded(string sectionName)
+    {
+        if (_includeSections == null)
+            return false;
+
+        foreach (var s in _includeSections)
+        {
+            if (string.Equals(s, sectionName, _comparison))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/Markout/MarkoutProjection.cs
+++ b/src/Markout/MarkoutProjection.cs
@@ -1,0 +1,215 @@
+namespace Markout;
+
+/// <summary>
+/// Defines a projection that trims markout output to specific sections, columns, and fields.
+/// Projection is subtractive — it narrows from full output to what is requested.
+/// </summary>
+/// <remarks>
+/// <para>Three granularities compose naturally: section narrows to a block,
+/// column/field narrows within that block.</para>
+/// <para>Include lists are ordered — column and field order follows the list order.
+/// Exclude sets are unordered.</para>
+/// <para>For each granularity, set either Include or Exclude, not both.</para>
+/// </remarks>
+public class MarkoutProjection
+{
+    private IReadOnlyList<string>? _includeColumns;
+    private HashSet<string>? _excludeColumns;
+    private IReadOnlyList<string>? _includeFields;
+    private HashSet<string>? _excludeFields;
+    private StringComparison _comparison = StringComparison.OrdinalIgnoreCase;
+
+    /// <summary>
+    /// If set, only table columns whose header text matches are rendered, in the specified order.
+    /// </summary>
+    public IReadOnlyList<string>? IncludeColumns
+    {
+        get => _includeColumns;
+        set
+        {
+            if (value != null && _excludeColumns != null)
+                throw new InvalidOperationException("Cannot set IncludeColumns when ExcludeColumns is set.");
+            _includeColumns = value;
+        }
+    }
+
+    /// <summary>
+    /// If set, table columns whose header text matches are excluded from output.
+    /// </summary>
+    public HashSet<string>? ExcludeColumns
+    {
+        get => _excludeColumns;
+        set
+        {
+            if (value != null && _includeColumns != null)
+                throw new InvalidOperationException("Cannot set ExcludeColumns when IncludeColumns is set.");
+            _excludeColumns = value;
+        }
+    }
+
+    /// <summary>
+    /// If set, only scalar fields whose key matches are rendered, in the specified order.
+    /// </summary>
+    public IReadOnlyList<string>? IncludeFields
+    {
+        get => _includeFields;
+        set
+        {
+            if (value != null && _excludeFields != null)
+                throw new InvalidOperationException("Cannot set IncludeFields when ExcludeFields is set.");
+            _includeFields = value;
+        }
+    }
+
+    /// <summary>
+    /// If set, scalar fields whose key matches are excluded from output.
+    /// </summary>
+    public HashSet<string>? ExcludeFields
+    {
+        get => _excludeFields;
+        set
+        {
+            if (value != null && _includeFields != null)
+                throw new InvalidOperationException("Cannot set ExcludeFields when IncludeFields is set.");
+            _excludeFields = value;
+        }
+    }
+
+    /// <summary>
+    /// String comparison used for matching column headers and field keys.
+    /// Default is <see cref="StringComparison.OrdinalIgnoreCase"/>.
+    /// </summary>
+    public StringComparison Comparison
+    {
+        get => _comparison;
+        set => _comparison = value;
+    }
+
+    /// <summary>
+    /// Returns true if the given column header should be included in output.
+    /// </summary>
+    internal bool IsColumnIncluded(string header)
+    {
+        if (_includeColumns != null)
+        {
+            foreach (var col in _includeColumns)
+            {
+                if (string.Equals(col, header, _comparison))
+                    return true;
+            }
+            return false;
+        }
+
+        if (_excludeColumns != null)
+        {
+            foreach (var col in _excludeColumns)
+            {
+                if (string.Equals(col, header, _comparison))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns true if the given field key should be included in output.
+    /// </summary>
+    internal bool IsFieldIncluded(string key)
+    {
+        if (_includeFields != null)
+        {
+            foreach (var field in _includeFields)
+            {
+                if (string.Equals(field, key, _comparison))
+                    return true;
+            }
+            return false;
+        }
+
+        if (_excludeFields != null)
+        {
+            foreach (var field in _excludeFields)
+            {
+                if (string.Equals(field, key, _comparison))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Computes a column index map for projecting table columns.
+    /// Returns null if no column projection is needed.
+    /// Each entry maps projected position → original position.
+    /// </summary>
+    internal int[]? ComputeColumnMap(string[] headers)
+    {
+        if (_includeColumns != null)
+        {
+            // Include: output columns in the order specified by IncludeColumns
+            var map = new List<int>(_includeColumns.Count);
+            foreach (var col in _includeColumns)
+            {
+                for (int i = 0; i < headers.Length; i++)
+                {
+                    if (string.Equals(col, headers[i], _comparison))
+                    {
+                        map.Add(i);
+                        break;
+                    }
+                }
+            }
+            return map.Count > 0 ? map.ToArray() : null;
+        }
+
+        if (_excludeColumns != null)
+        {
+            // Exclude: preserve original order, skip excluded columns
+            var map = new List<int>(headers.Length);
+            for (int i = 0; i < headers.Length; i++)
+            {
+                bool excluded = false;
+                foreach (var col in _excludeColumns)
+                {
+                    if (string.Equals(col, headers[i], _comparison))
+                    {
+                        excluded = true;
+                        break;
+                    }
+                }
+                if (!excluded)
+                    map.Add(i);
+            }
+            return map.Count < headers.Length ? map.ToArray() : null;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Projects headers through a column map.
+    /// </summary>
+    internal static string[] ProjectHeaders(string[] headers, int[] columnMap)
+    {
+        var result = new string[columnMap.Length];
+        for (int i = 0; i < columnMap.Length; i++)
+            result[i] = headers[columnMap[i]];
+        return result;
+    }
+
+    /// <summary>
+    /// Projects a row through a column map.
+    /// </summary>
+    internal static string[] ProjectRow(string[] row, int[] columnMap)
+    {
+        var result = new string[columnMap.Length];
+        for (int i = 0; i < columnMap.Length; i++)
+        {
+            int srcIndex = columnMap[i];
+            result[i] = srcIndex < row.Length ? row[srcIndex] : string.Empty;
+        }
+        return result;
+    }
+}

--- a/src/Markout/MarkoutSchemaInfo.cs
+++ b/src/Markout/MarkoutSchemaInfo.cs
@@ -88,7 +88,10 @@ public sealed class MarkoutSchemaInfo
         foreach (var prop in props)
         {
             if (prop.Rendering.StartsWith("Field", StringComparison.Ordinal))
-                names.Add(prop.DisplayName);
+            {
+                if (!names.Contains(prop.DisplayName))
+                    names.Add(prop.DisplayName);
+            }
             else if (prop.Rendering == "Fields")
                 CollectFieldNames(prop.Children, names);
         }

--- a/src/Markout/MarkoutSchemaInfo.cs
+++ b/src/Markout/MarkoutSchemaInfo.cs
@@ -50,6 +50,96 @@ public sealed class MarkoutSchemaInfo
         markout.Flush();
     }
     
+    /// <summary>
+    /// Returns the display names of all scalar fields in the document schema.
+    /// Matches properties with Rendering starting with "Field".
+    /// </summary>
+    public string[] GetFieldNames()
+    {
+        var names = new List<string>();
+        CollectFieldNames(AsDocument, names);
+        return names.ToArray();
+    }
+
+    /// <summary>
+    /// Returns the display names of all table columns across all tables in the document schema.
+    /// Collects column names from Children of table-type properties.
+    /// </summary>
+    public string[] GetColumnNames()
+    {
+        var names = new List<string>();
+        CollectColumnNames(AsDocument, names);
+        return names.ToArray();
+    }
+
+    /// <summary>
+    /// Returns the names of all sections in the document schema.
+    /// Extracts section names from Rendering strings like <c>H2 Section "Dependencies" (table)</c>.
+    /// </summary>
+    public string[] GetSectionNames()
+    {
+        var names = new List<string>();
+        CollectSectionNames(AsDocument, names);
+        return names.ToArray();
+    }
+
+    private static void CollectFieldNames(IReadOnlyList<MarkoutPropertySchema> props, List<string> names)
+    {
+        foreach (var prop in props)
+        {
+            if (prop.Rendering.StartsWith("Field", StringComparison.Ordinal))
+                names.Add(prop.DisplayName);
+            else if (prop.Rendering == "Fields")
+                CollectFieldNames(prop.Children, names);
+        }
+    }
+
+    private static void CollectColumnNames(IReadOnlyList<MarkoutPropertySchema> props, List<string> names)
+    {
+        foreach (var prop in props)
+        {
+            if (prop.Rendering.Contains("(table)") || prop.Rendering == "Table")
+            {
+                foreach (var child in prop.Children)
+                {
+                    if (child.Rendering.StartsWith("Column", StringComparison.Ordinal) &&
+                        !names.Contains(child.DisplayName))
+                        names.Add(child.DisplayName);
+                }
+            }
+            else if (prop.Children.Count > 0)
+            {
+                CollectColumnNames(prop.Children, names);
+            }
+        }
+    }
+
+    private static void CollectSectionNames(IReadOnlyList<MarkoutPropertySchema> props, List<string> names)
+    {
+        foreach (var prop in props)
+        {
+            var sectionName = ExtractSectionName(prop.Rendering);
+            if (sectionName != null)
+                names.Add(sectionName);
+        }
+    }
+
+    /// <summary>
+    /// Extracts the section name from a Rendering string like <c>H2 Section "Dependencies" (table)</c>.
+    /// Returns null if the string is not a section rendering.
+    /// </summary>
+    public static string? ExtractSectionName(string rendering)
+    {
+        // Parse: H2 Section "Dependencies" (table)
+        const string marker = "Section \"";
+        int start = rendering.IndexOf(marker, StringComparison.Ordinal);
+        if (start < 0) return null;
+        start += marker.Length;
+        int end = rendering.IndexOf('"', start);
+        if (end < 0) return null;
+        return rendering[start..end];
+    }
+
     private bool HasDifferences()
     {
         if (AsDocument.Count != AsTableItem.Count) return true;

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -32,6 +32,7 @@ public class MarkoutWriter
     private List<string[]>? _streamingRows;
     private int[]? _columnMap;
     private (int Level, string Text, string? Context)? _pendingSection;
+    private bool _projectionSectionActive;
 
     /// <summary>
     /// Creates a writer that builds output in memory with default options.
@@ -219,6 +220,11 @@ public class MarkoutWriter
         // Content before first H2 (no section name) is always included
         if (_currentSectionName == null)
             return true;
+
+        // Projection section includes override options-level excludes
+        if (_options.Projection?.IsSectionIncluded(_currentSectionName) == true)
+            return true;
+
         if (_options.IncludeSections != null && !_options.IncludeSections.Contains(_currentSectionName))
             return false;
         if (_options.ExcludeSections?.Contains(_currentSectionName) == true)
@@ -229,7 +235,7 @@ public class MarkoutWriter
     private MarkoutField[] ProjectFields(IReadOnlyList<MarkoutField> fields)
     {
         var projection = _options.Projection;
-        if (projection == null)
+        if (projection == null || _projectionSectionActive)
         {
             if (fields is MarkoutField[] array)
                 return array;
@@ -448,7 +454,7 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
-        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+        if (_options.Projection != null && !_projectionSectionActive && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -465,7 +471,7 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
-        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+        if (_options.Projection != null && !_projectionSectionActive && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -482,7 +488,7 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
-        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+        if (_options.Projection != null && !_projectionSectionActive && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -501,7 +507,7 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
-        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+        if (_options.Projection != null && !_projectionSectionActive && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -519,7 +525,7 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
-        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+        if (_options.Projection != null && !_projectionSectionActive && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -537,7 +543,7 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
-        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+        if (_options.Projection != null && !_projectionSectionActive && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -731,8 +737,8 @@ public class MarkoutWriter
         if (headers.Length == 0)
             throw new ArgumentException("At least one header is required.", nameof(headers));
 
-        // Apply column projection
-        _columnMap = _options.Projection?.ComputeColumnMap(headers);
+        // Apply column projection (skip when section is projection-selected)
+        _columnMap = _projectionSectionActive ? null : _options.Projection?.ComputeColumnMap(headers);
         _streamingHeaders = _columnMap != null
             ? MarkoutProjection.ProjectHeaders(headers, _columnMap)
             : headers;
@@ -1465,6 +1471,8 @@ public class MarkoutWriter
         {
             _currentSectionName = text;
             _sectionExcluded = !IsSectionIncluded();
+            _projectionSectionActive = !_sectionExcluded
+                && _options.Projection?.IsSectionIncluded(text) == true;
         }
     }
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -31,7 +31,7 @@ public class MarkoutWriter
     private string[]? _streamingHeaders;
     private List<string[]>? _streamingRows;
     private int[]? _columnMap;
-    private (int Level, string Text, string? Context)? _pendingSection;
+    private PendingSectionHeading? _pendingSection;
     private bool _projectionSectionActive;
 
     /// <summary>
@@ -370,7 +370,7 @@ public class MarkoutWriter
         // Defer heading until content is actually written, so empty sections are suppressed
         if (_options.Projection != null)
         {
-            _pendingSection = (level, text, context);
+            _pendingSection = new PendingSectionHeading(level, text, context);
             return;
         }
 
@@ -1451,10 +1451,10 @@ public class MarkoutWriter
 
     private void FlushPendingSection()
     {
-        if (_pendingSection is var (level, text, context))
+        if (_pendingSection is { } pending)
         {
             _pendingSection = null;
-            WriteSectionHeading(level, text, context);
+            WriteSectionHeading(pending.Level, pending.Text, pending.Context);
         }
     }
 
@@ -1476,3 +1476,5 @@ public class MarkoutWriter
         }
     }
 }
+
+internal readonly record struct PendingSectionHeading(int Level, string Text, string? Context);

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -31,6 +31,7 @@ public class MarkoutWriter
     private string[]? _streamingHeaders;
     private List<string[]>? _streamingRows;
     private int[]? _columnMap;
+    private (int Level, string Text, string? Context)? _pendingSection;
 
     /// <summary>
     /// Creates a writer that builds output in memory with default options.
@@ -355,6 +356,28 @@ public class MarkoutWriter
     /// <param name="context">Optional context to append in parentheses.</param>
     public virtual void WriteSectionStart(int level, string text, string? context = null)
     {
+        UpdateSectionState(level, text);
+
+        if (_sectionExcluded)
+            return;
+
+        // Defer heading until content is actually written, so empty sections are suppressed
+        if (_options.Projection != null)
+        {
+            _pendingSection = (level, text, context);
+            return;
+        }
+
+        WriteSectionHeading(level, text, context);
+    }
+
+    /// <summary>
+    /// Writes the section heading. Override to customize section heading rendering.
+    /// Called either immediately from <see cref="WriteSectionStart"/> or deferred
+    /// until first content when projection is active.
+    /// </summary>
+    protected virtual void WriteSectionHeading(int level, string text, string? context)
+    {
         WriteHeading(level, text, context);
     }
 
@@ -364,6 +387,7 @@ public class MarkoutWriter
     /// </summary>
     public virtual void WriteSectionEnd()
     {
+        _pendingSection = null;
     }
 
     /// <summary>
@@ -1410,10 +1434,21 @@ public class MarkoutWriter
     /// </summary>
     protected virtual void EnsureBlankLineIfNeeded()
     {
+        FlushPendingSection();
+
         if (_needsBlankLine)
         {
             _writer.WriteLine();
             _needsBlankLine = false;
+        }
+    }
+
+    private void FlushPendingSection()
+    {
+        if (_pendingSection is var (level, text, context))
+        {
+            _pendingSection = null;
+            WriteSectionHeading(level, text, context);
         }
     }
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -30,6 +30,7 @@ public class MarkoutWriter
     private MarkoutShape _warnedShapes;
     private string[]? _streamingHeaders;
     private List<string[]>? _streamingRows;
+    private int[]? _columnMap;
 
     /// <summary>
     /// Creates a writer that builds output in memory with default options.
@@ -224,6 +225,56 @@ public class MarkoutWriter
         return true;
     }
 
+    private MarkoutField[] ProjectFields(IReadOnlyList<MarkoutField> fields)
+    {
+        var projection = _options.Projection;
+        if (projection == null)
+        {
+            if (fields is MarkoutField[] array)
+                return array;
+            var result = new MarkoutField[fields.Count];
+            for (int i = 0; i < fields.Count; i++)
+                result[i] = fields[i];
+            return result;
+        }
+
+        if (projection.IncludeFields != null)
+        {
+            // Include: output fields in the order specified by IncludeFields
+            var result = new List<MarkoutField>(projection.IncludeFields.Count);
+            foreach (var name in projection.IncludeFields)
+            {
+                for (int i = 0; i < fields.Count; i++)
+                {
+                    if (string.Equals(name, fields[i].Key, projection.Comparison))
+                    {
+                        result.Add(fields[i]);
+                        break;
+                    }
+                }
+            }
+            return result.ToArray();
+        }
+
+        if (projection.ExcludeFields != null)
+        {
+            var result = new List<MarkoutField>(fields.Count);
+            for (int i = 0; i < fields.Count; i++)
+            {
+                if (projection.IsFieldIncluded(fields[i].Key))
+                    result.Add(fields[i]);
+            }
+            return result.ToArray();
+        }
+
+        if (fields is MarkoutField[] arr)
+            return arr;
+        var copy = new MarkoutField[fields.Count];
+        for (int i = 0; i < fields.Count; i++)
+            copy[i] = fields[i];
+        return copy;
+    }
+
     /// <summary>
     /// Writes a formatted value using ISpanFormattable.
     /// Available to subclasses for custom rendering.
@@ -373,6 +424,9 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
+        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+            return;
+
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         _writer.WriteLine(value ?? string.Empty);
@@ -387,6 +441,9 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
+        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+            return;
+
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         _writer.WriteLine(value ? "yes" : "no");
@@ -399,6 +456,9 @@ public class MarkoutWriter
     public virtual void WriteField<T>(string key, T value) where T : ISpanFormattable
     {
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
+            return;
+
+        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -417,6 +477,9 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
+        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+            return;
+
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         _writer.WriteLine(value ?? string.Empty);
@@ -432,6 +495,9 @@ public class MarkoutWriter
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
             return;
 
+        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
+            return;
+
         EnsureBlankLineIfNeeded();
         WriteFieldName(key);
         _writer.WriteLine(value ? "yes" : "no");
@@ -445,6 +511,9 @@ public class MarkoutWriter
     public virtual void WriteFieldNoBreak<T>(string key, T value) where T : ISpanFormattable
     {
         if (_sectionExcluded || ShapeUnsupported(MarkoutShape.Fields))
+            return;
+
+        if (_options.Projection != null && !_options.Projection.IsFieldIncluded(key))
             return;
 
         EnsureBlankLineIfNeeded();
@@ -496,15 +565,19 @@ public class MarkoutWriter
         if (_sectionExcluded || fields.Length == 0 || ShapeUnsupported(MarkoutShape.FieldList))
             return;
 
+        var projected = ProjectFields(fields);
+        if (projected.Length == 0)
+            return;
+
         EnsureBlankLineIfNeeded();
 
-        for (int i = 0; i < fields.Length; i++)
+        for (int i = 0; i < projected.Length; i++)
         {
             if (i > 0)
                 _writer.Write(" | ");
 
-            WriteFieldName(fields[i].Key);
-            _writer.Write(fields[i].Value ?? string.Empty);
+            WriteFieldName(projected[i].Key);
+            _writer.Write(projected[i].Value ?? string.Empty);
         }
 
         _writer.WriteLine();
@@ -522,15 +595,19 @@ public class MarkoutWriter
         if (_sectionExcluded || fields.Count == 0 || ShapeUnsupported(MarkoutShape.FieldList))
             return;
 
+        var projected = ProjectFields(fields);
+        if (projected.Length == 0)
+            return;
+
         EnsureBlankLineIfNeeded();
 
-        for (int i = 0; i < fields.Count; i++)
+        for (int i = 0; i < projected.Length; i++)
         {
             if (i > 0)
                 _writer.Write(" | ");
 
-            WriteFieldName(fields[i].Key);
-            _writer.Write(fields[i].Value ?? string.Empty);
+            WriteFieldName(projected[i].Key);
+            _writer.Write(projected[i].Value ?? string.Empty);
         }
 
         _writer.WriteLine();
@@ -618,6 +695,7 @@ public class MarkoutWriter
         _inTable = true;
         _tableRowCount = 0;
         _tableRowsSkipped = 0;
+        _columnMap = null;
 
         if (SectionExcluded || ShapeUnsupported(MarkoutShape.Tables))
             return;
@@ -625,7 +703,11 @@ public class MarkoutWriter
         if (headers.Length == 0)
             throw new ArgumentException("At least one header is required.", nameof(headers));
 
-        _streamingHeaders = headers;
+        // Apply column projection
+        _columnMap = _options.Projection?.ComputeColumnMap(headers);
+        _streamingHeaders = _columnMap != null
+            ? MarkoutProjection.ProjectHeaders(headers, _columnMap)
+            : headers;
         _streamingRows = [];
     }
 
@@ -643,7 +725,9 @@ public class MarkoutWriter
         if (!ShouldWriteTableRow())
             return;
 
-        _streamingRows?.Add(values);
+        _streamingRows?.Add(_columnMap != null
+            ? MarkoutProjection.ProjectRow(values, _columnMap)
+            : values);
     }
 
     /// <summary>
@@ -738,6 +822,17 @@ public class MarkoutWriter
 
         var headerArray = headers as string[] ?? headers.ToArray();
         var rowList = rows as IList<string[]> ?? rows.ToList();
+
+        // Apply column projection
+        var columnMap = _options.Projection?.ComputeColumnMap(headerArray);
+        if (columnMap != null)
+        {
+            headerArray = MarkoutProjection.ProjectHeaders(headerArray, columnMap);
+            var projected = new List<string[]>(rowList.Count);
+            foreach (var row in rowList)
+                projected.Add(MarkoutProjection.ProjectRow(row, columnMap));
+            rowList = projected;
+        }
 
         // Calculate column widths
         var widths = new int[headerArray.Length];

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -624,10 +624,14 @@ public class MarkoutWriter
         if (fields.Count == 0)
             return;
 
+        var projected = ProjectFields(fields);
+        if (projected.Length == 0)
+            return;
+
         WriteTableStart("Property", "Value");
-        for (int i = 0; i < fields.Count; i++)
+        for (int i = 0; i < projected.Length; i++)
         {
-            WriteTableRow(fields[i].Key, fields[i].Value ?? string.Empty);
+            WriteTableRow(projected[i].Key, projected[i].Value ?? string.Empty);
         }
         WriteTableEnd();
     }

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -13,6 +13,7 @@ public class MarkoutWriterOptions
     private int? _maxItems;
     private HashSet<string>? _includeSections;
     private HashSet<string>? _excludeSections;
+    private MarkoutProjection? _projection;
 
     /// <summary>
     /// Gets the default options instance. This instance is read-only.
@@ -118,6 +119,21 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _excludeSections = value;
+        }
+    }
+
+    /// <summary>
+    /// Projection for trimming output to specific columns and fields.
+    /// When set, the projection filters table columns and scalar fields at render time.
+    /// Works across all renderers.
+    /// </summary>
+    public MarkoutProjection? Projection
+    {
+        get => _projection;
+        set
+        {
+            ThrowIfReadOnly();
+            _projection = value;
         }
     }
 

--- a/tests/Markout.Tests/ProjectionTests.cs
+++ b/tests/Markout.Tests/ProjectionTests.cs
@@ -1,0 +1,524 @@
+using Markout;
+
+namespace Markout.Tests;
+
+public class ProjectionTests
+{
+    // --- Column projection: IncludeColumns ---
+
+    [Fact]
+    public void IncludeColumns_FiltersTableToSpecifiedColumns()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name", "TFM"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version", "TFM", "Signed");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0", "yes");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("Name", output);
+        Assert.Contains("TFM", output);
+        Assert.Contains("Foo.dll", output);
+        Assert.Contains("net8.0", output);
+        Assert.DoesNotContain("Version", output);
+        Assert.DoesNotContain("1.0.0", output);
+        Assert.DoesNotContain("Signed", output);
+        Assert.DoesNotContain("yes", output);
+    }
+
+    [Fact]
+    public void IncludeColumns_ReordersColumnsToMatchSpecifiedOrder()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["TFM", "Name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version", "TFM");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        // TFM should appear before Name
+        int tfmIndex = output.IndexOf("TFM");
+        int nameIndex = output.IndexOf("Name");
+        Assert.True(tfmIndex < nameIndex, "TFM should appear before Name in output");
+    }
+
+    [Fact]
+    public void IncludeColumns_CaseInsensitiveByDefault()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["name", "tfm"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version", "TFM");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("Name", output);
+        Assert.Contains("TFM", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    [Fact]
+    public void IncludeColumns_UnmatchedColumnsIgnored()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name", "NonExistent"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version");
+        writer.WriteTableRow("Foo.dll", "1.0.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("Name", output);
+        Assert.Contains("Foo.dll", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    // --- Column projection: ExcludeColumns ---
+
+    [Fact]
+    public void ExcludeColumns_RemovesSpecifiedColumns()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                ExcludeColumns = ["Version", "Signed"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version", "TFM", "Signed");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0", "yes");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("Name", output);
+        Assert.Contains("TFM", output);
+        Assert.DoesNotContain("Version", output);
+        Assert.DoesNotContain("Signed", output);
+    }
+
+    [Fact]
+    public void ExcludeColumns_PreservesOriginalOrder()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                ExcludeColumns = ["Version"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version", "TFM");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        int nameIndex = output.IndexOf("Name");
+        int tfmIndex = output.IndexOf("TFM");
+        Assert.True(nameIndex < tfmIndex, "Name should appear before TFM (original order)");
+    }
+
+    // --- Column projection with WriteTable (batch API) ---
+
+    [Fact]
+    public void IncludeColumns_WorksWithBatchWriteTable()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTable(
+            ["Name", "Version", "TFM"],
+            [["Foo.dll", "1.0.0", "net8.0"], ["Bar.dll", "2.0.0", "net9.0"]]);
+        var output = writer.ToString();
+        Assert.Contains("Name", output);
+        Assert.Contains("Foo.dll", output);
+        Assert.Contains("Bar.dll", output);
+        Assert.DoesNotContain("Version", output);
+        Assert.DoesNotContain("TFM", output);
+    }
+
+    // --- Column projection with MarkdownWriter ---
+
+    [Fact]
+    public void IncludeColumns_WorksWithMarkdownWriter()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name", "TFM"]
+            }
+        };
+        var writer = new MarkdownWriter(options);
+        writer.WriteTableStart("Name", "Version", "TFM");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("| Name", output);
+        Assert.Contains("TFM", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    // --- Column projection with OneLineWriter ---
+
+    [Fact]
+    public void IncludeColumns_WorksWithOneLineWriter()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name"]
+            }
+        };
+        var writer = new OneLineWriter(sw, options);
+        writer.WriteTableStart("Name", "Version", "TFM");
+        writer.WriteTableRow("Foo.dll", "1.0.0", "net8.0");
+        writer.WriteTableEnd();
+        var output = sw.ToString();
+        Assert.Contains("NAME", output);
+        Assert.Contains("Foo.dll", output);
+        Assert.DoesNotContain("VERSION", output);
+        Assert.DoesNotContain("TFM", output);
+    }
+
+    // --- Field projection: IncludeFields ---
+
+    [Fact]
+    public void IncludeFields_FiltersScalarFields()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["Name", "License"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteField("Name", "System.Text.Json");
+        writer.WriteField("Version", "9.0.0");
+        writer.WriteField("License", "MIT");
+        var output = writer.ToString();
+        Assert.Contains("Name: System.Text.Json", output);
+        Assert.Contains("License: MIT", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    [Fact]
+    public void IncludeFields_FiltersBooleanFields()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["Signed"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteField("Name", "Foo");
+        writer.WriteField("Signed", true);
+        var output = writer.ToString();
+        Assert.Contains("Signed: yes", output);
+        Assert.DoesNotContain("Name", output);
+    }
+
+    [Fact]
+    public void IncludeFields_FiltersGenericFields()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["Count"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteField("Name", "Foo");
+        writer.WriteField("Count", 42);
+        var output = writer.ToString();
+        Assert.Contains("Count: 42", output);
+        Assert.DoesNotContain("Name", output);
+    }
+
+    [Fact]
+    public void IncludeFields_CaseInsensitiveByDefault()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteField("Name", "Foo");
+        writer.WriteField("Version", "1.0.0");
+        var output = writer.ToString();
+        Assert.Contains("Name: Foo", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    // --- Field projection: ExcludeFields ---
+
+    [Fact]
+    public void ExcludeFields_RemovesSpecifiedFields()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                ExcludeFields = ["Version"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteField("Name", "Foo");
+        writer.WriteField("Version", "1.0.0");
+        writer.WriteField("License", "MIT");
+        var output = writer.ToString();
+        Assert.Contains("Name: Foo", output);
+        Assert.Contains("License: MIT", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    // --- Field projection: FieldList ---
+
+    [Fact]
+    public void IncludeFields_FiltersFieldList()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["Name", "TFM"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteFieldList(
+            new MarkoutField("Name", "Foo"),
+            new MarkoutField("Version", "1.0.0"),
+            new MarkoutField("TFM", "net8.0"));
+        var output = writer.ToString();
+        Assert.Contains("Name: Foo", output);
+        Assert.Contains("TFM: net8.0", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    [Fact]
+    public void IncludeFields_ReordersFieldList()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["TFM", "Name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteFieldList(
+            new MarkoutField("Name", "Foo"),
+            new MarkoutField("Version", "1.0.0"),
+            new MarkoutField("TFM", "net8.0"));
+        var output = writer.ToString();
+        int tfmIndex = output.IndexOf("TFM");
+        int nameIndex = output.IndexOf("Name");
+        Assert.True(tfmIndex < nameIndex, "TFM should appear before Name in field list");
+    }
+
+    [Fact]
+    public void ExcludeFields_FiltersFieldList()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                ExcludeFields = ["Version"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteFieldList(
+            new MarkoutField("Name", "Foo"),
+            new MarkoutField("Version", "1.0.0"),
+            new MarkoutField("TFM", "net8.0"));
+        var output = writer.ToString();
+        Assert.Contains("Name: Foo", output);
+        Assert.Contains("TFM: net8.0", output);
+        Assert.DoesNotContain("Version", output);
+    }
+
+    [Fact]
+    public void IncludeFields_AllFilteredProducesNoOutput()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["NonExistent"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteField("Name", "Foo");
+        writer.WriteFieldList(
+            new MarkoutField("Name", "Foo"),
+            new MarkoutField("Version", "1.0.0"));
+        var output = writer.ToString();
+        Assert.Equal("", output);
+    }
+
+    // --- WriteFieldNoBreak projection ---
+
+    [Fact]
+    public void IncludeFields_FiltersFieldNoBreak()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection
+            {
+                IncludeFields = ["Name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteFieldNoBreak("Name", "Foo");
+        writer.WriteFieldNoBreak("Version", "1.0.0");
+        writer.WriteFieldNoBreak("Signed", true);
+        writer.WriteFieldNoBreak("Count", 42);
+        var output = writer.ToString();
+        Assert.Contains("Name: Foo", output);
+        Assert.DoesNotContain("Version", output);
+        Assert.DoesNotContain("Signed", output);
+        Assert.DoesNotContain("Count", output);
+    }
+
+    // --- Projection composes with section filtering ---
+
+    [Fact]
+    public void Projection_ComposesWithSectionFiltering()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            IncludeSections = ["Details"],
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteHeading(1, "Report");
+        writer.WriteField("TopLevel", "value");
+        writer.WriteHeading(2, "Details");
+        writer.WriteTableStart("Name", "Version");
+        writer.WriteTableRow("Foo", "1.0.0");
+        writer.WriteTableEnd();
+        writer.WriteHeading(2, "Other");
+        writer.WriteTableStart("Name", "Version");
+        writer.WriteTableRow("Bar", "2.0.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        // Details section included, Other excluded
+        Assert.Contains("Foo", output);
+        Assert.DoesNotContain("Bar", output);
+        // Column projection applied within Details
+        Assert.DoesNotContain("1.0.0", output);
+    }
+
+    // --- Mutual exclusion validation ---
+
+    [Fact]
+    public void IncludeAndExcludeColumns_ThrowsWhenBothSet()
+    {
+        var projection = new MarkoutProjection
+        {
+            IncludeColumns = ["Name"]
+        };
+        Assert.Throws<InvalidOperationException>(() =>
+            projection.ExcludeColumns = ["Version"]);
+    }
+
+    [Fact]
+    public void IncludeAndExcludeFields_ThrowsWhenBothSet()
+    {
+        var projection = new MarkoutProjection
+        {
+            IncludeFields = ["Name"]
+        };
+        Assert.Throws<InvalidOperationException>(() =>
+            projection.ExcludeFields = ["Version"]);
+    }
+
+    // --- No projection = passthrough ---
+
+    [Fact]
+    public void NoProjection_TablePassesThrough()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteTableStart("Name", "Version");
+        writer.WriteTableRow("Foo", "1.0.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("Name", output);
+        Assert.Contains("Version", output);
+        Assert.Contains("Foo", output);
+        Assert.Contains("1.0.0", output);
+    }
+
+    [Fact]
+    public void NoProjection_FieldsPassThrough()
+    {
+        var writer = new MarkoutWriter();
+        writer.WriteField("Name", "Foo");
+        writer.WriteField("Version", "1.0.0");
+        var output = writer.ToString();
+        Assert.Contains("Name: Foo", output);
+        Assert.Contains("Version: 1.0.0", output);
+    }
+
+    // --- Column projection with MaxItems ---
+
+    [Fact]
+    public void IncludeColumns_ComposesWithMaxItems()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            MaxItems = 1,
+            Projection = new MarkoutProjection
+            {
+                IncludeColumns = ["Name"]
+            }
+        };
+        var writer = new MarkoutWriter(options);
+        writer.WriteTableStart("Name", "Version");
+        writer.WriteTableRow("Foo", "1.0.0");
+        writer.WriteTableRow("Bar", "2.0.0");
+        writer.WriteTableRow("Baz", "3.0.0");
+        writer.WriteTableEnd();
+        var output = writer.ToString();
+        Assert.Contains("Foo", output);
+        Assert.DoesNotContain("Bar", output);
+        Assert.Contains("... and 2 more", output);
+        Assert.DoesNotContain("Version", output);
+    }
+}

--- a/tests/Markout.Tests/ProjectionTests.cs
+++ b/tests/Markout.Tests/ProjectionTests.cs
@@ -521,4 +521,92 @@ public class ProjectionTests
         Assert.Contains("... and 2 more", output);
         Assert.DoesNotContain("Version", output);
     }
+
+    // --- Schema discovery ---
+
+    [Fact]
+    public void GetFieldNames_ReturnsDocumentLevelFields()
+    {
+        var schema = SectionTestContext.PackageWithSectionsSchema;
+        var fields = schema.GetFieldNames();
+        Assert.Equal(["Name", "Version"], fields);
+    }
+
+    [Fact]
+    public void GetColumnNames_ReturnsUniqueColumnsAcrossTables()
+    {
+        var schema = SectionTestContext.PackageWithSectionsSchema;
+        var columns = schema.GetColumnNames();
+        // Dependencies has Id, Version; Assemblies has Name, Arch
+        Assert.Equal(["Id", "Version", "Name", "Arch"], columns);
+    }
+
+    [Fact]
+    public void GetSectionNames_ReturnsSectionHeadingNames()
+    {
+        var schema = SectionTestContext.PackageWithSectionsSchema;
+        var sections = schema.GetSectionNames();
+        Assert.Equal(["Dependencies", "Assemblies"], sections);
+    }
+
+    [Fact]
+    public void ExtractSectionName_ParsesSectionRendering()
+    {
+        Assert.Equal("Dependencies", MarkoutSchemaInfo.ExtractSectionName("H2 Section \"Dependencies\" (table)"));
+        Assert.Equal("API Surface", MarkoutSchemaInfo.ExtractSectionName("H2 Section \"API Surface\" (subsections)"));
+        Assert.Null(MarkoutSchemaInfo.ExtractSectionName("Field"));
+        Assert.Null(MarkoutSchemaInfo.ExtractSectionName("Table"));
+    }
+
+    [Fact]
+    public void GetFieldNames_EmptyForTableOnlySchema()
+    {
+        // A type with no scalar fields should return empty
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "NoFields",
+            AsDocument = [
+                new() { Name = "Items", DisplayName = "Items", Rendering = "H2 Section \"Items\" (table)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                ] },
+            ],
+        };
+        Assert.Empty(schema.GetFieldNames());
+    }
+
+    [Fact]
+    public void GetColumnNames_EmptyForFieldOnlySchema()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "FieldsOnly",
+            AsDocument = [
+                new() { Name = "Name", DisplayName = "Name", Rendering = "Field" },
+                new() { Name = "Version", DisplayName = "Version", Rendering = "Field" },
+            ],
+        };
+        Assert.Empty(schema.GetColumnNames());
+    }
+
+    [Fact]
+    public void GetColumnNames_DeduplicatesAcrossTables()
+    {
+        // Two tables both have a "Name" column — should appear once
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "DupCols",
+            AsDocument = [
+                new() { Name = "Deps", DisplayName = "Deps", Rendering = "H2 Section \"Deps\" (table)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                    new() { Name = "Version", DisplayName = "Version", Rendering = "Column" },
+                ] },
+                new() { Name = "Refs", DisplayName = "Refs", Rendering = "H2 Section \"Refs\" (table)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                    new() { Name = "Target", DisplayName = "Target", Rendering = "Column" },
+                ] },
+            ],
+        };
+        var columns = schema.GetColumnNames();
+        Assert.Equal(["Name", "Version", "Target"], columns);
+    }
 }


### PR DESCRIPTION
## Summary

Adds the `MarkoutProjection` system for runtime output projection (field/column/section filtering), schema discovery, and supporting infrastructure.

## Changes

- **`MarkoutProjection`** — Include/exclude for columns, fields, and sections with case-insensitive matching
- **`MarkoutSchemaInfo`** — `GetFieldNames()`, `GetColumnNames()`, `GetSectionNames()` for discovery
- **`MarkoutWriter`** — Projection wired into all `WriteField`, `WriteFieldList`, `WriteFieldTable`, and `WriteTableStart` paths
- **Deferred section headings** — `WriteSectionStart` defers heading until content is written; empty sections suppressed
- **Section-aware projection** — `IncludeSections` on projection overrides options-level section excludes; content within projection-matched sections renders unfiltered
- **Version bump** to 0.7.2

## Testing

- 408 Markout tests pass
- 59 template tests pass
- 32 new projection tests