### PR TITLE
Release Markout 0.7.3 — [MarkoutUnwrap] and empty section names

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -82,50 +82,59 @@ internal static class CollectionEmitter
         var indent = new string(' ', indentLevel * 4);
         var subsectionLevel = parentSectionLevel + 1;
         var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
+        bool skipPerItemHeading = prop.IsUnwrapped && string.IsNullOrEmpty(prop.ElementTitleProperty);
 
         sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
         sb.AppendLine($"{indent}{{");
 
-        // Write subsection heading using TitleProperty or first string property
-        if (!string.IsNullOrEmpty(prop.ElementTitleProperty))
+        if (skipPerItemHeading)
         {
-            if (!string.IsNullOrEmpty(prop.ElementTitleContextProperty))
-            {
-                sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
-                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty}, {itemVar}.{prop.ElementTitleContextProperty});");
-            }
-            else
-            {
-                sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
-                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty});");
-            }
+            // Unwrapped with no title: emit each item's properties inline at the current level
+            SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel, nestingDepth + 1, prop.ElementAutoFields, prop.ElementFieldLayout);
         }
         else
         {
-            // Try to find a suitable property for the heading
-            var titleProp = prop.ElementProperties.FirstOrDefault(p => 
-                !p.IsIgnored && p.Kind == PropertyKind.String && 
-                (p.Name == "Name" || p.Name == "Title" || p.Name == "Id"));
-            
-            if (titleProp != null)
+            // Write subsection heading using TitleProperty or first string property
+            if (!string.IsNullOrEmpty(prop.ElementTitleProperty))
             {
-                sb.AppendLine($"{indent}    if ({itemVar}.{titleProp.Name} != null)");
-                sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{titleProp.Name});");
+                if (!string.IsNullOrEmpty(prop.ElementTitleContextProperty))
+                {
+                    sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
+                    sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty}, {itemVar}.{prop.ElementTitleContextProperty});");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}    if ({itemVar}.{prop.ElementTitleProperty} != null)");
+                    sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{prop.ElementTitleProperty});");
+                }
             }
             else
             {
-                // Fallback: use first string property
-                var firstString = prop.ElementProperties.FirstOrDefault(p => !p.IsIgnored && p.Kind == PropertyKind.String);
-                if (firstString != null)
+                // Try to find a suitable property for the heading
+                var titleProp = prop.ElementProperties.FirstOrDefault(p => 
+                    !p.IsIgnored && p.Kind == PropertyKind.String && 
+                    (p.Name == "Name" || p.Name == "Title" || p.Name == "Id"));
+                
+                if (titleProp != null)
                 {
-                    sb.AppendLine($"{indent}    if ({itemVar}.{firstString.Name} != null)");
-                    sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{firstString.Name});");
+                    sb.AppendLine($"{indent}    if ({itemVar}.{titleProp.Name} != null)");
+                    sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{titleProp.Name});");
+                }
+                else
+                {
+                    // Fallback: use first string property
+                    var firstString = prop.ElementProperties.FirstOrDefault(p => !p.IsIgnored && p.Kind == PropertyKind.String);
+                    if (firstString != null)
+                    {
+                        sb.AppendLine($"{indent}    if ({itemVar}.{firstString.Name} != null)");
+                        sb.AppendLine($"{indent}        writer.WriteHeading({subsectionLevel}, {itemVar}.{firstString.Name});");
+                    }
                 }
             }
-        }
 
-        // Emit property serializations for each item, at a deeper level
-        SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1, prop.ElementAutoFields, prop.ElementFieldLayout);
+            // Emit property serializations for each item, at a deeper level
+            SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1, prop.ElementAutoFields, prop.ElementFieldLayout);
+        }
 
         sb.AppendLine($"{indent}}}");
     }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -493,39 +493,49 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
 
-            if (prop.SectionGroupByProperty != null)
+            if (prop.IsUnwrapped)
             {
-                // Grouped rendering: partition by property, subheading per group
-                CollectionEmitter.EmitGroupedSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel);
-            }
-            else if (prop.MaxItems != null)
-            {
-                var innerIndent = indent + "    ";
-                var (truncVar, _) = EmitHelpers.EmitMaxItemsTruncation(sb, prop, propAccess, innerIndent, nestingDepth);
-                if (prop.ElementHasNestedContent)
-                {
-                    CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, truncVar, indentLevel + 1, effectiveSectionLevel, nestingDepth);
-                }
-                else
-                {
-                    CollectionEmitter.EmitTableSerialization(sb, prop, truncVar, indentLevel + 1, nestingDepth);
-                }
-                EmitHelpers.EmitMaxItemsEllipsis(sb, prop, propAccess, innerIndent, nestingDepth);
+                // Unwrapped: iterate items at the section level without a section heading
+                CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel - 1, nestingDepth);
             }
             else
             {
-                if (prop.ElementHasNestedContent)
+                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+
+                if (prop.SectionGroupByProperty != null)
                 {
-                    CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+                    // Grouped rendering: partition by property, subheading per group
+                    CollectionEmitter.EmitGroupedSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel);
+                }
+                else if (prop.MaxItems != null)
+                {
+                    var innerIndent = indent + "    ";
+                    var (truncVar, _) = EmitHelpers.EmitMaxItemsTruncation(sb, prop, propAccess, innerIndent, nestingDepth);
+                    if (prop.ElementHasNestedContent)
+                    {
+                        CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, truncVar, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+                    }
+                    else
+                    {
+                        CollectionEmitter.EmitTableSerialization(sb, prop, truncVar, indentLevel + 1, nestingDepth);
+                    }
+                    EmitHelpers.EmitMaxItemsEllipsis(sb, prop, propAccess, innerIndent, nestingDepth);
                 }
                 else
                 {
-                    CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                    if (prop.ElementHasNestedContent)
+                    {
+                        CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, nestingDepth);
+                    }
+                    else
+                    {
+                        CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                    }
                 }
+                sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             }
-            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+
             sb.AppendLine($"{indent}}}");
         }
         else if (prop.Kind == PropertyKind.StringArray)
@@ -691,14 +701,22 @@ internal static class SerializerEmitter
                 {
                     sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
                     sb.AppendLine($"{indent}{{");
-                    sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EmitHelpers.EscapeString(prop.DisplayName)}\");");
-                    if (prop.ElementHasNestedContent)
+                    if (prop.IsUnwrapped)
                     {
-                        CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, baseHeadingLevel, nestingDepth);
+                        // Unwrapped: iterate items at current heading level without a parent heading
+                        CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, baseHeadingLevel - 1, nestingDepth);
                     }
                     else
                     {
-                        CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                        sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EmitHelpers.EscapeString(prop.DisplayName)}\");");
+                        if (prop.ElementHasNestedContent)
+                        {
+                            CollectionEmitter.EmitSubsectionPerItemSerialization(sb, prop, propAccess, indentLevel + 1, baseHeadingLevel, nestingDepth);
+                        }
+                        else
+                        {
+                            CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                        }
                     }
                     sb.AppendLine($"{indent}}}");
                 }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -149,6 +149,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public bool IsLink { get; }
     public string? LinkTextProperty { get; }
     public IReadOnlyList<(string Key, string Value)>? ValueMap { get; }
+    public bool IsUnwrapped { get; }
 
     public PropertyMetadata(
         string name,
@@ -190,7 +191,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? showWhenProperty = null,
         bool isLink = false,
         string? linkTextProperty = null,
-        IReadOnlyList<(string Key, string Value)>? valueMap = null)
+        IReadOnlyList<(string Key, string Value)>? valueMap = null,
+        bool isUnwrapped = false)
     {
         Name = name;
         DisplayName = displayName;
@@ -232,6 +234,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         IsLink = isLink;
         LinkTextProperty = linkTextProperty;
         ValueMap = valueMap;
+        IsUnwrapped = isUnwrapped;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -277,6 +280,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                IsLink == other.IsLink &&
                LinkTextProperty == other.LinkTextProperty &&
                ValueMapEqual(ValueMap, other.ValueMap) &&
+               IsUnwrapped == other.IsUnwrapped &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -307,6 +311,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ IsLink.GetHashCode();
             hash = hash * 397 ^ (LinkTextProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (ValueMap?.Count ?? 0);
+            hash = hash * 397 ^ IsUnwrapped.GetHashCode();
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -648,7 +648,8 @@ internal static class TypeParser
     {
         if (props == null) return false;
         return props.Any(p => !p.IsIgnored &&
-            (p.Kind == PropertyKind.NestedObject || p.Kind == PropertyKind.ComplexArray ||
+            (p.IsSection || p.Kind == PropertyKind.Callout ||
+             p.Kind == PropertyKind.NestedObject || p.Kind == PropertyKind.ComplexArray ||
              p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree ||
              p.Kind == PropertyKind.Description || p.Kind == PropertyKind.Metric ||
              p.Kind == PropertyKind.CodeSection || p.Kind == PropertyKind.Breakdown ||

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -29,6 +29,7 @@ internal static class TypeParser
     private const string MarkoutShowWhenAttribute = "Markout.MarkoutShowWhenAttribute";
     private const string MarkoutLinkAttribute = "Markout.MarkoutLinkAttribute";
     private const string MarkoutValueMapAttribute = "Markout.MarkoutValueMapAttribute";
+    private const string MarkoutUnwrapAttribute = "Markout.MarkoutUnwrapAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -199,6 +200,7 @@ internal static class TypeParser
         var isIgnored = HasAttribute(prop, MarkoutIgnoreAttribute);
         var isIgnoredInTable = HasAttribute(prop, MarkoutIgnoreInTableAttribute);
         var isSection = HasAttribute(prop, MarkoutSectionAttribute);
+        var isUnwrapped = HasAttribute(prop, MarkoutUnwrapAttribute);
         var sectionLevel = 2;
         string? sectionName = null;
         string? sectionIgnoreProperty = null;
@@ -394,7 +396,7 @@ internal static class TypeParser
         // Determine if property is unsupported in table context
         // Joined string arrays are treated as scalars, so they're fine in tables
         bool isJoinedArray = kind == PropertyKind.StringArray && joinSeparator != null;
-        bool isUnsupportedInTable = !isIgnored && !isSection && !IsScalarKind(kind) && !isJoinedArray && kind != PropertyKind.Formattable;
+        bool isUnsupportedInTable = !isIgnored && !isSection && !isUnwrapped && !IsScalarKind(kind) && !isJoinedArray && kind != PropertyKind.Formattable;
 
         // Emit warning for unsupported properties without [MarkoutIgnoreInTable]
         if (isUnsupportedInTable && !isIgnoredInTable)
@@ -448,7 +450,8 @@ internal static class TypeParser
             showWhenProperty,
             isLink,
             linkTextProperty,
-            valueMap);
+            valueMap,
+            isUnwrapped);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutUnwrapAttribute.cs
+++ b/src/Markout/Attributes/MarkoutUnwrapAttribute.cs
@@ -1,0 +1,36 @@
+namespace Markout;
+
+/// <summary>
+/// Renders a collection property's items inline at the current heading level,
+/// without emitting a parent section heading.
+/// <para>
+/// Use this when the collection represents an object model layer that should be
+/// transparent in the rendered document. Each item is rendered as a subsection
+/// using its <see cref="MarkoutSerializableAttribute.TitleProperty"/> as the heading.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// [MarkoutSerializable(TitleProperty = nameof(Title))]
+/// public class Report
+/// {
+///     public string Title { get; set; }
+///
+///     [MarkoutUnwrap]
+///     public List&lt;Chapter&gt; Chapters { get; set; }
+/// }
+/// </code>
+/// Without [MarkoutUnwrap], "Chapters" would render as:
+/// <code>
+/// ## Chapters
+/// ### Chapter One
+/// </code>
+/// With [MarkoutUnwrap], the wrapper heading is omitted:
+/// <code>
+/// ## Chapter One
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutUnwrapAttribute : Attribute
+{
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -384,6 +384,9 @@ public class MarkoutWriter
     /// </summary>
     protected virtual void WriteSectionHeading(int level, string text, string? context)
     {
+        if (string.IsNullOrEmpty(text))
+            return;
+
         WriteHeading(level, text, context);
     }
 

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -1240,6 +1240,43 @@ public partial class NestedCalloutTestContext : MarkoutSerializerContext
 {
 }
 
+// MarkoutUnwrap: collection items rendered inline without parent heading
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class UnwrapReport
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public string Generated { get; set; } = "";
+
+    [MarkoutUnwrap]
+    public List<UnwrapFamily>? Families { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class UnwrapFamily
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutUnwrap]
+    public List<UnwrapDistro>? Distros { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class UnwrapDistro
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+    [MarkoutIgnoreInTable]
+    public Callout Alert { get; set; }
+
+    [MarkoutSection(Name = "Issues")]
+    public List<IssueRow>? Issues { get; set; }
+}
+
+[MarkoutContext(typeof(UnwrapReport))]
+public partial class UnwrapTestContext : MarkoutSerializerContext
+{
+}
+
 #endregion
 
 public class CodeSectionTests
@@ -1741,5 +1778,88 @@ public class NestedCalloutSectionTests
         Assert.DoesNotContain("## Families", md);
         Assert.Contains("# Clean", md);
         Assert.Contains("Generated: 2026-02-22", md);
+    }
+}
+
+public class UnwrapTests
+{
+    [Fact]
+    public void Serialize_Unwrap_RendersItemsWithoutParentHeading()
+    {
+        var report = new UnwrapReport
+        {
+            Title = "Verification",
+            Generated = "2026-02-22",
+            Families =
+            [
+                new()
+                {
+                    Name = "Linux",
+                    Distros =
+                    [
+                        new()
+                        {
+                            Name = "Ubuntu",
+                            Alert = new(CalloutSeverity.Warning, "EOL but still supported"),
+                            Issues = [new("22.04", "2027-04-01")]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var md = MarkoutSerializer.Serialize(report, UnwrapTestContext.Default);
+
+        // No intermediate "Families" or "Distros" headings
+        Assert.DoesNotContain("Families", md);
+        Assert.DoesNotContain("Distros", md);
+
+        // Heading hierarchy: H1 title, H2 family, H3 distro
+        Assert.Contains("# Verification", md);
+        Assert.Contains("## Linux", md);
+        Assert.Contains("### Ubuntu", md);
+
+        // Callout and table render inside distro
+        Assert.Contains("> [!WARNING]", md);
+        Assert.Contains("| Version | EOL Date |", md);
+        Assert.Contains("| 22.04 | 2027-04-01 |", md);
+    }
+
+    [Fact]
+    public void Serialize_Unwrap_MultipleItemsAtSameLevel()
+    {
+        var report = new UnwrapReport
+        {
+            Title = "Report",
+            Generated = "2026-02-22",
+            Families =
+            [
+                new() { Name = "Linux", Distros = [] },
+                new() { Name = "macOS", Distros = [] }
+            ]
+        };
+
+        var md = MarkoutSerializer.Serialize(report, UnwrapTestContext.Default);
+
+        // Both families at H2, no wrapper heading
+        Assert.Contains("## Linux", md);
+        Assert.Contains("## macOS", md);
+        Assert.DoesNotContain("Families", md);
+    }
+
+    [Fact]
+    public void Serialize_Unwrap_EmptyList_SkipsContent()
+    {
+        var report = new UnwrapReport
+        {
+            Title = "Clean",
+            Generated = "2026-02-22",
+            Families = []
+        };
+
+        var md = MarkoutSerializer.Serialize(report, UnwrapTestContext.Default);
+
+        Assert.Contains("# Clean", md);
+        Assert.DoesNotContain("##", md);
     }
 }

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -1198,6 +1198,48 @@ public partial class GroupByTestContext : MarkoutSerializerContext
 {
 }
 
+// Nested callout + section table: collection elements with Callout property and [MarkoutSection] table
+// This tests that HasNestedContent recognizes Callout/Section and triggers subsection-per-item rendering
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class VerificationReport
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public string Generated { get; set; } = "";
+
+    [MarkoutSection(Name = "Families")]
+    public List<FamilyReport>? Families { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class FamilyReport
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+
+    [MarkoutSection(Name = "Distros")]
+    public List<DistroReport>? Distros { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class DistroReport
+{
+    [MarkoutIgnore] public string Name { get; set; } = "";
+    [MarkoutIgnoreInTable]
+    public Callout Alert { get; set; }
+
+    [MarkoutSection(Name = "Issues")]
+    public List<IssueRow>? Issues { get; set; }
+}
+
+[MarkoutSerializable]
+public record IssueRow(string Version, [property: MarkoutPropertyName("EOL Date")] string EolDate);
+
+[MarkoutContext(typeof(VerificationReport))]
+[MarkoutContext(typeof(IssueRow))]
+public partial class NestedCalloutTestContext : MarkoutSerializerContext
+{
+}
+
 #endregion
 
 public class CodeSectionTests
@@ -1632,5 +1674,72 @@ public class GroupByTests
 
         Assert.DoesNotContain("Breaking Changes", mdf);
         Assert.DoesNotContain("Additive Changes", mdf);
+    }
+}
+
+public class NestedCalloutSectionTests
+{
+    [Fact]
+    public void Serialize_CalloutPlusSection_RendersSubsectionsWithCalloutAndTable()
+    {
+        var report = new VerificationReport
+        {
+            Title = "Verification",
+            Generated = "2026-02-22",
+            Families =
+            [
+                new()
+                {
+                    Name = "Linux",
+                    Distros =
+                    [
+                        new()
+                        {
+                            Name = "Ubuntu",
+                            Alert = new(CalloutSeverity.Warning, "EOL but still supported"),
+                            Issues = [new("22.04", "2027-04-01")]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedCalloutTestContext.Default);
+
+        // Heading hierarchy: families → distros as subsections
+        Assert.Contains("## Families", md);
+        Assert.Contains("### Linux", md);
+        Assert.Contains("#### Distros", md);
+        Assert.Contains("##### Ubuntu", md);
+
+        // Callout renders inside the distro subsection
+        Assert.Contains("> [!WARNING]", md);
+        Assert.Contains("> EOL but still supported", md);
+
+        // Table renders inside the distro subsection
+        Assert.Contains("| Version | EOL Date |", md);
+        Assert.Contains("| 22.04 | 2027-04-01 |", md);
+
+        // Callout should appear before the table
+        int calloutPos = md.IndexOf("> [!WARNING]");
+        int tablePos = md.IndexOf("| Version |");
+        Assert.True(calloutPos < tablePos, "Callout should appear before the table");
+    }
+
+    [Fact]
+    public void Serialize_EmptyIssues_SkipsSection()
+    {
+        var report = new VerificationReport
+        {
+            Title = "Clean",
+            Generated = "2026-02-22",
+            Families = []
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedCalloutTestContext.Default);
+
+        Assert.DoesNotContain("## Families", md);
+        Assert.Contains("# Clean", md);
+        Assert.Contains("Generated: 2026-02-22", md);
     }
 }


### PR DESCRIPTION
## Changes

### `[MarkoutUnwrap]` attribute
Marks a collection property so the serializer iterates items as subsections without emitting a parent section heading. This saves heading levels when the object model has structural layers (e.g., families → distros → issue buckets) that shouldn't produce headings in the output.

### Empty section name support
`WriteSectionHeading` now skips the heading when the section name is empty, allowing table sections to render inline without a heading via `[MarkoutSection(Name = "")]`.

### `HasNestedContent` fix
`HasNestedContent` now detects `IsSection` properties and `PropertyKind.Callout`, enabling correct subsection-per-item rendering for types that contain sections or callouts.

### Motivation
Real-world usage in [dotnet-release](https://github.com/richlander/dotnet-release) verification reports required 3-level nesting (family → distro → callout + table). Without `[MarkoutUnwrap]`, this required `IMarkoutFormattable` workarounds with `[MarkoutPropertyName("")]` to shunt rendering into imperative code. With these changes, the entire hierarchy is declarative.

**All 708 tests pass** (413 Markout + 236 MarkdownTable + 59 Templates).