### PR TITLE
Release Markout 0.8.0 — [MarkoutIgnoreColumnWhen] conditional column visibility

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -15,10 +15,18 @@ internal static class CollectionEmitter
         PropertyMetadata prop,
         string propAccess,
         int indentLevel,
-        int nestingDepth = 0)
+        int nestingDepth = 0,
+        IReadOnlyList<(string ConditionVar, string ColumnName)>? dynamicIgnoreColumns = null)
     {
         if (prop.ElementProperties == null || prop.ElementProperties.Count == 0)
             return;
+
+        // When dynamic ignore columns are present, use List-based dynamic rendering
+        if (dynamicIgnoreColumns != null && dynamicIgnoreColumns.Count > 0)
+        {
+            EmitDynamicTableSerialization(sb, prop, propAccess, indentLevel, nestingDepth, dynamicIgnoreColumns);
+            return;
+        }
 
         var indent = new string(' ', indentLevel * 4);
         var ignoreNames = prop.SectionIgnoreProperty != null
@@ -64,6 +72,76 @@ internal static class CollectionEmitter
         }
 
         sb.AppendLine($"{indent}    writer.WriteTableRow({string.Join(", ", values)});");
+        sb.AppendLine($"{indent}}}");
+        sb.AppendLine($"{indent}writer.WriteTableEnd();");
+    }
+
+    /// <summary>
+    /// Emits table rendering with dynamically ignored columns based on runtime conditions.
+    /// Uses List-based header/row building with conditional adds.
+    /// </summary>
+    private static void EmitDynamicTableSerialization(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        int indentLevel,
+        int nestingDepth,
+        IReadOnlyList<(string ConditionVar, string ColumnName)> dynamicIgnoreColumns)
+    {
+        var indent = new string(' ', indentLevel * 4);
+        var ignoreNames = prop.SectionIgnoreProperty != null
+            ? new HashSet<string>(prop.SectionIgnoreProperty.Split(',').Select(s => s.Trim()))
+            : new HashSet<string>();
+        var visibleProps = prop.ElementProperties!
+            .Where(p => !p.IsIgnored && !ignoreNames.Contains(p.Name))
+            .ToList();
+        var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
+        var dynamicLookup = dynamicIgnoreColumns.ToDictionary(d => d.ColumnName, d => d.ConditionVar);
+
+        // Build headers dynamically
+        sb.AppendLine($"{indent}var __headers = new global::System.Collections.Generic.List<string>();");
+        foreach (var p in visibleProps)
+        {
+            var headerStr = p.Name == prop.SectionFormatProperty && prop.SectionColumnName != null
+                ? $"\"{EmitHelpers.EscapeString(prop.SectionColumnName)}\""
+                : $"\"{EmitHelpers.EscapeString(p.DisplayName)}\"";
+
+            if (dynamicLookup.TryGetValue(p.Name, out var condVar))
+                sb.AppendLine($"{indent}if (!{condVar}) __headers.Add({headerStr});");
+            else
+                sb.AppendLine($"{indent}__headers.Add({headerStr});");
+        }
+        sb.AppendLine($"{indent}writer.WriteTableStart(__headers.ToArray());");
+
+        // Instantiate formatter if configured
+        if (prop.SectionFormatterTypeName != null)
+            sb.AppendLine($"{indent}var __fmt = new {prop.SectionFormatterTypeName}();");
+
+        // Build rows dynamically
+        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
+        sb.AppendLine($"{indent}{{");
+        sb.AppendLine($"{indent}    var __row = new global::System.Collections.Generic.List<string>();");
+
+        foreach (var elemProp in visibleProps)
+        {
+            string value;
+            if (elemProp.Name == prop.SectionFormatProperty && prop.SectionFormatterTypeName != null)
+            {
+                var access = $"{itemVar}.{elemProp.Name}";
+                value = $"{access} != null ? __fmt.Format({access}) : \"\"";
+            }
+            else
+            {
+                value = EmitHelpers.GetTableCellValue(elemProp, itemVar);
+            }
+
+            if (dynamicLookup.TryGetValue(elemProp.Name, out var condVar))
+                sb.AppendLine($"{indent}    if (!{condVar}) __row.Add({value});");
+            else
+                sb.AppendLine($"{indent}    __row.Add({value});");
+        }
+
+        sb.AppendLine($"{indent}    writer.WriteTableRow(__row.ToArray());");
         sb.AppendLine($"{indent}}}");
         sb.AppendLine($"{indent}writer.WriteTableEnd();");
     }
@@ -148,7 +226,8 @@ internal static class CollectionEmitter
         PropertyMetadata prop,
         string propAccess,
         int indentLevel,
-        int parentSectionLevel = 2)
+        int parentSectionLevel = 2,
+        IReadOnlyList<(string ConditionVar, string ColumnName)>? dynamicIgnoreColumns = null)
     {
         if (prop.ElementProperties == null || prop.ElementProperties.Count == 0)
             return;
@@ -181,18 +260,51 @@ internal static class CollectionEmitter
         }
         else if (visibleProps.Count > 0)
         {
-            // Multiple properties → table per group
-            var headers = string.Join(", ", visibleProps.Select(p =>
-                $"\"{EmitHelpers.EscapeString(p.DisplayName)}\""));
-            sb.AppendLine($"{indent}    writer.WriteTableStart({headers});");
-            sb.AppendLine($"{indent}    foreach (var __item in __grp)");
-            sb.AppendLine($"{indent}    {{");
+            if (dynamicIgnoreColumns != null && dynamicIgnoreColumns.Count > 0)
+            {
+                // Dynamic column visibility within grouped tables
+                var dynamicLookup = dynamicIgnoreColumns.ToDictionary(d => d.ColumnName, d => d.ConditionVar);
 
-            var values = visibleProps.Select(p => EmitHelpers.GetTableCellValue(p, "__item")).ToList();
-            sb.AppendLine($"{indent}        writer.WriteTableRow({string.Join(", ", values)});");
+                sb.AppendLine($"{indent}    var __grpHeaders = new global::System.Collections.Generic.List<string>();");
+                foreach (var p in visibleProps)
+                {
+                    var headerStr = $"\"{EmitHelpers.EscapeString(p.DisplayName)}\"";
+                    if (dynamicLookup.TryGetValue(p.Name, out var condVar))
+                        sb.AppendLine($"{indent}    if (!{condVar}) __grpHeaders.Add({headerStr});");
+                    else
+                        sb.AppendLine($"{indent}    __grpHeaders.Add({headerStr});");
+                }
+                sb.AppendLine($"{indent}    writer.WriteTableStart(__grpHeaders.ToArray());");
+                sb.AppendLine($"{indent}    foreach (var __item in __grp)");
+                sb.AppendLine($"{indent}    {{");
+                sb.AppendLine($"{indent}        var __grpRow = new global::System.Collections.Generic.List<string>();");
+                foreach (var p in visibleProps)
+                {
+                    var value = EmitHelpers.GetTableCellValue(p, "__item");
+                    if (dynamicLookup.TryGetValue(p.Name, out var condVar))
+                        sb.AppendLine($"{indent}        if (!{condVar}) __grpRow.Add({value});");
+                    else
+                        sb.AppendLine($"{indent}        __grpRow.Add({value});");
+                }
+                sb.AppendLine($"{indent}        writer.WriteTableRow(__grpRow.ToArray());");
+                sb.AppendLine($"{indent}    }}");
+                sb.AppendLine($"{indent}    writer.WriteTableEnd();");
+            }
+            else
+            {
+                // Multiple properties → table per group
+                var headers = string.Join(", ", visibleProps.Select(p =>
+                    $"\"{EmitHelpers.EscapeString(p.DisplayName)}\""));
+                sb.AppendLine($"{indent}    writer.WriteTableStart({headers});");
+                sb.AppendLine($"{indent}    foreach (var __item in __grp)");
+                sb.AppendLine($"{indent}    {{");
 
-            sb.AppendLine($"{indent}    }}");
-            sb.AppendLine($"{indent}    writer.WriteTableEnd();");
+                var values = visibleProps.Select(p => EmitHelpers.GetTableCellValue(p, "__item")).ToList();
+                sb.AppendLine($"{indent}        writer.WriteTableRow({string.Join(", ", values)});");
+
+                sb.AppendLine($"{indent}    }}");
+                sb.AppendLine($"{indent}    writer.WriteTableEnd();");
+            }
         }
 
         sb.AppendLine($"{indent}}}");

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -453,13 +453,13 @@ internal static class SerializerEmitter
             sb.AppendLine($"{showWhenIndent}if (!{skipVar})");
             sb.AppendLine($"{showWhenIndent}{{");
 
-            EmitSectionBody(sb, prop, propAccess, showWhenIndent + "    ", showWhenIndentLevel + 1, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+            EmitSectionBody(sb, prop, propAccess, showWhenIndent + "    ", showWhenIndentLevel + 1, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName, rootTypeName);
 
             sb.AppendLine($"{showWhenIndent}}}");
         }
         else
         {
-            EmitSectionBody(sb, prop, propAccess, showWhenIndent, showWhenIndentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName);
+            EmitSectionBody(sb, prop, propAccess, showWhenIndent, showWhenIndentLevel, effectiveSectionLevel, nestingDepth, fieldLayout, sectionName, rootTypeName);
         }
 
         if (prop.SectionShowWhenProperty != null && rootValueExpr != null)
@@ -477,7 +477,8 @@ internal static class SerializerEmitter
         int effectiveSectionLevel,
         int nestingDepth,
         FieldLayoutKind fieldLayout,
-        string sectionName)
+        string sectionName,
+        string? rootTypeName = null)
     {
 
         if (prop.Kind == PropertyKind.FieldCollection)
@@ -494,6 +495,9 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
             sb.AppendLine($"{indent}{{");
 
+            // Emit dynamic ignore column conditions
+            var dynamicIgnores = EmitIgnoreColumnWhenConditions(sb, prop, propAccess, indent + "    ", rootTypeName);
+
             if (prop.IsUnwrapped)
             {
                 // Unwrapped: iterate items at the section level without a section heading
@@ -506,7 +510,7 @@ internal static class SerializerEmitter
                 if (prop.SectionGroupByProperty != null)
                 {
                     // Grouped rendering: partition by property, subheading per group
-                    CollectionEmitter.EmitGroupedSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel);
+                    CollectionEmitter.EmitGroupedSerialization(sb, prop, propAccess, indentLevel + 1, effectiveSectionLevel, dynamicIgnores);
                 }
                 else if (prop.MaxItems != null)
                 {
@@ -518,7 +522,7 @@ internal static class SerializerEmitter
                     }
                     else
                     {
-                        CollectionEmitter.EmitTableSerialization(sb, prop, truncVar, indentLevel + 1, nestingDepth);
+                        CollectionEmitter.EmitTableSerialization(sb, prop, truncVar, indentLevel + 1, nestingDepth, dynamicIgnores);
                     }
                     EmitHelpers.EmitMaxItemsEllipsis(sb, prop, propAccess, innerIndent, nestingDepth);
                 }
@@ -530,7 +534,7 @@ internal static class SerializerEmitter
                     }
                     else
                     {
-                        CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth);
+                        CollectionEmitter.EmitTableSerialization(sb, prop, propAccess, indentLevel + 1, nestingDepth, dynamicIgnores);
                     }
                 }
                 sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
@@ -638,6 +642,29 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
             sb.AppendLine($"{indent}writer.WriteSectionEnd();");
         }
+    }
+
+    /// <summary>
+    /// Emits condition variables for [MarkoutIgnoreColumnWhen] attributes and returns the list for CollectionEmitter.
+    /// </summary>
+    private static List<(string ConditionVar, string ColumnName)>? EmitIgnoreColumnWhenConditions(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        string? rootTypeName)
+    {
+        if (prop.SectionIgnoreColumnWhen == null || prop.SectionIgnoreColumnWhen.Count == 0 || rootTypeName == null)
+            return null;
+
+        var result = new List<(string, string)>();
+        foreach (var (methodName, columnName) in prop.SectionIgnoreColumnWhen)
+        {
+            var condVar = $"__ignore{columnName}";
+            sb.AppendLine($"{indent}var {condVar} = {rootTypeName}.{methodName}({propAccess});");
+            result.Add((condVar, columnName));
+        }
+        return result;
     }
 
     private static void EmitNonSectionProperty(

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -125,6 +125,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? SectionColumnName { get; }
     public string? SectionShowWhenProperty { get; }
     public string? SectionGroupByProperty { get; }
+    public IReadOnlyList<(string MethodName, string ColumnName)>? SectionIgnoreColumnWhen { get; }
     public string? ElementTypeName { get; }
     public IReadOnlyList<PropertyMetadata>? ElementProperties { get; }
     public bool ElementHasNestedContent { get; }
@@ -168,6 +169,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? sectionColumnName = null,
         string? sectionShowWhenProperty = null,
         string? sectionGroupByProperty = null,
+        IReadOnlyList<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null,
         string? elementTypeName = null,
         IReadOnlyList<PropertyMetadata>? elementProperties = null,
         bool elementHasNestedContent = false,
@@ -210,6 +212,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         SectionColumnName = sectionColumnName;
         SectionShowWhenProperty = sectionShowWhenProperty;
         SectionGroupByProperty = sectionGroupByProperty;
+        SectionIgnoreColumnWhen = sectionIgnoreColumnWhen;
         ElementTypeName = elementTypeName;
         ElementProperties = elementProperties;
         ElementHasNestedContent = elementHasNestedContent;
@@ -257,6 +260,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                SectionColumnName == other.SectionColumnName &&
                SectionShowWhenProperty == other.SectionShowWhenProperty &&
                SectionGroupByProperty == other.SectionGroupByProperty &&
+               IgnoreColumnWhenEqual(SectionIgnoreColumnWhen, other.SectionIgnoreColumnWhen) &&
                ElementTypeName == other.ElementTypeName &&
                ElementHasNestedContent == other.ElementHasNestedContent &&
                ElementTitleProperty == other.ElementTitleProperty &&
@@ -306,6 +310,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionColumnName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionGroupByProperty?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (SectionIgnoreColumnWhen?.Count ?? 0);
             hash = hash * 397 ^ (ValueFormatterTypeName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (ShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ IsLink.GetHashCode();
@@ -333,6 +338,16 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         if (a.Count != b.Count) return false;
         for (int i = 0; i < a.Count; i++)
             if (a[i].Key != b[i].Key || a[i].Value != b[i].Value) return false;
+        return true;
+    }
+
+    private static bool IgnoreColumnWhenEqual(IReadOnlyList<(string MethodName, string ColumnName)>? a, IReadOnlyList<(string MethodName, string ColumnName)>? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return a is null && b is null;
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+            if (a[i].MethodName != b[i].MethodName || a[i].ColumnName != b[i].ColumnName) return false;
         return true;
     }
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -30,6 +30,7 @@ internal static class TypeParser
     private const string MarkoutLinkAttribute = "Markout.MarkoutLinkAttribute";
     private const string MarkoutValueMapAttribute = "Markout.MarkoutValueMapAttribute";
     private const string MarkoutUnwrapAttribute = "Markout.MarkoutUnwrapAttribute";
+    private const string MarkoutIgnoreColumnWhenAttribute = "Markout.MarkoutIgnoreColumnWhenAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -209,6 +210,7 @@ internal static class TypeParser
         string? sectionColumnName = null;
         string? sectionShowWhenProperty = null;
         string? sectionGroupByProperty = null;
+        List<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null;
 
         if (isSection)
         {
@@ -235,6 +237,19 @@ internal static class TypeParser
                     else if (named.Key == "GroupBy" && named.Value.Value is string gb)
                         sectionGroupByProperty = gb;
                 }
+            }
+        }
+
+        // Parse [MarkoutIgnoreColumnWhen] attributes (AllowMultiple)
+        foreach (var icwAttr in prop.GetAttributes()
+            .Where(a => a.AttributeClass?.ToDisplayString() == MarkoutIgnoreColumnWhenAttribute))
+        {
+            if (icwAttr.ConstructorArguments.Length >= 2 &&
+                icwAttr.ConstructorArguments[0].Value is string methodName &&
+                icwAttr.ConstructorArguments[1].Value is string columnName)
+            {
+                sectionIgnoreColumnWhen ??= new List<(string, string)>();
+                sectionIgnoreColumnWhen.Add((methodName, columnName));
             }
         }
 
@@ -427,6 +442,7 @@ internal static class TypeParser
             sectionColumnName,
             sectionShowWhenProperty,
             sectionGroupByProperty,
+            sectionIgnoreColumnWhen,
             elementTypeName,
             elementProperties,
             hasNestedContent,

--- a/src/Markout/Attributes/MarkoutIgnoreColumnWhenAttribute.cs
+++ b/src/Markout/Attributes/MarkoutIgnoreColumnWhenAttribute.cs
@@ -1,0 +1,45 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies that a table column should be conditionally hidden based on a static method's return value.
+/// </summary>
+/// <remarks>
+/// Apply to a section property to dynamically hide a column when a condition method returns <c>true</c>.
+/// The method must be a <c>static bool</c> method on the declaring type that accepts the section collection as its parameter.
+/// Multiple attributes can be applied to conditionally hide different columns.
+/// </remarks>
+/// <example>
+/// <code>
+/// [MarkoutSection(Name = "Results")]
+/// [MarkoutIgnoreColumnWhen(nameof(PatternIsUniform), "Pattern")]
+/// [MarkoutIgnoreColumnWhen(nameof(SimilarityIsUniform), "Similarity")]
+/// public List&lt;FindRow&gt;? Results { get; set; }
+///
+/// public static bool PatternIsUniform(List&lt;FindRow&gt;? rows)
+///     =&gt; rows?.Select(r => r.Pattern).Distinct().Count() &lt;= 1;
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+public sealed class MarkoutIgnoreColumnWhenAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the name of the static method that determines whether to hide the column.
+    /// </summary>
+    public string MethodName { get; }
+
+    /// <summary>
+    /// Gets the name of the column to hide when the method returns <c>true</c>.
+    /// </summary>
+    public string ColumnName { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified method and column names.
+    /// </summary>
+    /// <param name="methodName">The name of a static bool method on the declaring type.</param>
+    /// <param name="columnName">The name of the element property (column) to conditionally hide.</param>
+    public MarkoutIgnoreColumnWhenAttribute(string methodName, string columnName)
+    {
+        MethodName = methodName;
+        ColumnName = columnName;
+    }
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.7.3</Version>
+    <Version>0.8.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/IgnoreColumnWhenTests.cs
+++ b/tests/Markout.Tests/IgnoreColumnWhenTests.cs
@@ -1,0 +1,250 @@
+using System.Collections.Generic;
+using System.Linq;
+using Markout;
+
+namespace Markout.Tests;
+
+// --- Test types ---
+
+[MarkoutSerializable]
+public class FindRow
+{
+    public string Pattern { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string Kind { get; set; } = "";
+    public string? Similarity { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class FindResultView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Results")]
+    [MarkoutIgnoreColumnWhen(nameof(PatternIsUniform), "Pattern")]
+    [MarkoutIgnoreColumnWhen(nameof(SimilarityIsUniform), "Similarity")]
+    public List<FindRow>? Results { get; set; }
+
+    public static bool PatternIsUniform(List<FindRow>? rows)
+        => rows?.Select(r => r.Pattern).Distinct().Count() <= 1;
+
+    public static bool SimilarityIsUniform(List<FindRow>? rows)
+        => rows?.Select(r => r.Similarity).Distinct().Count() <= 1;
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class SingleConditionView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Items")]
+    [MarkoutIgnoreColumnWhen(nameof(KindIsUniform), "Kind")]
+    public List<FindRow>? Items { get; set; }
+
+    public static bool KindIsUniform(List<FindRow>? rows)
+        => rows?.Select(r => r.Kind).Distinct().Count() <= 1;
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class MixedIgnoreView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Items", IgnoreProperty = "Similarity")]
+    [MarkoutIgnoreColumnWhen(nameof(PatternIsUniform), "Pattern")]
+    public List<FindRow>? Items { get; set; }
+
+    public static bool PatternIsUniform(List<FindRow>? rows)
+        => rows?.Select(r => r.Pattern).Distinct().Count() <= 1;
+}
+
+[MarkoutContext(typeof(FindRow))]
+[MarkoutContext(typeof(FindResultView))]
+[MarkoutContext(typeof(SingleConditionView))]
+[MarkoutContext(typeof(MixedIgnoreView))]
+public partial class IgnoreColumnWhenTestContext : MarkoutSerializerContext
+{
+}
+
+// --- Tests ---
+
+public class IgnoreColumnWhenTests
+{
+    [Fact]
+    public void UniformPattern_HidesPatternColumn()
+    {
+        var view = new FindResultView
+        {
+            Title = "Search",
+            Results = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Foo", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        Assert.Contains("## Results", mdf);
+        // Pattern is uniform ("Foo" for all) → hidden
+        Assert.DoesNotContain("| Pattern", mdf);
+        // Similarity is NOT uniform → shown
+        Assert.Contains("Similarity", mdf);
+        Assert.Contains("Class", mdf);
+        Assert.Contains("Struct", mdf);
+    }
+
+    [Fact]
+    public void NonUniformPattern_ShowsAllColumns()
+    {
+        var view = new FindResultView
+        {
+            Title = "Search",
+            Results = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Bar", Type = "Struct", Kind = "internal", Similarity = "1.00" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        // Pattern is NOT uniform → shown
+        Assert.Contains("Pattern", mdf);
+        // Similarity IS uniform → hidden
+        Assert.DoesNotContain("| Similarity", mdf);
+        Assert.Contains("Foo", mdf);
+        Assert.Contains("Bar", mdf);
+    }
+
+    [Fact]
+    public void BothUniform_HidesBothColumns()
+    {
+        var view = new FindResultView
+        {
+            Title = "Search",
+            Results = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Foo", Type = "Struct", Kind = "internal", Similarity = "1.00" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        Assert.DoesNotContain("| Pattern", mdf);
+        Assert.DoesNotContain("| Similarity", mdf);
+        Assert.Contains("Type", mdf);
+        Assert.Contains("Kind", mdf);
+    }
+
+    [Fact]
+    public void NeitherUniform_ShowsAllColumns()
+    {
+        var view = new FindResultView
+        {
+            Title = "Search",
+            Results = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Bar", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        Assert.Contains("Pattern", mdf);
+        Assert.Contains("Similarity", mdf);
+        Assert.Contains("Type", mdf);
+        Assert.Contains("Kind", mdf);
+    }
+
+    [Fact]
+    public void SingleCondition_HidesWhenTrue()
+    {
+        var view = new SingleConditionView
+        {
+            Title = "Test",
+            Items = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Bar", Type = "Struct", Kind = "public", Similarity = "0.85" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        // Kind is uniform → hidden
+        Assert.DoesNotContain("| Kind", mdf);
+        // Other columns shown
+        Assert.Contains("Pattern", mdf);
+        Assert.Contains("Type", mdf);
+        Assert.Contains("Similarity", mdf);
+    }
+
+    [Fact]
+    public void SingleCondition_ShowsWhenFalse()
+    {
+        var view = new SingleConditionView
+        {
+            Title = "Test",
+            Items = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Bar", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        // Kind is NOT uniform → shown
+        Assert.Contains("Kind", mdf);
+        Assert.Contains("Pattern", mdf);
+    }
+
+    [Fact]
+    public void MixedWithStaticIgnore_BothApply()
+    {
+        var view = new MixedIgnoreView
+        {
+            Title = "Test",
+            Items = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Foo", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        // Similarity is statically ignored via IgnoreProperty
+        Assert.DoesNotContain("Similarity", mdf);
+        // Pattern is dynamically hidden (uniform)
+        Assert.DoesNotContain("| Pattern", mdf);
+        // Remaining columns shown
+        Assert.Contains("Type", mdf);
+        Assert.Contains("Kind", mdf);
+    }
+
+    [Fact]
+    public void MixedWithStaticIgnore_DynamicShowsWhenNotUniform()
+    {
+        var view = new MixedIgnoreView
+        {
+            Title = "Test",
+            Items = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Bar", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        // Similarity still statically ignored
+        Assert.DoesNotContain("Similarity", mdf);
+        // Pattern is NOT uniform → shown
+        Assert.Contains("Pattern", mdf);
+        Assert.Contains("Type", mdf);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `[MarkoutIgnoreColumnWhen]` — a section-level attribute that conditionally hides table columns based on a static method's return value. This eliminates the need for duplicate section properties when column visibility depends on data characteristics.

## Usage

```csharp
[MarkoutSection(Name = "Results")]
[MarkoutIgnoreColumnWhen(nameof(PatternIsUniform), "Pattern")]
[MarkoutIgnoreColumnWhen(nameof(SimilarityIsUniform), "Similarity")]
public List<FindRow>? Results { get; set; }

public static bool PatternIsUniform(List<FindRow>? rows)
    => rows?.Select(r => r.Pattern).Distinct().Count() <= 1;
```

When `PatternIsUniform` returns `true`, the Pattern column is omitted from the rendered table. Multiple attributes can be applied to conditionally hide different columns independently.

## What changed

- **New attribute**: `MarkoutIgnoreColumnWhenAttribute` (`AllowMultiple = true`) with `(string methodName, string columnName)` constructor
- **Source generator**: Emits dynamic `List<string>`-based table rendering when the attribute is present; existing static codegen is unchanged when the attribute is not used
- **Combinable**: Works alongside static `IgnoreProperty` and `GroupBy`
- **Version**: 0.7.3 → 0.8.0

## Tests

8 new tests covering: single/multiple conditions, true/false outcomes, mixed with static `IgnoreProperty`. All 421 tests pass.