### PR TITLE
Add [MarkoutIgnoreFields] attribute to suppress writer warnings

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -50,6 +50,20 @@ internal static class SerializerEmitter
             sb.AppendLine();
         }
 
+        // Suppress field warnings for specified writer types
+        if (type.IgnoreFieldsWriters.Count > 0)
+        {
+            foreach (var writerType in type.IgnoreFieldsWriters)
+            {
+                sb.AppendLine($"        if (writer is global::Markout.{writerType})");
+                sb.AppendLine("        {");
+                sb.AppendLine($"            writer.SuppressWarning(global::Markout.MarkoutShape.Fields);");
+                sb.AppendLine($"            writer.SuppressWarning(global::Markout.MarkoutShape.FieldList);");
+                sb.AppendLine("        }");
+            }
+            sb.AppendLine();
+        }
+
         sb.AppendLine("        OnSerializing(writer, value);");
 
         // Emit title (H1) if TitleProperty is set — opens document section

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -36,6 +36,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public string? DescriptionProperty { get; }
     public bool AutoFields { get; }
     public FieldLayoutKind FieldLayout { get; }
+    public IReadOnlyList<string> IgnoreFieldsWriters { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
 
     public TypeMetadata(
@@ -49,6 +50,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         string? descriptionProperty = null,
         bool autoFields = true,
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
+        IReadOnlyList<string>? ignoreFieldsWriters = null,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
         Namespace = @namespace;
@@ -61,6 +63,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         DescriptionProperty = descriptionProperty;
         AutoFields = autoFields;
         FieldLayout = fieldLayout;
+        IgnoreFieldsWriters = ignoreFieldsWriters ?? Array.Empty<string>();
         Diagnostics = diagnostics ?? Array.Empty<DiagnosticInfo>();
     }
 
@@ -77,6 +80,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
                DescriptionProperty == other.DescriptionProperty &&
                AutoFields == other.AutoFields &&
                FieldLayout == other.FieldLayout &&
+               StringSequenceEqual(IgnoreFieldsWriters, other.IgnoreFieldsWriters) &&
                SequenceEqual(Properties, other.Properties);
     }
 
@@ -89,6 +93,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
             hash = hash * 397 ^ IsValueType.GetHashCode();
             hash = hash * 397 ^ AutoFields.GetHashCode();
             hash = hash * 397 ^ (int)FieldLayout;
+            hash = hash * 397 ^ IgnoreFieldsWriters.Count;
             foreach (var prop in Properties)
                 hash = hash * 397 ^ prop.GetHashCode();
             return hash;
@@ -100,6 +105,14 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         if (a.Count != b.Count) return false;
         for (int i = 0; i < a.Count; i++)
             if (!a[i].Equals(b[i])) return false;
+        return true;
+    }
+
+    private static bool StringSequenceEqual(IReadOnlyList<string> a, IReadOnlyList<string> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (int i = 0; i < a.Count; i++)
+            if (a[i] != b[i]) return false;
         return true;
     }
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -31,6 +31,7 @@ internal static class TypeParser
     private const string MarkoutValueMapAttribute = "Markout.MarkoutValueMapAttribute";
     private const string MarkoutUnwrapAttribute = "Markout.MarkoutUnwrapAttribute";
     private const string MarkoutIgnoreColumnWhenAttribute = "Markout.MarkoutIgnoreColumnWhenAttribute";
+    private const string MarkoutIgnoreFieldsAttribute = "Markout.MarkoutIgnoreFieldsAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -128,6 +129,14 @@ internal static class TypeParser
         // Default to OneLine
         fieldLayout ??= FieldLayoutKind.OneLine;
 
+        // Parse [MarkoutIgnoreFields] attributes (AllowMultiple)
+        var ignoreFieldsWriters = typeSymbol.GetAttributes()
+            .Where(a => a.AttributeClass?.ToDisplayString() == MarkoutIgnoreFieldsAttribute)
+            .Select(a => a.ConstructorArguments.Length > 0 && a.ConstructorArguments[0].Value is string s ? s : null)
+            .Where(s => s != null)
+            .Cast<string>()
+            .ToList();
+
         var properties = new List<PropertyMetadata>();
         var diagnostics = new List<DiagnosticInfo>();
 
@@ -188,6 +197,7 @@ internal static class TypeParser
             descriptionProperty,
             autoFields.Value,
             fieldLayout.Value,
+            ignoreFieldsWriters.Count > 0 ? ignoreFieldsWriters : null,
             filteredDiagnostics);
     }
 

--- a/src/Markout/Attributes/MarkoutIgnoreFieldsAttribute.cs
+++ b/src/Markout/Attributes/MarkoutIgnoreFieldsAttribute.cs
@@ -1,0 +1,36 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies that fields should be silently ignored (no warning) for the specified writer type.
+/// Apply to a serializable class to suppress "does not support Fields" warnings for specific writers.
+/// </summary>
+/// <example>
+/// <code>
+/// [MarkoutSerializable]
+/// [MarkoutIgnoreFields(nameof(OneLineWriter))]
+/// public class MyView
+/// {
+///     public int Count { get; set; }  // Field - ignored by OneLineWriter without warning
+///
+///     [MarkoutSection(Name = "Results")]
+///     public List&lt;MyRow&gt;? Results { get; set; }  // Table - rendered by OneLineWriter
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+public sealed class MarkoutIgnoreFieldsAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the name of the writer type that should silently ignore fields.
+    /// </summary>
+    public string WriterTypeName { get; }
+
+    /// <summary>
+    /// Initializes a new instance specifying the writer type name.
+    /// </summary>
+    /// <param name="writerTypeName">The name of the writer type (e.g., nameof(OneLineWriter)).</param>
+    public MarkoutIgnoreFieldsAttribute(string writerTypeName)
+    {
+        WriterTypeName = writerTypeName;
+    }
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -28,6 +28,7 @@ public class MarkoutWriter
     private int _tableRowCount;
     private int _tableRowsSkipped;
     private MarkoutShape _warnedShapes;
+    private MarkoutShape _suppressedShapes;
     private string[]? _streamingHeaders;
     private List<string[]>? _streamingRows;
     private int[]? _columnMap;
@@ -194,6 +195,12 @@ public class MarkoutWriter
     protected bool Supports(MarkoutShape shape) => (SupportedShapes & shape) != 0;
 
     /// <summary>
+    /// Suppresses warnings for the specified shape. Use when a type explicitly opts out of
+    /// certain shapes for specific writers via <see cref="MarkoutIgnoreFieldsAttribute"/>.
+    /// </summary>
+    public void SuppressWarning(MarkoutShape shape) => _suppressedShapes |= shape;
+
+    /// <summary>
     /// Writes a diagnostic warning for an unsupported shape (once per shape) and returns true.
     /// Returns false if the shape is supported. Use as: <c>if (ShapeUnsupported(shape)) return;</c>
     /// </summary>
@@ -201,6 +208,10 @@ public class MarkoutWriter
     {
         if (Supports(shape))
             return false;
+
+        // Skip warning if explicitly suppressed
+        if ((_suppressedShapes & shape) != 0)
+            return true;
 
         if ((_warnedShapes & shape) == 0)
         {

--- a/tests/Markout.Tests/IgnoreFieldsTests.cs
+++ b/tests/Markout.Tests/IgnoreFieldsTests.cs
@@ -1,0 +1,162 @@
+using Markout;
+
+namespace Markout.Tests;
+
+// --- Test types ---
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+[MarkoutIgnoreFields(nameof(OneLineWriter))]
+public class ViewWithIgnoreFields
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public int Count { get; set; }  // Field - would warn without the attribute
+
+    [MarkoutSection(Name = "Items")]
+    public List<SimpleRow>? Items { get; set; }
+}
+
+[MarkoutSerializable]
+public class SimpleRow
+{
+    public string Name { get; set; } = "";
+    public string Value { get; set; } = "";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ViewWithoutIgnoreFields
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public int Count { get; set; }  // Field - will warn
+
+    [MarkoutSection(Name = "Items")]
+    public List<SimpleRow>? Items { get; set; }
+}
+
+[MarkoutContext(typeof(SimpleRow))]
+[MarkoutContext(typeof(ViewWithIgnoreFields))]
+[MarkoutContext(typeof(ViewWithoutIgnoreFields))]
+public partial class IgnoreFieldsTestContext : MarkoutSerializerContext
+{
+}
+
+// --- Tests ---
+
+public class IgnoreFieldsTests
+{
+    [Fact]
+    public void SuppressWarning_PreventsWarning()
+    {
+        var errWriter = new StringWriter();
+        var origErr = Console.Error;
+        Console.SetError(errWriter);
+        try
+        {
+            var sw = new StringWriter();
+            var writer = new OneLineWriter(sw);
+            writer.SuppressWarning(MarkoutShape.Fields);
+            writer.WriteField("Key", "Value");
+            Assert.Equal("", sw.ToString());
+            Assert.Equal("", errWriter.ToString());  // No warning
+        }
+        finally
+        {
+            Console.SetError(origErr);
+        }
+    }
+
+    [Fact]
+    public void WithoutSuppressWarning_GeneratesWarning()
+    {
+        var errWriter = new StringWriter();
+        var origErr = Console.Error;
+        Console.SetError(errWriter);
+        try
+        {
+            var sw = new StringWriter();
+            var writer = new OneLineWriter(sw);
+            writer.WriteField("Key", "Value");
+            Assert.Equal("", sw.ToString());
+            Assert.Contains("does not support Fields", errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetError(origErr);
+        }
+    }
+
+    [Fact]
+    public void Serialize_WithIgnoreFieldsAttribute_NoWarning()
+    {
+        var errWriter = new StringWriter();
+        var origErr = Console.Error;
+        Console.SetError(errWriter);
+        try
+        {
+            var view = new ViewWithIgnoreFields
+            {
+                Title = "Test",
+                Count = 42,
+                Items = [new SimpleRow { Name = "A", Value = "1" }]
+            };
+
+            var sw = new StringWriter();
+            var writer = new OneLineWriter(sw);
+            MarkoutSerializer.Serialize(view, writer, IgnoreFieldsTestContext.Default);
+
+            Assert.Contains("A", sw.ToString());
+            Assert.Equal("", errWriter.ToString());  // No warning due to [MarkoutIgnoreFields]
+        }
+        finally
+        {
+            Console.SetError(origErr);
+        }
+    }
+
+    [Fact]
+    public void Serialize_WithoutIgnoreFieldsAttribute_GeneratesWarning()
+    {
+        var errWriter = new StringWriter();
+        var origErr = Console.Error;
+        Console.SetError(errWriter);
+        try
+        {
+            var view = new ViewWithoutIgnoreFields
+            {
+                Title = "Test",
+                Count = 42,
+                Items = [new SimpleRow { Name = "A", Value = "1" }]
+            };
+
+            var sw = new StringWriter();
+            var writer = new OneLineWriter(sw);
+            MarkoutSerializer.Serialize(view, writer, IgnoreFieldsTestContext.Default);
+
+            Assert.Contains("A", sw.ToString());
+            // FieldList warning because AutoFields renders scalar fields as a field list
+            Assert.Contains("does not support FieldList", errWriter.ToString());
+        }
+        finally
+        {
+            Console.SetError(origErr);
+        }
+    }
+
+    [Fact]
+    public void Serialize_WithIgnoreFieldsAttribute_MarkdownWriterStillRendersFields()
+    {
+        // MarkoutIgnoreFields only affects OneLineWriter, not MarkdownWriter
+        var view = new ViewWithIgnoreFields
+        {
+            Title = "Test",
+            Count = 42,
+            Items = [new SimpleRow { Name = "A", Value = "1" }]
+        };
+
+        var output = MarkoutSerializer.Serialize(view, IgnoreFieldsTestContext.Default);
+
+        // MarkdownWriter should still render the Count field
+        Assert.Contains("# Test", output);
+        Assert.Contains("Count:", output);
+        Assert.Contains("42", output);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `[MarkoutIgnoreFields(nameof(OneLineWriter))]` attribute to suppress field-related warnings for specific writer types
- When serializing views to writers with limited shape support (e.g., `OneLineWriter` which only supports Tables/Lists), fields would trigger warnings like "Warning: OneLineWriter does not support Fields"
- The source generator now emits `SuppressWarning(Fields)` and `SuppressWarning(FieldList)` calls when the specified writer type is detected

## Test plan

- [x] All 426 Markout tests pass
- [x] Verified with dotnet-inspect: warning no longer appears when using `--oneline` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)