### PR TITLE
Add integration tests for IgnoreColumnWhen with GroupBy and OneLineWriter

### DIFF
--- a/tests/Markout.Tests/IgnoreColumnWhenTests.cs
+++ b/tests/Markout.Tests/IgnoreColumnWhenTests.cs
@@ -58,10 +58,54 @@ public class MixedIgnoreView
         => rows?.Select(r => r.Pattern).Distinct().Count() <= 1;
 }
 
+// --- GroupBy + IgnoreColumnWhen integration ---
+
+[MarkoutSerializable]
+public class GroupedFindRow
+{
+    public string Category { get; set; } = "";
+    public string Pattern { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string Kind { get; set; } = "";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class GroupByWithIgnoreColumnWhenView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+
+    [MarkoutSection(Name = "Results", GroupBy = nameof(GroupedFindRow.Category))]
+    [MarkoutIgnoreColumnWhen(nameof(PatternIsUniform), "Pattern")]
+    public List<GroupedFindRow>? Results { get; set; }
+
+    public static bool PatternIsUniform(List<GroupedFindRow>? rows)
+        => rows?.Select(r => r.Pattern).Distinct().Count() <= 1;
+}
+
+// --- OneLineWriter + IgnoreColumnWhen + IgnoreFields integration ---
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+[MarkoutIgnoreFields(nameof(OneLineWriter))]
+public class OneLineIgnoreColumnWhenView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public int Count { get; set; }
+
+    [MarkoutSection(Name = "Results")]
+    [MarkoutIgnoreColumnWhen(nameof(PatternIsUniform), "Pattern")]
+    public List<FindRow>? Results { get; set; }
+
+    public static bool PatternIsUniform(List<FindRow>? rows)
+        => rows?.Select(r => r.Pattern).Distinct().Count() <= 1;
+}
+
 [MarkoutContext(typeof(FindRow))]
 [MarkoutContext(typeof(FindResultView))]
 [MarkoutContext(typeof(SingleConditionView))]
 [MarkoutContext(typeof(MixedIgnoreView))]
+[MarkoutContext(typeof(GroupByWithIgnoreColumnWhenView))]
+[MarkoutContext(typeof(GroupedFindRow))]
+[MarkoutContext(typeof(OneLineIgnoreColumnWhenView))]
 public partial class IgnoreColumnWhenTestContext : MarkoutSerializerContext
 {
 }
@@ -246,5 +290,140 @@ public class IgnoreColumnWhenTests
         // Pattern is NOT uniform → shown
         Assert.Contains("Pattern", mdf);
         Assert.Contains("Type", mdf);
+    }
+
+    // --- GroupBy + IgnoreColumnWhen integration ---
+
+    [Fact]
+    public void GroupBy_WithIgnoreColumnWhen_HidesUniformColumn()
+    {
+        var view = new GroupByWithIgnoreColumnWhenView
+        {
+            Title = "Search",
+            Results = new List<GroupedFindRow>
+            {
+                new() { Category = "Classes", Pattern = "Foo", Type = "Class", Kind = "public" },
+                new() { Category = "Classes", Pattern = "Foo", Type = "Class", Kind = "internal" },
+                new() { Category = "Structs", Pattern = "Foo", Type = "Struct", Kind = "public" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        // GroupBy creates subheadings
+        Assert.Contains("### Classes", mdf);
+        Assert.Contains("### Structs", mdf);
+        // Pattern is uniform → hidden from grouped tables
+        Assert.DoesNotContain("| Pattern", mdf);
+        // Other columns visible
+        Assert.Contains("Type", mdf);
+        Assert.Contains("Kind", mdf);
+    }
+
+    [Fact]
+    public void GroupBy_WithIgnoreColumnWhen_ShowsNonUniformColumn()
+    {
+        var view = new GroupByWithIgnoreColumnWhenView
+        {
+            Title = "Search",
+            Results = new List<GroupedFindRow>
+            {
+                new() { Category = "Classes", Pattern = "Foo", Type = "Class", Kind = "public" },
+                new() { Category = "Classes", Pattern = "Bar", Type = "Class", Kind = "internal" },
+                new() { Category = "Structs", Pattern = "Baz", Type = "Struct", Kind = "public" }
+            }
+        };
+
+        var mdf = MarkoutSerializer.Serialize(view, IgnoreColumnWhenTestContext.Default);
+
+        Assert.Contains("### Classes", mdf);
+        // Pattern is NOT uniform → shown in grouped tables
+        Assert.Contains("Pattern", mdf);
+        Assert.Contains("Foo", mdf);
+        Assert.Contains("Bar", mdf);
+    }
+
+    // --- OneLineWriter + IgnoreColumnWhen + IgnoreFields integration ---
+
+    [Fact]
+    public void OneLineWriter_WithIgnoreColumnWhen_HidesUniformColumn()
+    {
+        var view = new OneLineIgnoreColumnWhenView
+        {
+            Title = "Search",
+            Count = 2,
+            Results = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Foo", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var sw = new StringWriter();
+        var writer = new OneLineWriter(sw);
+        MarkoutSerializer.Serialize(view, writer, IgnoreColumnWhenTestContext.Default);
+        var output = sw.ToString();
+
+        // OneLineWriter renders table rows as pipe-separated lines
+        Assert.Contains("Class", output);
+        Assert.Contains("Struct", output);
+        // Pattern is uniform → hidden
+        Assert.DoesNotContain("Foo", output);
+    }
+
+    [Fact]
+    public void OneLineWriter_WithIgnoreColumnWhen_ShowsNonUniformColumn()
+    {
+        var view = new OneLineIgnoreColumnWhenView
+        {
+            Title = "Search",
+            Count = 2,
+            Results = new List<FindRow>
+            {
+                new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" },
+                new() { Pattern = "Bar", Type = "Struct", Kind = "internal", Similarity = "0.85" }
+            }
+        };
+
+        var sw = new StringWriter();
+        var writer = new OneLineWriter(sw);
+        MarkoutSerializer.Serialize(view, writer, IgnoreColumnWhenTestContext.Default);
+        var output = sw.ToString();
+
+        // Pattern is NOT uniform → shown
+        Assert.Contains("Foo", output);
+        Assert.Contains("Bar", output);
+    }
+
+    [Fact]
+    public void OneLineWriter_WithIgnoreFields_NoFieldWarning()
+    {
+        var errWriter = new StringWriter();
+        var origErr = Console.Error;
+        Console.SetError(errWriter);
+        try
+        {
+            var view = new OneLineIgnoreColumnWhenView
+            {
+                Title = "Search",
+                Count = 42,
+                Results = new List<FindRow>
+                {
+                    new() { Pattern = "Foo", Type = "Class", Kind = "public", Similarity = "1.00" }
+                }
+            };
+
+            var sw = new StringWriter();
+            var writer = new OneLineWriter(sw);
+            MarkoutSerializer.Serialize(view, writer, IgnoreColumnWhenTestContext.Default);
+
+            // No "does not support Fields" warning thanks to [MarkoutIgnoreFields]
+            Assert.Equal("", errWriter.ToString());
+            Assert.Contains("Class", sw.ToString());
+        }
+        finally
+        {
+            Console.SetError(origErr);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds 5 integration tests that exercise the new `[MarkoutIgnoreColumnWhen]` and `[MarkoutIgnoreFields]` attributes in combination with other features:

- **GroupBy + IgnoreColumnWhen** (2 tests): Verifies dynamic column hiding works within grouped table rendering
- **OneLineWriter + IgnoreColumnWhen** (2 tests): Verifies conditional columns work with the one-line pipe-separated renderer
- **OneLineWriter + IgnoreFields** (1 test): Verifies `[MarkoutIgnoreFields(nameof(OneLineWriter))]` suppresses field warnings when combined with `IgnoreColumnWhen`

All 431 tests pass.