### PR TITLE
Render metrics/breakdowns as Markdown tables; add GitHubRepo sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Markout is a source-generated .NET serializer that projects objects into human-readable documents instead of data formats like JSON. You annotate view models with attributes that describe data relationships — identity, enumeration, tabulation, measurement, hierarchy — and the source generator emits code that writes through an abstract renderer. The same object graph produces Markdown tables, ANSI terminal output with colored bars, plain text with aligned columns, or one-line summaries, without the developer making visual decisions.
 
-The name captures the philosophy: where markup layers formatting instructions onto content, Markout works in the opposite direction, stripping an object graph down to what the data *is* — a measurement, a breakdown, a hierarchy — and letting the renderer decide what it *looks like*. The word also nods to an older tradition. Long before digital markup languages, typesetters performed two complementary acts: marking *up* a manuscript with rendering instructions, and marking *out* content that didn't belong in the final form. Computing formalized markup into an entire paradigm (GML, SGML, HTML, XML) but largely forgot its counterpart. Markout reclaims that half of the craft.
-
 ## Quick Start
 
 ```csharp
@@ -40,9 +38,9 @@ public partial class ArtistContext : MarkoutSerializerContext { }
 Genre: Pop / Adult Contemporary | Origin: Halifax, Nova Scotia | DebutYear: 1988 | BestKnownFor: Angel, Building a Mystery, Adia
 ```
 
-Three things: a record, a context, one line of serialization. The `TitleProperty` becomes a heading; everything else renders as fields. See the [RecordDemo](samples/RecordDemo) sample.
+Three things: a record, a context, one line of serialization. The `TitleProperty` becomes a heading; everything else renders as fields.
 
-## Sections and Tables
+## Adding Sections and Tables
 
 Add `[MarkoutSection]` to group properties with headings, and use `List<T>` for tables:
 
@@ -67,6 +65,7 @@ public class LandmarkRow
 }
 
 [MarkoutContext(typeof(CityReport))]
+[MarkoutContext(typeof(LandmarkRow))]
 public partial class ReportContext : MarkoutSerializerContext { }
 
 MarkoutSerializer.Serialize(city, Console.Out, ReportContext.Default);
@@ -89,19 +88,107 @@ Population: 2632000
 | Science World    | Museum     | 1989 |
 ```
 
-Same object, different renderer:
+## Real-World Example: GitHub Repository Report
+
+The [GitHubRepo](samples/GitHubRepo) sample fetches four GitHub API endpoints in parallel and projects the combined JSON into a single report — fields, bar charts, contributor metrics, and release tables — all from one view model:
 
 ```csharp
-// ANSI terminal — colored headings, bold field names
-MarkoutSerializer.Serialize(city, Console.Out, ReportContext.Default, new AnsiWriter(Console.Out));
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
+[MarkoutIgnoreFields(nameof(OneLineWriter))]
+public class RepoView
+{
+    public string Title { get; set; } = "";
 
-// One-line summary — tables only, no headings or fields
-MarkoutSerializer.Serialize(city, Console.Out, ReportContext.Default, new OneLineWriter(Console.Out));
+    [MarkoutIgnore]
+    public string Description { get; set; } = "";
+
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Stars { get; set; }
+
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Forks { get; set; }
+
+    [MarkoutPropertyName("Open Issues")]
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int OpenIssues { get; set; }
+
+    public string Language { get; set; } = "";
+    public string License { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    [MarkoutSkipDefault]
+    public Callout ArchivedWarning { get; set; }
+
+    [MarkoutSection(Name = "Languages")]
+    [MarkoutIgnoreInTable]
+    public List<Breakdown>? Languages { get; set; }
+
+    [MarkoutSection(Name = "Top Contributors")]
+    [MarkoutIgnoreInTable]
+    public List<Metric>? TopContributors { get; set; }
+
+    [MarkoutSection(Name = "Releases")]
+    public List<ReleaseRow>? Releases { get; set; }
+}
 ```
+
+Run it:
+
+```bash
+dotnet run samples/GitHubRepo/GitHubRepo.cs                                     # ANSI terminal (default)
+dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format markdown # Markdown
+dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format oneline  # Compact table
+```
+
+**Markdown output** for `dotnet/runtime`:
+
+```markdown
+# dotnet/runtime
+
+.NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
+
+Stars: 17,698 | Forks: 5,350 | Open Issues: 8,385 | Language: C# | License: MIT License
+
+## Languages
+
+| Category | Count | % |
+| -------- | ----- | - |
+| C#       | 80    | 83 |
+| C++      | 9     | 9  |
+| C        | 7     | 7  |
+
+## Top Contributors
+
+| Label       | Value |
+| ----------- | ----- |
+| vargaz      | 11910 |
+| stephentoub | 10417 |
+| kumpera     | 4074  |
+| jkotas      | 3244  |
+
+## Releases
+
+| Tag     | Name        | Published  |
+| ------- | ----------- | ---------- |
+| v10.0.3 | .NET 10.0.3 | 2026-02-10 |
+| v10.0.2 | .NET 10.0.2 | 2026-01-14 |
+| v9.0.13 | v9.0.13     | 2026-02-10 |
+```
+
+**One-line output** — same view model, `--oneline` flag, shows the Releases table only:
+
+```text
+TAG      NAME         PUBLISHED
+v8.0.24  .NET 8.0.24  2026-02-10
+v9.0.13  v9.0.13      2026-02-10
+v10.0.3  .NET 10.0.3  2026-02-10
+```
+
+The pattern is always the same: deserialize your API data, project to a view model, serialize. Markout handles the rest.
 
 ## Shape Library
 
-Markout is a serializer for a **shape library**. Each property on a view model maps to a data relationship, not a visual element. Renderers decide how to present each shape.
+Each property on a view model maps to a data relationship, not a visual element. Renderers decide how to present each shape.
 
 | Relationship | C# type | What it means | Markdown | ANSI |
 |---|---|---|---|---|
@@ -232,6 +319,8 @@ Markout provides multiple layers of control, from zero-config to full custom:
 [MarkoutShowWhen(nameof(HasDetails))]  // conditional rendering
 [MarkoutMaxItems(10)]                  // truncate long lists
 [MarkoutValueMap("k=badge", ...)]      // map values to badge-prefixed output
+[MarkoutUnwrap]                        // inline collection items without section heading
+[MarkoutIgnoreColumnWhen(...)]         // conditionally hide table columns
 ```
 
 **Layer 2 — Writer Options** (runtime): Control which sections appear.
@@ -268,12 +357,19 @@ The package includes the source generator — no additional packages needed.
 
 ## Samples
 
-- **[RecordDemo](samples/RecordDemo)** — Simplest possible example: a record, a context, one line of serialization
+- **[HelloMarkout](samples/HelloMarkout)** — Simplest possible example: a class, a context, one line of serialization
+- **[RecordDemo](samples/RecordDemo)** — Records as view models
+- **[GitHubRepo](samples/GitHubRepo)** — GitHub API → fields, breakdowns, metrics, and tables with Spectre/Markdown/OneLineWriter output
+- **[GitHubActivity](samples/GitHubActivity)** — User profile and recent events from the GitHub API
 - **[CanadianContent](samples/CanadianContent)** — Canadian actors and shows with tables, trees, metrics, and multiple renderers
 - **[LatestCves](samples/LatestCves)** — .NET security advisories with trees and severity breakdowns
 - **[DotNetReleases](samples/DotNetReleases)** — .NET release information from GitHub
 - **[Serialization](samples/Serialization)** — Shape gallery, section filtering, and writer API examples
 - **[TemplateDemo](samples/TemplateDemo)** — Document template with inline tables, conditional sections, and multi-format rendering
+
+## For Coding Agents
+
+If you are an LLM or coding agent building a CLI tool that needs structured, readable output, see **[SKILL.md](SKILL.md)** for step-by-step integration instructions and attribute reference.
 
 ## Real-World Usage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,249 @@
+# Markout — Coding Agent Integration Guide
+
+Markout is a .NET source-generated serializer that turns objects into readable documents (Markdown, ANSI terminal, plain text). Use it whenever a CLI tool needs structured, human-readable output instead of raw `Console.WriteLine`.
+
+## Installation
+
+```bash
+dotnet add package Markout
+```
+
+This single package includes the source generator. No additional packages needed for Markdown or plain text output.
+
+For ANSI terminal output with Spectre.Console:
+
+```bash
+dotnet add package Markout.Ansi.Spectre
+```
+
+## Core Pattern
+
+Every markout integration follows three steps:
+
+### 1. Define a view model
+
+Annotate a class or record with `[MarkoutSerializable]`. Scalar properties become fields. `List<T>` properties become tables. Built-in types like `Metric`, `Breakdown`, `Callout`, and `TreeNode` produce charts, bars, alerts, and trees.
+
+```csharp
+using Markout;
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ToolReport
+{
+    public string Title { get; set; } = "";
+    public string Status { get; set; } = "";
+    public int ItemCount { get; set; }
+
+    [MarkoutSection(Name = "Results")]
+    public List<ResultRow>? Results { get; set; }
+}
+
+[MarkoutSerializable]
+public class ResultRow
+{
+    public string Name { get; set; } = "";
+    public string Value { get; set; } = "";
+}
+```
+
+### 2. Define a context
+
+Create a partial class that registers your view models for source generation:
+
+```csharp
+[MarkoutContext(typeof(ToolReport))]
+[MarkoutContext(typeof(ResultRow))]
+public partial class ToolContext : MarkoutSerializerContext { }
+```
+
+### 3. Serialize
+
+```csharp
+MarkoutSerializer.Serialize(report, Console.Out, ToolContext.Default);
+```
+
+That's it. The output is Markdown by default.
+
+## Attribute Reference
+
+### Type-level attributes
+
+| Attribute | Purpose | Example |
+|---|---|---|
+| `[MarkoutSerializable]` | Mark type for serialization | `[MarkoutSerializable(TitleProperty = "Name")]` |
+| `[MarkoutContext(typeof(T))]` | Register type with context | `[MarkoutContext(typeof(MyView))]` |
+| `[MarkoutIgnoreFields("OneLineWriter")]` | Suppress field warnings for a writer | `[MarkoutIgnoreFields(nameof(OneLineWriter))]` |
+
+`MarkoutSerializable` properties:
+
+- `TitleProperty` — Property to render as the H1 heading
+- `DescriptionProperty` — Property to render as a paragraph below the heading
+- `AutoFields` — Auto-render scalar properties as fields (default: `true`)
+- `FieldLayout` — `OneLine` (pipe-separated) or `LineBreaks`
+
+### Property-level attributes
+
+| Attribute | Purpose | Example |
+|---|---|---|
+| `[MarkoutSection(Name = "...")]` | Render as a `## Heading` section | `[MarkoutSection(Name = "Errors")]` |
+| `[MarkoutPropertyName("...")]` | Custom display name | `[MarkoutPropertyName("Open Issues")]` |
+| `[MarkoutDisplayFormat("...")]` | Format string | `[MarkoutDisplayFormat("{0:N0}")]` |
+| `[MarkoutBoolFormat("✓", "✗")]` | Custom bool display | `[MarkoutBoolFormat("Yes", "No")]` |
+| `[MarkoutSkipNull]` | Hide when null | |
+| `[MarkoutSkipDefault]` | Hide when default value | |
+| `[MarkoutShowWhen(nameof(Flag))]` | Conditional rendering | `[MarkoutShowWhen(nameof(HasErrors))]` |
+| `[MarkoutIgnore]` | Exclude from output | |
+| `[MarkoutIgnoreInTable]` | Exclude from table columns | |
+| `[MarkoutMaxItems(N)]` | Truncate long lists | `[MarkoutMaxItems(10)]` |
+| `[MarkoutLink(nameof(Url))]` | Render as hyperlink | `[MarkoutLink(nameof(HtmlUrl))]` |
+| `[MarkoutUnwrap]` | Inline collection without section heading | |
+| `[MarkoutIgnoreColumnWhen(...)]` | Conditionally hide table column | |
+| `[MarkoutValueMap("k=v", ...)]` | Map values to display strings | |
+
+### Section properties
+
+`[MarkoutSection]` supports:
+
+- `Name` — Section heading text
+- `Level` — Heading level (default: 2 for `##`)
+- `GroupBy` — Group items by a property value
+- `ShowWhenProperty` — Boolean property controlling visibility
+- `IgnoreProperty` — Comma-separated column names to hide
+
+## Built-in Shape Types
+
+Use these types as properties on your view model to get rich output:
+
+```csharp
+// Bar chart — comparative quantities
+[MarkoutSection(Name = "Performance")]
+[MarkoutIgnoreInTable]
+public List<Metric>? Metrics { get; set; }
+// Usage: new Metric("Build Time", 4.2)
+
+// Stacked bar — proportional composition
+[MarkoutSection(Name = "Distribution")]
+[MarkoutIgnoreInTable]
+public List<Breakdown>? Distribution { get; set; }
+// Usage: new Breakdown("By Type", [new Segment("Critical", 3), new Segment("Low", 12)])
+
+// Alert box
+[MarkoutIgnoreInTable]
+[MarkoutSkipDefault]
+public Callout Warning { get; set; }
+// Usage: new Callout(CalloutSeverity.Warning, "3 issues found")
+
+// Tree hierarchy
+[MarkoutIgnoreInTable]
+public List<TreeNode>? Dependencies { get; set; }
+// Usage: new TreeNode("root", [new TreeNode("child1"), new TreeNode("child2")])
+
+// Term + explanation list
+[MarkoutSection(Name = "Glossary")]
+[MarkoutIgnoreInTable]
+public List<Description>? Terms { get; set; }
+// Usage: new Description("API", "Application Programming Interface")
+
+// Code block
+[MarkoutIgnoreInTable]
+public CodeSection? SourceCode { get; set; }
+// Usage: new CodeSection("csharp", "public class Foo { }")
+```
+
+## Choosing a Renderer
+
+```csharp
+// Markdown (default) — documentation, LLM output, reports
+MarkoutSerializer.Serialize(view, Console.Out, context);
+
+// Markdown with writer instance
+MarkoutSerializer.Serialize(view, new MarkdownWriter(Console.Out), context);
+
+// Spectre terminal — colored, interactive
+using Markout.Ansi.Spectre;
+using Spectre.Console;
+MarkoutSerializer.Serialize(view, new SpectreWriter(AnsiConsole.Console), context);
+
+// One-line — compact table, grep-friendly
+MarkoutSerializer.Serialize(view, new OneLineWriter(Console.Out), context);
+
+// One-line with section filter — show only one table
+var options = new MarkoutWriterOptions
+{
+    IncludeDescription = false,
+    IncludeSections = new HashSet<string> { "Results" }
+};
+MarkoutSerializer.Serialize(view, new OneLineWriter(Console.Out, options), context);
+
+// Plain text — log files, piped output
+MarkoutSerializer.Serialize(view, new MarkoutWriter(Console.Out), context);
+```
+
+## Common Recipe: JSON API to Report
+
+This is the most common pattern — fetch JSON, project to view model, serialize:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Markout;
+
+// 1. Fetch and deserialize
+using var http = new HttpClient();
+var json = await http.GetStringAsync("https://api.example.com/data");
+var data = JsonSerializer.Deserialize(json, ApiJsonContext.Default.ApiResponse)!;
+
+// 2. Project to view model
+var view = new ReportView
+{
+    Title = data.Name,
+    Count = data.Items.Count,
+    Items = data.Items.Select(i => new ItemRow
+    {
+        Name = i.Name,
+        Status = i.Status
+    }).ToList()
+};
+
+// 3. Serialize
+MarkoutSerializer.Serialize(view, Console.Out, ReportContext.Default);
+
+// --- View Model ---
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ReportView
+{
+    public string Title { get; set; } = "";
+    public int Count { get; set; }
+
+    [MarkoutSection(Name = "Items")]
+    public List<ItemRow>? Items { get; set; }
+}
+
+[MarkoutSerializable]
+public class ItemRow
+{
+    public string Name { get; set; } = "";
+    public string Status { get; set; } = "";
+}
+
+[MarkoutContext(typeof(ReportView))]
+[MarkoutContext(typeof(ItemRow))]
+public partial class ReportContext : MarkoutSerializerContext { }
+
+// --- JSON Model (separate from view model) ---
+public class ApiResponse { public string Name { get; set; } = ""; public List<ApiItem> Items { get; set; } = []; }
+public class ApiItem { public string Name { get; set; } = ""; public string Status { get; set; } = ""; }
+
+[JsonSerializable(typeof(ApiResponse))]
+internal partial class ApiJsonContext : JsonSerializerContext { }
+```
+
+## Key Principles
+
+1. **View models are not domain models.** Keep your JSON/API models separate. The view model is the projection layer — it decides what the user sees.
+2. **Attributes describe data relationships, not visuals.** Say "this is a measurement" (`Metric`), not "draw a bar."
+3. **Register every type.** Every class used in serialization needs `[MarkoutSerializable]` and must be registered via `[MarkoutContext(typeof(T))]` on the context.
+4. **The context must be `partial`.** The source generator fills in the implementation.
+5. **`List<T>` → table, scalar → field.** The type system drives rendering. A `List<MyRow>` automatically becomes a table; a `string` or `int` property becomes a key-value field.
+6. **Sections group content.** Use `[MarkoutSection(Name = "...")]` on any property to create a `## Heading` above it.
+7. **Use `[MarkoutIgnoreInTable]`** on properties that aren't tabular (metrics, breakdowns, callouts, trees) to prevent them from being treated as table columns.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -160,3 +160,42 @@ to express meaningfully in plain text. Needs more design work.
 ### Gantt / Timeline — Deferred
 
 Sequential labeled time spans. Same multi-renderer concern. Needs more design work.
+
+## SpectreWriter: adopt Spectre widgets for tables
+
+SpectreWriter currently uses `IAnsiConsole` as a character-level ANSI markup emitter
+and hand-renders every shape — tables, trees, bars, breakdowns, rules, panels — with
+manual padding and `█` characters. It uses none of Spectre's built-in widgets (`Table`,
+`BarChart`, `BreakdownChart`, `Tree`, `Rule`, `Panel`).
+
+### Recommendation: use Spectre `Table` for tables
+
+`WriteTable` and `WriteTree` receive complete data, so they could delegate to Spectre
+widgets without changing the base class. Spectre `Table` handles Unicode width
+calculation, column wrapping, and border styles better than manual `PadRight`.
+
+```csharp
+// Current: manual column-width calculation + PadRight (lines 254–321)
+// Proposed:
+var table = new Table().NoBorder();
+foreach (var h in headers) table.AddColumn(new TableColumn(h));
+foreach (var row in rows) table.AddRow(row);
+_console.Write(table);
+```
+
+### Do NOT adopt Spectre widgets for bars, breakdowns, or trees
+
+`WriteMetricBar` and `WriteBreakdownRow` are called per-item by the base class — the
+base owns iteration. Spectre's `BarChart` and `BreakdownChart` are whole-object widgets
+that want all data at construction. Using them would require changing the base class
+rendering model, which affects every writer.
+
+Trees *could* use Spectre `Tree`, but markout's hand-drawn tree rendering (gradient
+depth coloring, badge support, box-drawing style) is a deliberate visual choice that
+would be lost.
+
+### Visual consistency concern
+
+If tables get Spectre box borders while everything else stays hand-drawn, the output
+may look inconsistent. Mitigate by using `NoBorder()` or `MinimalBorder()` and matching
+the existing uppercase header + `─` separator style.

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="true" />
+  </ItemGroup>
+</Project>

--- a/samples/GitHubRepo/GitHubRepo.cs
+++ b/samples/GitHubRepo/GitHubRepo.cs
@@ -1,0 +1,258 @@
+#:project ../../src/Markout.Ansi.Spectre/Markout.Ansi.Spectre.csproj
+#:package System.CommandLine@2.0.3
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Markout;
+using Markout.Ansi.Spectre;
+using Spectre.Console;
+
+var repoArg = new Argument<string>("repo") { DefaultValueFactory = _ => "dotnet/runtime", Description = "GitHub repository (owner/repo)" };
+var formatOption = new Option<string>("--format", "-f") { DefaultValueFactory = _ => "spectre", Description = "Output format" };
+formatOption.AcceptOnlyFromAmong("spectre", "markdown", "oneline");
+var sectionOption = new Option<string?>("--section", "-s") { Description = "Section to display" };
+
+var rootCommand = new RootCommand("GitHub repository report — fields, charts, metrics, and tables via Markout")
+{
+    repoArg, formatOption, sectionOption
+};
+
+rootCommand.SetAction(Run);
+return await rootCommand.Parse(args).InvokeAsync();
+
+async Task Run(ParseResult parseResult, CancellationToken ct)
+{
+    var repo = parseResult.GetValue(repoArg)!;
+    var format = parseResult.GetValue(formatOption)!;
+    var section = parseResult.GetValue(sectionOption);
+
+    var parts = repo.Split('/');
+    if (parts.Length != 2) { Console.Error.WriteLine("Repository must be in owner/repo format."); return; }
+    var (owner, name) = (parts[0], parts[1]);
+
+    // Fetch and deserialize from GitHub API in parallel
+    using var http = new HttpClient();
+    http.DefaultRequestHeaders.Add("User-Agent", "Markout-GitHubRepo");
+    http.DefaultRequestHeaders.Add("Accept", "application/vnd.github+json");
+
+    var repoTask = http.GetFromJsonAsync($"https://api.github.com/repos/{owner}/{name}", GitHubJsonContext.Default.RepoData, ct);
+    var langsTask = http.GetFromJsonAsync($"https://api.github.com/repos/{owner}/{name}/languages", GitHubJsonContext.Default.DictionaryStringInt64, ct);
+    var contribTask = http.GetFromJsonAsync($"https://api.github.com/repos/{owner}/{name}/contributors?per_page=10", GitHubJsonContext.Default.ListContributor, ct);
+    var releasesTask = http.GetFromJsonAsync($"https://api.github.com/repos/{owner}/{name}/releases?per_page=10", GitHubJsonContext.Default.ListRelease, ct);
+
+    var repoData = await repoTask;
+    var languages = await langsTask ?? [];
+    var contributors = await contribTask ?? [];
+    var releases = await releasesTask ?? [];
+
+    if (repoData is null)
+    {
+        Console.Error.WriteLine("Repository not found.");
+        return;
+    }
+
+    // Choose renderer first — projection depends on writer capabilities
+    var options = section is not null
+        ? new MarkoutWriterOptions { IncludeSections = new HashSet<string> { section } }
+        : new MarkoutWriterOptions();
+
+    MarkoutWriter writer = format switch
+    {
+        "markdown" => new MarkdownWriter(Console.Out, options),
+        "oneline" => new OneLineWriter(Console.Out, new MarkoutWriterOptions
+        {
+            IncludeDescription = false,
+            IncludeSections = options.IncludeSections ?? new HashSet<string> { "Releases" }
+        }),
+        _ => new SpectreWriter(AnsiConsole.Console, options),
+    };
+
+    bool useMetrics = writer.SupportedShapes.HasFlag(MarkoutShape.Metrics);
+
+    // Project to view model — shape selection depends on writer
+    var totalBytes = languages.Values.Sum();
+    int maxLanguages = 8;
+    int maxContributors = 8;
+    int maxReleases = 8;
+    int maxPreviewReleases = 5;
+    int maxReleaseNameLength = 40;
+
+    var view = new RepoView
+    {
+        Title = repoData.FullName ?? repo,
+        Description = repoData.Description ?? "",
+        Stars = repoData.StargazersCount,
+        Forks = repoData.ForksCount,
+        OpenIssues = repoData.OpenIssuesCount,
+        Language = repoData.Language ?? "unknown",
+        License = repoData.License?.Name ?? "None",
+        Created = DateTimeOffset.TryParse(repoData.CreatedAt, out var c) ? c.ToString("yyyy-MM-dd") : "",
+        LastPush = DateTimeOffset.TryParse(repoData.PushedAt, out var p) ? p.ToString("yyyy-MM-dd") : "",
+        ArchivedWarning = repoData.Archived
+            ? new Callout(CalloutSeverity.Warning, "This repository has been archived and is read-only.")
+            : default,
+        NoLicenseWarning = repoData.License is null
+            ? new Callout(CalloutSeverity.Note, "This repository does not specify a license.")
+            : default,
+        Languages = totalBytes > 0
+            ? [new Breakdown("By bytes", languages
+                .OrderByDescending(kv => kv.Value)
+                .Take(maxLanguages)
+                .Select(kv => new Segment(kv.Key, (int)(kv.Value * 100 / totalBytes)))
+                .ToArray())]
+            : null,
+        ContributorMetrics = useMetrics ? contributors
+            .Take(maxContributors)
+            .Select(c => new Metric(c.Login ?? "unknown", c.Contributions))
+            .ToList() : null,
+        ContributorTable = !useMetrics ? contributors
+            .Take(maxContributors)
+            .Select(c => new ContributorRow
+            {
+                Login = c.Login ?? "unknown",
+                Contributions = c.Contributions
+            }).ToList() : null,
+        Releases = releases
+            .Where(r => !r.Prerelease)
+            .Take(maxReleases)
+            .Select(r => new ReleaseRow
+            {
+                Tag = r.TagName ?? "",
+                Name = Truncate(r.Name ?? r.TagName ?? "", maxReleaseNameLength),
+                Published = DateTimeOffset.TryParse(r.PublishedAt, out var d) ? d.ToString("yyyy-MM-dd") : "",
+            }).ToList(),
+        PreviewReleases = releases
+            .Where(r => r.Prerelease)
+            .Take(maxPreviewReleases)
+            .Select(r => new ReleaseRow
+            {
+                Tag = r.TagName ?? "",
+                Name = Truncate(r.Name ?? r.TagName ?? "", maxReleaseNameLength),
+                Published = DateTimeOffset.TryParse(r.PublishedAt, out var d) ? d.ToString("yyyy-MM-dd") : "",
+            }).ToList()
+    };
+
+    MarkoutSerializer.Serialize(view, writer, RepoContext.Default);
+}
+
+static string Truncate(string s, int max) => s.Length <= max ? s : s[..(max - 1)] + "…";
+
+// --- View Models ---
+
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
+[MarkoutIgnoreFields(nameof(OneLineWriter))]
+public class RepoView
+{
+    public string Title { get; set; } = "";
+
+    [MarkoutIgnore]
+    public string Description { get; set; } = "";
+
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Stars { get; set; }
+
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Forks { get; set; }
+
+    [MarkoutPropertyName("Open Issues")]
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int OpenIssues { get; set; }
+
+    public string Language { get; set; } = "";
+    public string License { get; set; } = "";
+    public string Created { get; set; } = "";
+
+    [MarkoutPropertyName("Last Push")]
+    public string LastPush { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    [MarkoutSkipDefault]
+    public Callout ArchivedWarning { get; set; }
+
+    [MarkoutIgnoreInTable]
+    [MarkoutSkipDefault]
+    public Callout NoLicenseWarning { get; set; }
+
+    [MarkoutSection(Name = "Languages")]
+    [MarkoutIgnoreInTable]
+    public List<Breakdown>? Languages { get; set; }
+
+    [MarkoutSection(Name = "Top Contributors")]
+    [MarkoutIgnoreInTable]
+    public List<Metric>? ContributorMetrics { get; set; }
+
+    [MarkoutSection(Name = "Top Contributors")]
+    public List<ContributorRow>? ContributorTable { get; set; }
+
+    [MarkoutSection(Name = "Releases")]
+    public List<ReleaseRow>? Releases { get; set; }
+
+    [MarkoutSection(Name = "Preview Releases")]
+    public List<ReleaseRow>? PreviewReleases { get; set; }
+}
+
+[MarkoutSerializable]
+public class ContributorRow
+{
+    public string Login { get; set; } = "";
+    [MarkoutDisplayFormat("{0:N0}")]
+    public int Contributions { get; set; }
+}
+
+[MarkoutSerializable]
+public class ReleaseRow
+{
+    public string Tag { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Published { get; set; } = "";
+}
+
+[MarkoutContext(typeof(RepoView))]
+[MarkoutContext(typeof(ContributorRow))]
+[MarkoutContext(typeof(ReleaseRow))]
+public partial class RepoContext : MarkoutSerializerContext { }
+
+// --- JSON Models ---
+
+public class RepoData
+{
+    public string? FullName { get; set; }
+    public string? Description { get; set; }
+    public int StargazersCount { get; set; }
+    public int ForksCount { get; set; }
+    public int OpenIssuesCount { get; set; }
+    public string? Language { get; set; }
+    public LicenseInfo? License { get; set; }
+    public bool Archived { get; set; }
+    public string? CreatedAt { get; set; }
+    public string? PushedAt { get; set; }
+}
+
+public class LicenseInfo
+{
+    public string? Key { get; set; }
+    public string? Name { get; set; }
+}
+
+public class Contributor
+{
+    public string? Login { get; set; }
+    public int Contributions { get; set; }
+}
+
+public class Release
+{
+    public string? TagName { get; set; }
+    public string? Name { get; set; }
+    public string? PublishedAt { get; set; }
+    public bool Prerelease { get; set; }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(RepoData))]
+[JsonSerializable(typeof(Dictionary<string, long>))]
+[JsonSerializable(typeof(List<Contributor>))]
+[JsonSerializable(typeof(List<Release>))]
+internal partial class GitHubJsonContext : JsonSerializerContext { }

--- a/src/Markout/MarkdownWriter.cs
+++ b/src/Markout/MarkdownWriter.cs
@@ -499,46 +499,39 @@ public class MarkdownWriter : MarkoutWriter
         if (items.Count == 0 || SectionExcluded || ShapeUnsupported(MarkoutShape.Breakdowns))
             return;
 
-        EnsureBlankLineIfNeeded();
-        Writer.WriteLine("```text");
-
-        // Reuse base rendering logic for the content
-        var categories = new List<string>();
-        foreach (var item in items)
-            foreach (var seg in item.Segments)
-                if (!categories.Contains(seg.Category))
-                    categories.Add(seg.Category);
-
-        var maxLabelWidth = 0;
-        var maxTotal = 0;
-        foreach (var item in items)
+        // Single breakdown: simple Category | Count | % table
+        // Multiple breakdowns: include Label column to distinguish them
+        if (items.Count == 1)
         {
-            if (item.Label.Length > maxLabelWidth) maxLabelWidth = item.Label.Length;
+            var item = items[0];
             var total = 0;
             foreach (var seg in item.Segments) total += seg.Count;
-            if (total > maxTotal) maxTotal = total;
-        }
-        if (maxTotal == 0) maxTotal = 1;
-        var effectiveBarWidth = maxBarWidth ?? Math.Min(maxTotal, 30);
+            if (total == 0) total = 1;
 
-        foreach (var item in items)
+            var headers = new[] { "Category", "Count", "%" };
+            var rows = item.Segments
+                .Where(s => s.Count > 0)
+                .Select(s => new[] { s.Category, s.Count.ToString(), $"{s.Count * 100 / total}" })
+                .ToList();
+
+            WriteTable(headers, rows);
+        }
+        else
         {
-            var rowTotal = 0;
-            foreach (var seg in item.Segments) rowTotal += seg.Count;
-            if (rowTotal == 0) rowTotal = 1;
+            var headers = new[] { "Label", "Category", "Count", "%" };
+            var rows = new List<string[]>();
+            foreach (var item in items)
+            {
+                var total = 0;
+                foreach (var seg in item.Segments) total += seg.Count;
+                if (total == 0) total = 1;
 
-            var barScale = uniformBarWidth
-                ? (double)effectiveBarWidth / rowTotal
-                : (double)effectiveBarWidth / maxTotal;
+                foreach (var seg in item.Segments.Where(s => s.Count > 0))
+                    rows.Add([item.Label, seg.Category, seg.Count.ToString(), $"{seg.Count * 100 / total}"]);
+            }
 
-            WriteBreakdownRow(item, categories, maxLabelWidth, barScale, effectiveBarWidth);
+            WriteTable(headers, rows);
         }
-
-        Writer.WriteLine();
-        WriteBreakdownLegend(categories);
-        Writer.WriteLine("```");
-        NeedsBlankLine = true;
-        HasContent = true;
     }
 
     /// <inheritdoc/>
@@ -547,40 +540,16 @@ public class MarkdownWriter : MarkoutWriter
         if (items.Count == 0 || SectionExcluded || ShapeUnsupported(MarkoutShape.Metrics))
             return;
 
-        EnsureBlankLineIfNeeded();
-        Writer.WriteLine("```text");
-        // Delegate to base rendering (which writes individual bar lines)
-        var maxValue = 0.0;
-        var maxLabelWidth = 0;
-        var maxValueWidth = 0;
-        foreach (var item in items)
-        {
-            if (item.Value > maxValue) maxValue = item.Value;
-            if (item.Label.Length > maxLabelWidth) maxLabelWidth = item.Label.Length;
-            var vw = FormatBarValue(item.Value).Length;
-            if (vw > maxValueWidth) maxValueWidth = vw;
-        }
-        if (maxValue <= 0) maxValue = 1;
-
-        foreach (var item in items)
-            WriteMetricBar(item, maxLabelWidth, maxBarWidth, maxValue, maxValueWidth);
-
-        Writer.WriteLine("```");
-        NeedsBlankLine = true;
-        HasContent = true;
+        // Render as a pipe table: Label | Value
+        var headers = new[] { "Label", "Value" };
+        var rows = items.Select(m => new[] { m.Label, FormatBarValue(m.Value) }).ToList();
+        WriteTable(headers, rows);
     }
 
     /// <inheritdoc/>
     public override void WriteVerticalMetrics(IReadOnlyList<Metric> items, int maxBarHeight = 10, int? barWidth = null)
     {
-        if (items.Count == 0 || SectionExcluded || ShapeUnsupported(MarkoutShape.Metrics))
-            return;
-
-        EnsureBlankLineIfNeeded();
-        Writer.WriteLine("```text");
-        WriteVerticalMetricsBody(items, maxBarHeight, barWidth);
-        Writer.WriteLine("```");
-        NeedsBlankLine = true;
-        HasContent = true;
+        // Same as horizontal — vertical layout is a terminal concept
+        WriteMetrics(items, maxBarHeight);
     }
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.8.1</Version>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/MarkOutWriterTests.cs
+++ b/tests/Markout.Tests/MarkOutWriterTests.cs
@@ -685,7 +685,7 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void WriteBreakdown_Markdown_WrapsInCodeFence()
+    public void WriteBreakdown_Markdown_RendersAsTable()
     {
         var writer = new MarkdownWriter();
         var items = new List<Breakdown>
@@ -695,10 +695,10 @@ public class MarkoutWriterTests
         writer.WriteBreakdown(items);
 
         var output = writer.ToString();
-        Assert.Contains("```text", output);
-        Assert.Contains("```", output);
-        Assert.Contains("v9.0", output);
-        Assert.Contains("2 Critical, 4 High", output);
+        Assert.Contains("| Category | Count | % |", output);
+        Assert.Contains("Critical", output);
+        Assert.Contains("High", output);
+        Assert.DoesNotContain("```text", output);
     }
 
     [Fact]

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -1506,7 +1506,8 @@ public class DistributionTests
         Assert.Contains("## Severity Distribution", mdf);
         Assert.Contains("Jan 2025", mdf);
         Assert.Contains("Feb 2025", mdf);
-        Assert.Contains("1 Critical, 3 High, 2 Medium", mdf);
+        Assert.Contains("Critical", mdf);
+        Assert.Contains("High", mdf);
     }
 
     [Fact]


### PR DESCRIPTION
## Breaking change

`MarkdownWriter` now renders `Metrics` and `Breakdowns` as pipe tables instead of Unicode bar charts in code fences. This improves copy-paste, screen reader accessibility, and rendering in proportional fonts.

**Markout version bumped to 0.9.0.**

## Changes

### Library
- `WriteMetrics` → `| Label | Value |` pipe table
- `WriteBreakdown` → `| Category | Count | % |` table (with `| Label |` column when multiple items)
- `WriteVerticalMetrics` delegates to `WriteMetrics`

### GitHubRepo sample
- File-based app fetching 4 GitHub API endpoints in parallel (repo, languages, contributors, releases)
- Writer-driven projection: Spectre gets bar charts, Markdown/OneLineWriter get tables
- `--format` flag (spectre/markdown/oneline) and `--section` for OneLineWriter filtering
- Uses `GetFromJsonAsync` with source-gen `JsonSerializerContext`

### Documentation
- `SKILL.md`: LLM/coding agent integration guide
- `README.md`: Real-world example, updated attribute reference, "For Coding Agents" section
- `samples/Directory.Build.props`: Shared Markout project references for all samples

### Tests
- Updated 2 tests for new table output format
- All 431 Markout + 236 MarkdownTable tests pass