### PR TITLE
feat: Add MARKOUT005 diagnostic for field/section name collisions

### DIFF
--- a/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
+++ b/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
@@ -61,4 +61,18 @@ internal static class DiagnosticDescriptors
                      "Without any such properties, the serialized output will be empty or contain only the title/description. " +
                      "Either add [MarkoutSection] to collection properties, or remove AutoFields=false."
     );
+
+    public static readonly DiagnosticDescriptor DuplicateFieldAndSectionName = new(
+        id: "MARKOUT005",
+        title: "Field and section share the same name",
+        messageFormat: "Type '{0}' has a field '{1}' and a section '{2}' with the same display name. " +
+                       "This causes ambiguity for projection queries like --select. " +
+                       "Rename one using [MarkoutPropertyName] or [MarkoutSection(Name = ...)].",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When a field and a section share the same display name (case-insensitive), " +
+                     "projection tools like --select cannot distinguish between them. " +
+                     "Use [MarkoutPropertyName] to rename the field or [MarkoutSection(Name = ...)] to rename the section."
+    );
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -177,6 +177,28 @@ internal static class TypeParser
             }
         }
 
+        // Warn if a field and a section share the same display name (ambiguous for --select)
+        var fieldNames = properties
+            .Where(p => !p.IsIgnored && !p.IsSection && p.Kind != PropertyKind.FieldCollection)
+            .Select(p => p.DisplayName)
+            .ToList();
+        var sectionNames = properties
+            .Where(p => !p.IsIgnored && p.IsSection)
+            .Select(p => p.SectionName ?? p.DisplayName)
+            .ToList();
+        foreach (var fieldName in fieldNames)
+        {
+            var collision = sectionNames.FirstOrDefault(s =>
+                string.Equals(s, fieldName, System.StringComparison.OrdinalIgnoreCase));
+            if (collision != null)
+            {
+                diagnostics.Add(new DiagnosticInfo(
+                    DiagnosticDescriptors.DuplicateFieldAndSectionName,
+                    typeSymbol.Locations.FirstOrDefault(),
+                    typeSymbol.Name, fieldName, collision));
+            }
+        }
+
         var ns = typeSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : typeSymbol.ContainingNamespace.ToDisplayString();

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/BuildResultsTests.cs
+++ b/tests/Markout.Tests/BuildResultsTests.cs
@@ -152,7 +152,7 @@ public class TestRunResult
     [MarkoutSection(Name = "Test Assemblies")]
     public List<TestAssembly>? Assemblies { get; set; }
     
-    [MarkoutSection(Name = "Failed Tests")]
+    [MarkoutSection(Name = "Failures")]
     public List<FailedTest>? FailedTestsList { get; set; }
 }
 
@@ -526,7 +526,7 @@ public class BuildResultsTests
         Assert.Contains("| MyApp.Api.Tests.dll |", mdf);
 
         // No failed tests section
-        Assert.DoesNotContain("## Failed Tests", mdf);
+        Assert.DoesNotContain("## Failures", mdf);
     }
 
     [Fact]
@@ -590,7 +590,7 @@ public class BuildResultsTests
         Assert.Contains("Failed Tests: 4", mdf);
 
         // Failed tests table
-        Assert.Contains("## Failed Tests", mdf);
+        Assert.Contains("## Failures", mdf);
         Assert.Contains("| Test Name |", mdf);
         Assert.Contains("| Class |", mdf);
         Assert.Contains("| Error |", mdf);


### PR DESCRIPTION
## Summary

Adds a new source generator diagnostic (MARKOUT005) that warns when a field and section share the same display name (case-insensitive). This causes ambiguity for projection queries like `--select`.

## Changes

- **DiagnosticDescriptors.cs** — New `DuplicateFieldAndSectionName` descriptor (MARKOUT005, Warning)
- **TypeParser.cs** — Check after property parsing: compares field DisplayNames against section SectionNames
- **BuildResultsTests.cs** — Fixed real collision: `TestRunResult` had field "Failed Tests" and section "Failed Tests". Renamed section to "Failures"

## Motivation

The `--select` projection system in dotnet-inspect needs unambiguous names to distinguish between fields, sections, and columns. This diagnostic catches collisions at build time so view models stay clean.

## Testing

All 431 tests pass. The diagnostic immediately caught a real collision in the test suite, validating its usefulness.