### PR TITLE
feat: SuppressedShapes option (0.9.2)

### DIFF
--- a/samples/GitHubRepo/GitHubRepo.cs
+++ b/samples/GitHubRepo/GitHubRepo.cs
@@ -64,7 +64,8 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
         "oneline" => new OneLineWriter(Console.Out, new MarkoutWriterOptions
         {
             IncludeDescription = false,
-            IncludeSections = options.IncludeSections ?? new HashSet<string> { "Releases" }
+            IncludeSections = options.IncludeSections ?? new HashSet<string> { "Releases" },
+            SuppressedShapes = MarkoutShape.FieldList
         }),
         _ => new SpectreWriter(AnsiConsole.Console, options),
     };
@@ -142,7 +143,6 @@ static string Truncate(string s, int max) => s.Length <= max ? s : s[..(max - 1)
 // --- View Models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
-[MarkoutIgnoreFields(nameof(OneLineWriter))]
 public class RepoView
 {
     public string Title { get; set; } = "";

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -69,6 +69,7 @@ public class MarkoutWriter
 
         _writer = writer;
         _options = options;
+        _suppressedShapes = options.SuppressedShapes;
     }
 
     /// <summary>

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -14,6 +14,7 @@ public class MarkoutWriterOptions
     private HashSet<string>? _includeSections;
     private HashSet<string>? _excludeSections;
     private MarkoutProjection? _projection;
+    private MarkoutShape _suppressedShapes;
 
     /// <summary>
     /// Gets the default options instance. This instance is read-only.
@@ -134,6 +135,21 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _projection = value;
+        }
+    }
+
+    /// <summary>
+    /// Shapes to suppress warnings for when unsupported by the writer.
+    /// Use when the caller knows the writer doesn't support certain shapes
+    /// and wants to silence the diagnostic warnings globally.
+    /// </summary>
+    public MarkoutShape SuppressedShapes
+    {
+        get => _suppressedShapes;
+        set
+        {
+            ThrowIfReadOnly();
+            _suppressedShapes = value;
         }
     }
 


### PR DESCRIPTION
Add `MarkoutWriterOptions.SuppressedShapes` for global runtime suppression of unsupported shape warnings. This is the expert opt-out — set once on writer options instead of annotating every view class with `[MarkoutIgnoreFields]`.

### Changes

- **MarkoutWriterOptions.SuppressedShapes** — `MarkoutShape` flags property for shapes to suppress warnings on
- **MarkoutWriter** — constructor initializes `_suppressedShapes` from options
- **GitHubRepo sample** — removed `[MarkoutIgnoreFields(nameof(OneLineWriter))]` on `RepoView`, uses `SuppressedShapes = MarkoutShape.FieldList` on writer options instead
- **Version** — 0.9.1 → 0.9.2

### Design

Two suppression mechanisms now exist:
1. **`[MarkoutIgnoreFields]`** — per-class, source-generator processed. For model authors.
2. **`SuppressedShapes`** — global, runtime. For app authors who know their writer and want to silence all warnings.