### PR TITLE
feat: AutoFieldsCount to limit hero summary fields (0.9.3)

### DIFF
--- a/samples/GitHubActivity/GitHubActivity.cs
+++ b/samples/GitHubActivity/GitHubActivity.cs
@@ -90,12 +90,13 @@ static string? RunCommand(string cmd, string args)
 
 // --- View Models ---
 
-[MarkoutSerializable(TitleProperty = nameof(Title))]
+[MarkoutSerializable(TitleProperty = nameof(Title), NamingPolicy = NamingPolicy.PascalCaseWords)]
+[MarkoutSkipNull]
 public record ActivityView
 {
     [MarkoutIgnore] public string Title { get; init; } = "";
     public string Name { get; init; } = "";
-    [MarkoutSkipNull] public string? Location { get; init; }
+    public string? Location { get; init; }
     [MarkoutPropertyName("Public repos")] public int PublicRepos { get; init; }
     public int Followers { get; init; }
     [MarkoutSection(Name = "Recent Activity")] public List<EventRow>? Events { get; init; }

--- a/samples/SkipNullDemo/SkipNullDemo.cs
+++ b/samples/SkipNullDemo/SkipNullDemo.cs
@@ -1,4 +1,5 @@
 // Demonstrates [MarkoutSkipNull] — optional fields are omitted when null.
+// Type-level [MarkoutSkipNull] applies to all nullable properties.
 
 using Markout;
 
@@ -15,15 +16,13 @@ var pkg = new PackageView
 MarkoutSerializer.Serialize(pkg, Console.Out, PackageContext.Default);
 
 [MarkoutSerializable(TitleProperty = nameof(Name))]
+[MarkoutSkipNull]
 public class PackageView
 {
     public string Name { get; set; } = "";
-    [MarkoutSkipNull]
     public string? License { get; set; }
-    [MarkoutSkipNull]
     public string? Repository { get; set; }
     public int Downloads { get; set; }
-    [MarkoutSkipNull]
     public int? Stars { get; set; }
 }
 

--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -168,7 +168,7 @@ internal static class CollectionEmitter
         if (skipPerItemHeading)
         {
             // Unwrapped with no title: emit each item's properties inline at the current level
-            SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel, nestingDepth + 1, prop.ElementAutoFields, prop.ElementFieldLayout);
+            SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel, nestingDepth + 1, prop.ElementAutoFields, 0, prop.ElementFieldLayout);
         }
         else
         {
@@ -211,7 +211,7 @@ internal static class CollectionEmitter
             }
 
             // Emit property serializations for each item, at a deeper level
-            SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1, prop.ElementAutoFields, prop.ElementFieldLayout);
+            SerializerEmitter.EmitPropertySerializations(sb, prop.ElementProperties, itemVar, indentLevel + 1, subsectionLevel + 1, nestingDepth + 1, prop.ElementAutoFields, 0, prop.ElementFieldLayout);
         }
 
         sb.AppendLine($"{indent}}}");

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -114,7 +114,7 @@ internal static class SerializerEmitter
             propsToRender = type.Properties.Where(p => !skip.Contains(p.Name)).ToList();
         }
 
-        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.AutoFields, type.FieldLayout, "value", type.FullTypeName);
+        EmitPropertySerializations(sb, propsToRender, "value", 2, 2, 0, type.AutoFields, type.AutoFieldsCount, type.FieldLayout, "value", type.FullTypeName);
 
         sb.AppendLine();
         sb.AppendLine("        OnSerialized(writer, value);");
@@ -260,6 +260,7 @@ internal static class SerializerEmitter
         int baseHeadingLevel = 2,
         int nestingDepth = 0,
         bool autoFields = true,
+        int autoFieldsCount = 0,
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
         string? rootValueExpr = null,
         string? rootTypeName = null)
@@ -328,10 +329,11 @@ internal static class SerializerEmitter
             }
         }
 
-        // Emit root scalars (unchanged)
+        // Emit root scalars
         if (autoFields && rootScalars.Count > 0)
         {
-            FieldEmitter.EmitScalarsWithLayout(sb, rootScalars, valueExpr, indentLevel, fieldLayout, nestingDepth);
+            var scalarsToEmit = autoFieldsCount > 0 ? rootScalars.Take(autoFieldsCount).ToList() : rootScalars;
+            FieldEmitter.EmitScalarsWithLayout(sb, scalarsToEmit, valueExpr, indentLevel, fieldLayout, nestingDepth);
         }
 
         // Build lookup for compound section props by name for ordered emission
@@ -769,7 +771,7 @@ internal static class SerializerEmitter
                     sb.AppendLine($"{indent}if ({propAccess} != null)");
                     sb.AppendLine($"{indent}{{");
                     sb.AppendLine($"{indent}    writer.WriteHeading({baseHeadingLevel}, \"{EmitHelpers.EscapeString(prop.DisplayName)}\");");
-                    EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth + 1, true, fieldLayout);
+                    EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, baseHeadingLevel + 1, nestingDepth + 1, true, 0, fieldLayout);
                     sb.AppendLine($"{indent}}}");
                 }
                 break;

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -37,6 +37,8 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public bool AutoFields { get; }
     public int AutoFieldsCount { get; }
     public FieldLayoutKind FieldLayout { get; }
+    public NamingPolicyKind NamingPolicy { get; }
+    public bool SkipNullByDefault { get; }
     public IReadOnlyList<string> IgnoreFieldsWriters { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
 
@@ -52,6 +54,8 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         bool autoFields = true,
         int autoFieldsCount = 0,
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
+        NamingPolicyKind namingPolicy = NamingPolicyKind.Default,
+        bool skipNullByDefault = false,
         IReadOnlyList<string>? ignoreFieldsWriters = null,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
@@ -66,6 +70,8 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         AutoFields = autoFields;
         AutoFieldsCount = autoFieldsCount;
         FieldLayout = fieldLayout;
+        NamingPolicy = namingPolicy;
+        SkipNullByDefault = skipNullByDefault;
         IgnoreFieldsWriters = ignoreFieldsWriters ?? Array.Empty<string>();
         Diagnostics = diagnostics ?? Array.Empty<DiagnosticInfo>();
     }
@@ -84,6 +90,8 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
                AutoFields == other.AutoFields &&
                AutoFieldsCount == other.AutoFieldsCount &&
                FieldLayout == other.FieldLayout &&
+               NamingPolicy == other.NamingPolicy &&
+               SkipNullByDefault == other.SkipNullByDefault &&
                StringSequenceEqual(IgnoreFieldsWriters, other.IgnoreFieldsWriters) &&
                SequenceEqual(Properties, other.Properties);
     }
@@ -98,6 +106,8 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
             hash = hash * 397 ^ AutoFields.GetHashCode();
             hash = hash * 397 ^ AutoFieldsCount;
             hash = hash * 397 ^ (int)FieldLayout;
+            hash = hash * 397 ^ (int)NamingPolicy;
+            hash = hash * 397 ^ SkipNullByDefault.GetHashCode();
             hash = hash * 397 ^ IgnoreFieldsWriters.Count;
             foreach (var prop in Properties)
                 hash = hash * 397 ^ prop.GetHashCode();
@@ -380,6 +390,15 @@ internal enum FieldLayoutKind
     LineBreaks = 1,
     LineBreaksDoubleSpace = 2,
     List = 3
+}
+
+/// <summary>
+/// Internal representation of NamingPolicy. Values mirror the runtime Markout.NamingPolicy enum.
+/// </summary>
+internal enum NamingPolicyKind
+{
+    Default = 0,
+    PascalCaseWords = 1
 }
 
 /// <summary>

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -35,6 +35,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public string? TitleContextProperty { get; }
     public string? DescriptionProperty { get; }
     public bool AutoFields { get; }
+    public int AutoFieldsCount { get; }
     public FieldLayoutKind FieldLayout { get; }
     public IReadOnlyList<string> IgnoreFieldsWriters { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
@@ -49,6 +50,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         string? titleContextProperty = null,
         string? descriptionProperty = null,
         bool autoFields = true,
+        int autoFieldsCount = 0,
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine,
         IReadOnlyList<string>? ignoreFieldsWriters = null,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
@@ -62,6 +64,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         TitleContextProperty = titleContextProperty;
         DescriptionProperty = descriptionProperty;
         AutoFields = autoFields;
+        AutoFieldsCount = autoFieldsCount;
         FieldLayout = fieldLayout;
         IgnoreFieldsWriters = ignoreFieldsWriters ?? Array.Empty<string>();
         Diagnostics = diagnostics ?? Array.Empty<DiagnosticInfo>();
@@ -79,6 +82,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
                TitleContextProperty == other.TitleContextProperty &&
                DescriptionProperty == other.DescriptionProperty &&
                AutoFields == other.AutoFields &&
+               AutoFieldsCount == other.AutoFieldsCount &&
                FieldLayout == other.FieldLayout &&
                StringSequenceEqual(IgnoreFieldsWriters, other.IgnoreFieldsWriters) &&
                SequenceEqual(Properties, other.Properties);
@@ -92,6 +96,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
             var hash = FullTypeName.GetHashCode();
             hash = hash * 397 ^ IsValueType.GetHashCode();
             hash = hash * 397 ^ AutoFields.GetHashCode();
+            hash = hash * 397 ^ AutoFieldsCount;
             hash = hash * 397 ^ (int)FieldLayout;
             hash = hash * 397 ^ IgnoreFieldsWriters.Count;
             foreach (var prop in Properties)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -100,6 +100,7 @@ internal static class TypeParser
         bool? autoFields = null,
         int? autoFieldsCount = null,
         FieldLayoutKind? fieldLayout = null,
+        NamingPolicyKind? namingPolicy = null,
         bool suppressTableWarnings = false)
     {
         // If titleProperty/descriptionProperty not passed, try to get them from the type's [MarkoutSerializable] attribute
@@ -123,6 +124,8 @@ internal static class TypeParser
                         autoFieldsCount ??= afc;
                     else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
                         fieldLayout ??= (FieldLayoutKind)fl;
+                    else if (named.Key == "NamingPolicy" && named.Value.Value is int np)
+                        namingPolicy ??= (NamingPolicyKind)np;
                 }
             }
         }
@@ -137,6 +140,12 @@ internal static class TypeParser
         autoFieldsCount ??= 0;
         // Default to OneLine
         fieldLayout ??= FieldLayoutKind.OneLine;
+        // Default naming policy
+        namingPolicy ??= NamingPolicyKind.Default;
+
+        // Check for type-level [MarkoutSkipNull]
+        bool skipNullByDefault = typeSymbol.GetAttributes()
+            .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipNullAttribute);
 
         // Parse [MarkoutIgnoreFields] attributes (AllowMultiple)
         var ignoreFieldsWriters = typeSymbol.GetAttributes()
@@ -166,7 +175,7 @@ internal static class TypeParser
             if (prop.GetMethod == null)
                 continue;
 
-            var propMeta = ParseProperty(prop, compilation, knownTypes, diagnostics, visitedTypes);
+            var propMeta = ParseProperty(prop, compilation, knownTypes, diagnostics, visitedTypes, namingPolicy.Value, skipNullByDefault);
             if (propMeta != null)
                 properties.Add(propMeta);
         }
@@ -229,6 +238,8 @@ internal static class TypeParser
             autoFields.Value,
             autoFieldsCount.Value,
             fieldLayout.Value,
+            namingPolicy.Value,
+            skipNullByDefault,
             ignoreFieldsWriters.Count > 0 ? ignoreFieldsWriters : null,
             filteredDiagnostics);
     }
@@ -238,7 +249,9 @@ internal static class TypeParser
         Compilation compilation,
         KnownTypeSymbols knownTypes,
         List<DiagnosticInfo> diagnostics,
-        HashSet<ITypeSymbol>? visitedTypes = null)
+        HashSet<ITypeSymbol>? visitedTypes = null,
+        NamingPolicyKind namingPolicy = NamingPolicyKind.Default,
+        bool skipNullByDefault = false)
     {
         var isIgnored = HasAttribute(prop, MarkoutIgnoreAttribute);
         var isIgnoredInTable = HasAttribute(prop, MarkoutIgnoreInTableAttribute);
@@ -303,6 +316,10 @@ internal static class TypeParser
         {
             displayName = customName;
         }
+        else if (namingPolicy == NamingPolicyKind.PascalCaseWords)
+        {
+            displayName = SplitPascalCase(displayName);
+        }
 
         // Parse [MarkoutBoolFormat] attribute
         string? boolTrueValue = null;
@@ -351,8 +368,8 @@ internal static class TypeParser
         bool skipWhenDefault = prop.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipDefaultAttribute);
 
-        // Parse [MarkoutSkipNull] attribute
-        bool skipWhenNull = prop.GetAttributes()
+        // Parse [MarkoutSkipNull] attribute (property-level or inherited from type-level)
+        bool skipWhenNull = skipNullByDefault || prop.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipNullAttribute);
 
         // Parse [MarkoutDisplayFormat] attribute
@@ -824,5 +841,33 @@ internal static class TypeParser
     {
         return symbol.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == attributeName);
+    }
+
+    /// <summary>
+    /// Splits a PascalCase identifier into space-separated words.
+    /// Example: "InformationalVersion" → "Informational Version", "PublicKeyToken" → "Public Key Token".
+    /// </summary>
+    private static string SplitPascalCase(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return name;
+
+        var sb = new System.Text.StringBuilder(name.Length + 4);
+        sb.Append(name[0]);
+
+        for (int i = 1; i < name.Length; i++)
+        {
+            if (char.IsUpper(name[i]) && !char.IsUpper(name[i - 1]))
+            {
+                sb.Append(' ');
+            }
+            else if (char.IsUpper(name[i]) && i + 1 < name.Length && !char.IsUpper(name[i + 1]))
+            {
+                // Handle acronym boundaries: "XMLParser" → "XML Parser"
+                sb.Append(' ');
+            }
+            sb.Append(name[i]);
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -98,6 +98,7 @@ internal static class TypeParser
         string? titleContextProperty = null,
         string? descriptionProperty = null,
         bool? autoFields = null,
+        int? autoFieldsCount = null,
         FieldLayoutKind? fieldLayout = null,
         bool suppressTableWarnings = false)
     {
@@ -118,14 +119,22 @@ internal static class TypeParser
                         descriptionProperty ??= dp;
                     else if (named.Key == "AutoFields" && named.Value.Value is bool af)
                         autoFields ??= af;
+                    else if (named.Key == "AutoFieldsCount" && named.Value.Value is int afc)
+                        autoFieldsCount ??= afc;
                     else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
                         fieldLayout ??= (FieldLayoutKind)fl;
                 }
             }
         }
 
+        // AutoFieldsCount > 0 implies AutoFields = true
+        if (autoFieldsCount is > 0)
+            autoFields = true;
+
         // Default to true if not specified
         autoFields ??= true;
+        // Default to 0 (unlimited)
+        autoFieldsCount ??= 0;
         // Default to OneLine
         fieldLayout ??= FieldLayoutKind.OneLine;
 
@@ -218,6 +227,7 @@ internal static class TypeParser
             titleContextProperty,
             descriptionProperty,
             autoFields.Value,
+            autoFieldsCount.Value,
             fieldLayout.Value,
             ignoreFieldsWriters.Count > 0 ? ignoreFieldsWriters : null,
             filteredDiagnostics);

--- a/src/Markout/Attributes/MarkoutSerializableAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSerializableAttribute.cs
@@ -34,6 +34,14 @@ public sealed class MarkoutSerializableAttribute : Attribute
     public bool AutoFields { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the maximum number of scalar properties to render as auto-fields.
+    /// When set to a positive value, only the first N scalar properties (in declaration order)
+    /// are rendered as the hero summary. Implies AutoFields = true.
+    /// Default is 0 (all scalar properties).
+    /// </summary>
+    public int AutoFieldsCount { get; set; }
+
+    /// <summary>
     /// Gets or sets the layout for scalar fields.
     /// Default is OneLine (pipe-separated on a single line).
     /// </summary>

--- a/src/Markout/Attributes/MarkoutSerializableAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSerializableAttribute.cs
@@ -46,4 +46,11 @@ public sealed class MarkoutSerializableAttribute : Attribute
     /// Default is OneLine (pipe-separated on a single line).
     /// </summary>
     public FieldLayout FieldLayout { get; set; } = FieldLayout.OneLine;
+
+    /// <summary>
+    /// Gets or sets the naming policy for transforming property names into display names.
+    /// Only applies to properties without an explicit [MarkoutPropertyName] attribute.
+    /// Default is Default (use property name as-is).
+    /// </summary>
+    public NamingPolicy NamingPolicy { get; set; } = NamingPolicy.Default;
 }

--- a/src/Markout/Attributes/MarkoutSkipNullAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSkipNullAttribute.cs
@@ -7,7 +7,7 @@ namespace Markout;
 /// Unlike <see cref="MarkoutSkipDefaultAttribute"/>, this does not skip non-null default values
 /// like <c>false</c> for <see langword="bool"/> or <c>0</c> for <see langword="int"/>.
 /// </summary>
-[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
 public sealed class MarkoutSkipNullAttribute : Attribute
 {
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.9.2</Version>
+    <Version>0.9.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/src/Markout/NamingPolicy.cs
+++ b/src/Markout/NamingPolicy.cs
@@ -1,0 +1,18 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies how property names are transformed into display names.
+/// </summary>
+public enum NamingPolicy
+{
+    /// <summary>
+    /// Use the property name as-is (or [MarkoutPropertyName] if specified).
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Split PascalCase into separate words.
+    /// Example: InformationalVersion → "Informational Version", PublicKeyToken → "Public Key Token".
+    /// </summary>
+    PascalCaseWords
+}

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -337,6 +337,31 @@ public class SerializerTests
     }
 
     [Fact]
+    public void Serialize_AutoFieldsCount_OnlyRendersFirstNScalars()
+    {
+        var data = new AutoFieldsCountTest
+        {
+            Name = "MyLib",
+            Version = "1.0.0",
+            Framework = "net9.0",
+            Architecture = "x64",
+            Company = "Contoso"
+        };
+
+        var context = new AutoFieldsCountTestContext();
+        var mdf = context.Serialize(data);
+
+        // First 3 fields should be present
+        Assert.Contains("MyLib", mdf);
+        Assert.Contains("1.0.0", mdf);
+        Assert.Contains("net9.0", mdf);
+
+        // Fields beyond count should NOT be present
+        Assert.DoesNotContain("x64", mdf);
+        Assert.DoesNotContain("Contoso", mdf);
+    }
+
+    [Fact]
     public void Context_DefaultInstance_HasReadOnlyOptions()
     {
         var context = TestMarkoutContext.Default;
@@ -1557,6 +1582,22 @@ public class AutoFieldsWarningTest
     // No [MarkoutSection] or FieldCollection properties - output will be empty
 }
 #pragma warning restore MARKOUT004
+
+// Test type for AutoFieldsCount — only first N scalar properties rendered as hero fields
+[MarkoutSerializable(AutoFieldsCount = 3)]
+public class AutoFieldsCountTest
+{
+    public string Name { get; set; } = "";
+    public string Version { get; set; } = "";
+    public string Framework { get; set; } = "";
+    public string Architecture { get; set; } = "";
+    public string Company { get; set; } = "";
+}
+
+[MarkoutContext(typeof(AutoFieldsCountTest))]
+public partial class AutoFieldsCountTestContext : MarkoutSerializerContext
+{
+}
 
 // Enum support types
 public enum Priority { Low, Medium, High, Critical }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -362,6 +362,46 @@ public class SerializerTests
     }
 
     [Fact]
+    public void Serialize_NamingPolicy_PascalCaseWords_SplitsNames()
+    {
+        var data = new NamingPolicyTest
+        {
+            AssemblyVersion = "1.0.0.0",
+            PublicKeyToken = "abc123",
+            TargetFramework = "net9.0"
+        };
+
+        var context = new NamingPolicyTestContext();
+        var mdf = context.Serialize(data);
+
+        // PascalCase should be split into words
+        Assert.Contains("Assembly Version", mdf);
+        Assert.Contains("Public Key Token", mdf);
+        // Explicit [MarkoutPropertyName] should take precedence
+        Assert.Contains("TFM", mdf);
+        Assert.DoesNotContain("Target Framework", mdf);
+    }
+
+    [Fact]
+    public void Serialize_TypeLevelSkipNull_SkipsNullProperties()
+    {
+        var data = new TypeLevelSkipNullTest
+        {
+            Name = "MyLib",
+            Version = null,
+            Company = "Contoso"
+        };
+
+        var context = new TypeLevelSkipNullTestContext();
+        var mdf = context.Serialize(data);
+
+        Assert.Contains("MyLib", mdf);
+        Assert.Contains("Contoso", mdf);
+        // Version is null and should be skipped due to type-level [MarkoutSkipNull]
+        Assert.DoesNotContain("Version", mdf);
+    }
+
+    [Fact]
     public void Context_DefaultInstance_HasReadOnlyOptions()
     {
         var context = TestMarkoutContext.Default;
@@ -1596,6 +1636,36 @@ public class AutoFieldsCountTest
 
 [MarkoutContext(typeof(AutoFieldsCountTest))]
 public partial class AutoFieldsCountTestContext : MarkoutSerializerContext
+{
+}
+
+// Test type for NamingPolicy — PascalCase → space-separated words
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords)]
+public class NamingPolicyTest
+{
+    public string AssemblyVersion { get; set; } = "";
+    public string PublicKeyToken { get; set; } = "";
+    [MarkoutPropertyName("TFM")]
+    public string TargetFramework { get; set; } = "";
+}
+
+[MarkoutContext(typeof(NamingPolicyTest))]
+public partial class NamingPolicyTestContext : MarkoutSerializerContext
+{
+}
+
+// Test type for type-level [MarkoutSkipNull]
+[MarkoutSerializable]
+[MarkoutSkipNull]
+public class TypeLevelSkipNullTest
+{
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+    public string? Company { get; set; }
+}
+
+[MarkoutContext(typeof(TypeLevelSkipNullTest))]
+public partial class TypeLevelSkipNullTestContext : MarkoutSerializerContext
 {
 }
 


### PR DESCRIPTION
Add `AutoFieldsCount` to `[MarkoutSerializable]` for controlling how many scalar properties render as the hero summary line.

### Problem

Views with many scalar properties (like `LibraryInspectionView` in dotnet-inspect) need a compact hero summary showing only the most important fields. Currently this requires `AutoFields = false` plus a hand-written `GetCompactFields()` method that duplicates data already available as properties.

### Solution

`AutoFieldsCount = N` renders only the first N scalar properties (in declaration order) as the hero summary via `WriteFieldList`. Properties beyond N are skipped. Setting `AutoFieldsCount > 0` implies `AutoFields = true`.

```csharp
// Only Name, Version, Framework appear in the hero summary
[MarkoutSerializable(AutoFieldsCount = 3)]
public class MyView
{
    public string Name { get; set; }      // ✅ hero
    public string Version { get; set; }   // ✅ hero  
    public string Framework { get; set; } // ✅ hero
    public string Architecture { get; set; } // ❌ skipped
    public string Company { get; set; }      // ❌ skipped
}
```

### Changes

- `MarkoutSerializableAttribute.AutoFieldsCount` — new int property (default 0 = all)
- `TypeParser` — parses the attribute, implies AutoFields when > 0
- `TypeMetadata` — stores the count
- `SerializerEmitter` — truncates rootScalars via `.Take(count)`
- Test: verifies first 3 of 5 scalars render, last 2 skipped
- Version 0.9.2 → 0.9.3