### PR TITLE
fix: Serialize Console.Error-dependent tests to prevent race conditions

### DIFF
--- a/tests/Markout.Tests/DiagramWriterTests.cs
+++ b/tests/Markout.Tests/DiagramWriterTests.cs
@@ -2,6 +2,7 @@ using Markout;
 
 namespace Markout.Tests;
 
+[Collection("ConsoleError")]
 public class DiagramWriterTests
 {
     [Fact]

--- a/tests/Markout.Tests/IgnoreColumnWhenTests.cs
+++ b/tests/Markout.Tests/IgnoreColumnWhenTests.cs
@@ -112,6 +112,7 @@ public partial class IgnoreColumnWhenTestContext : MarkoutSerializerContext
 
 // --- Tests ---
 
+[Collection("ConsoleError")]
 public class IgnoreColumnWhenTests
 {
     [Fact]

--- a/tests/Markout.Tests/IgnoreFieldsTests.cs
+++ b/tests/Markout.Tests/IgnoreFieldsTests.cs
@@ -41,6 +41,7 @@ public partial class IgnoreFieldsTestContext : MarkoutSerializerContext
 
 // --- Tests ---
 
+[Collection("ConsoleError")]
 public class IgnoreFieldsTests
 {
     [Fact]

--- a/tests/Markout.Tests/OneLineWriterTests.cs
+++ b/tests/Markout.Tests/OneLineWriterTests.cs
@@ -2,6 +2,7 @@ using Markout;
 
 namespace Markout.Tests;
 
+[Collection("ConsoleError")]
 public class OneLineWriterTests
 {
     [Fact]

--- a/tests/Markout.Tests/ShapeSupportTests.cs
+++ b/tests/Markout.Tests/ShapeSupportTests.cs
@@ -2,6 +2,7 @@ using Markout;
 
 namespace Markout.Tests;
 
+[Collection("ConsoleError")]
 public class ShapeSupportTests
 {
     /// <summary>


### PR DESCRIPTION
The CI failure on main (run [22372894569](https://github.com/richlander/markout/actions/runs/22372894569/job/64756142564)) was caused by a test parallelism race condition. Five test classes redirect `Console.SetError` to capture warning output, but xUnit v3 runs test classes in parallel. When two such tests run simultaneously, one overwrites the other's `Console.Error`, causing the assertion to find an empty string.

**Fix:** Add `[Collection("ConsoleError")]` to all 5 affected test classes, serializing their execution:
- `ShapeSupportTests`
- `IgnoreFieldsTests`
- `IgnoreColumnWhenTests`
- `OneLineWriterTests`
- `DiagramWriterTests`