### PR TITLE
Thread NamingPolicy, FieldLayout, and SkipNull to nested/element types

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -639,7 +639,7 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}if ({propAccess} != null)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
-            EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1);
+            EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1, autoFields: prop.ElementAutoFields, fieldLayout: prop.ElementFieldLayout);
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
         }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -585,9 +585,9 @@ internal static class TypeParser
             if (elementType.SpecialType == SpecialType.System_String)
                 return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.OneLine, true);
 
-            var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics, visitedTypes);
-            var hasNested = HasNestedContent(elementProps);
             var elementSettings = GetElementTypeSettings(elementType);
+            var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics, visitedTypes, elementSettings.NamingPolicy, elementSettings.SkipNullByDefault);
+            var hasNested = HasNestedContent(elementProps);
             return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, elementSettings.TitleProperty, elementSettings.TitleContextProperty, elementSettings.AutoFields, elementSettings.FieldLayout, true);
         }
 
@@ -696,9 +696,9 @@ internal static class TypeParser
                     if (elementType.SpecialType == SpecialType.System_String)
                         return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
 
-                    var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics, visitedTypes);
-                    var hasNested = HasNestedContent(elementProps);
                     var elementSettings = GetElementTypeSettings(elementType);
+                    var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics, visitedTypes, elementSettings.NamingPolicy, elementSettings.SkipNullByDefault);
+                    var hasNested = HasNestedContent(elementProps);
                     return (PropertyKind.ComplexArray, elementType.ToDisplayString(), elementProps, hasNested, elementSettings.TitleProperty, elementSettings.TitleContextProperty, elementSettings.AutoFields, elementSettings.FieldLayout, false);
                 }
             }
@@ -714,9 +714,10 @@ internal static class TypeParser
         // Nested object
         if (type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct)
         {
-            var props = GetTypeProperties(type, compilation, knownTypes, diagnostics, visitedTypes);
+            var nestedSettings = GetElementTypeSettings(type);
+            var props = GetTypeProperties(type, compilation, knownTypes, diagnostics, visitedTypes, nestedSettings.NamingPolicy, nestedSettings.SkipNullByDefault);
             if (props.Count > 0)
-                return (PropertyKind.NestedObject, null, props, false, null, null, true, FieldLayoutKind.OneLine, false);
+                return (PropertyKind.NestedObject, null, props, false, null, null, nestedSettings.AutoFields, nestedSettings.FieldLayout, false);
         }
 
         return (PropertyKind.Other, null, null, false, null, null, true, FieldLayoutKind.OneLine, false);
@@ -734,15 +735,16 @@ internal static class TypeParser
              (p.Kind == PropertyKind.StringArray && p.JoinSeparator == null)));
     }
 
-    private static (string? TitleProperty, string? TitleContextProperty, bool AutoFields, FieldLayoutKind FieldLayout) GetElementTypeSettings(ITypeSymbol type)
+    private static (string? TitleProperty, string? TitleContextProperty, bool AutoFields, FieldLayoutKind FieldLayout, NamingPolicyKind NamingPolicy, bool SkipNullByDefault) GetElementTypeSettings(ITypeSymbol type)
     {
         if (type is not INamedTypeSymbol namedType)
-            return (null, null, true, FieldLayoutKind.OneLine);
+            return (null, null, true, FieldLayoutKind.OneLine, NamingPolicyKind.Default, false);
 
         string? titleProperty = null;
         string? titleContextProperty = null;
         bool autoFields = true;
         FieldLayoutKind fieldLayout = FieldLayoutKind.OneLine;
+        NamingPolicyKind namingPolicy = NamingPolicyKind.Default;
 
         var serializableAttr = namedType.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutSerializableAttribute);
@@ -759,10 +761,15 @@ internal static class TypeParser
                     autoFields = af;
                 else if (named.Key == "FieldLayout" && named.Value.Value is int fl)
                     fieldLayout = (FieldLayoutKind)fl;
+                else if (named.Key == "NamingPolicy" && named.Value.Value is int np)
+                    namingPolicy = (NamingPolicyKind)np;
             }
         }
 
-        return (titleProperty, titleContextProperty, autoFields, fieldLayout);
+        bool skipNullByDefault = namedType.GetAttributes()
+            .Any(a => a.AttributeClass?.ToDisplayString() == MarkoutSkipNullAttribute);
+
+        return (titleProperty, titleContextProperty, autoFields, fieldLayout, namingPolicy, skipNullByDefault);
     }
 
     private static IReadOnlyList<PropertyMetadata> GetTypeProperties(
@@ -770,7 +777,9 @@ internal static class TypeParser
         Compilation compilation,
         KnownTypeSymbols? knownTypes = null,
         List<DiagnosticInfo>? diagnostics = null,
-        HashSet<ITypeSymbol>? visitedTypes = null)
+        HashSet<ITypeSymbol>? visitedTypes = null,
+        NamingPolicyKind namingPolicy = NamingPolicyKind.Default,
+        bool skipNullByDefault = false)
     {
         var properties = new List<PropertyMetadata>();
         diagnostics ??= new List<DiagnosticInfo>();
@@ -797,7 +806,7 @@ internal static class TypeParser
                 if (prop.GetMethod == null)
                     continue;
 
-                var propMeta = ParseProperty(prop, compilation, knownTypes, diagnostics, visitedTypes);
+                var propMeta = ParseProperty(prop, compilation, knownTypes, diagnostics, visitedTypes, namingPolicy, skipNullByDefault);
                 if (propMeta != null)
                     properties.Add(propMeta);
             }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.9.3</Version>
+    <Version>0.9.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -256,6 +256,45 @@ public class Person
         public string Value7 { get; set; } = "";
     }
 
+    // Nested object with NamingPolicy and FieldLayout on the nested type
+    [MarkoutSerializable(TitleProperty = nameof(FileName))]
+    public class LibraryReport
+    {
+        public string FileName { get; set; } = "";
+
+        [MarkoutSection(Name = "Library Info")]
+        public LibraryInfoSection? Info { get; set; }
+    }
+
+    [MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.LineBreaks)]
+    [MarkoutSkipNull]
+    public class LibraryInfoSection
+    {
+        public string? Name { get; set; }
+        public string? Version { get; set; }
+        public string? InformationalVersion { get; set; }
+        public string? AssemblyVersion { get; set; }
+        public string? TargetFramework { get; set; }
+    }
+
+    // Nested object in a collection with NamingPolicy
+    [MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords)]
+    public class AttributeRow
+    {
+        public string Name { get; set; } = "";
+        public string TargetKind { get; set; } = "";
+        public string AttributeValue { get; set; } = "";
+    }
+
+    [MarkoutSerializable(TitleProperty = nameof(Title))]
+    public class AttributeReport
+    {
+        public string Title { get; set; } = "";
+
+        [MarkoutSection(Name = "Custom Attributes")]
+        public List<AttributeRow>? Attributes { get; set; }
+    }
+
 #endregion
 
 #region Nested Structure Test Context
@@ -270,6 +309,8 @@ public class Person
 [MarkoutContext(typeof(OrgNode))]
 [MarkoutContext(typeof(CycleDepartment))]
 [MarkoutContext(typeof(Level1))]
+[MarkoutContext(typeof(LibraryReport))]
+[MarkoutContext(typeof(AttributeReport))]
 public partial class NestedTestContext : MarkoutSerializerContext
 {
 }
@@ -1862,5 +1903,103 @@ public class UnwrapTests
 
         Assert.Contains("# Clean", md);
         Assert.DoesNotContain("##", md);
+    }
+
+    [Fact]
+    public void NestedObject_RespectsNamingPolicy_PascalCaseWords()
+    {
+        var report = new LibraryReport
+        {
+            FileName = "System.Text.Json.dll",
+            Info = new LibraryInfoSection
+            {
+                Name = "System.Text.Json",
+                Version = "11.0.0",
+                InformationalVersion = "11.0.0+abc123",
+                AssemblyVersion = "11.0.0.0",
+                TargetFramework = ".NETCoreApp,Version=v11.0"
+            }
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedTestContext.Default);
+
+        // NamingPolicy should split PascalCase into words
+        Assert.Contains("Informational Version", md);
+        Assert.Contains("Assembly Version", md);
+        Assert.Contains("Target Framework", md);
+        // Should NOT contain unsplit names
+        Assert.DoesNotContain("InformationalVersion", md);
+        Assert.DoesNotContain("AssemblyVersion", md);
+        Assert.DoesNotContain("TargetFramework", md);
+    }
+
+    [Fact]
+    public void NestedObject_RespectsFieldLayout_LineBreaks()
+    {
+        var report = new LibraryReport
+        {
+            FileName = "System.Text.Json.dll",
+            Info = new LibraryInfoSection
+            {
+                Name = "System.Text.Json",
+                Version = "11.0.0",
+                AssemblyVersion = "11.0.0.0",
+            }
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedTestContext.Default);
+
+        // LineBreaks layout renders fields individually (one per line), not pipe-delimited
+        Assert.Contains("Name: System.Text.Json", md);
+        Assert.Contains("Version: 11.0.0", md);
+        Assert.Contains("Assembly Version: 11.0.0.0", md);
+        // Should NOT contain pipe-delimited format
+        Assert.DoesNotContain("Name: System.Text.Json |", md);
+    }
+
+    [Fact]
+    public void NestedObject_SkipNull_HidesNullFields()
+    {
+        var report = new LibraryReport
+        {
+            FileName = "Test.dll",
+            Info = new LibraryInfoSection
+            {
+                Name = "Test",
+                Version = "1.0.0",
+                // InformationalVersion, AssemblyVersion, TargetFramework are null
+            }
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedTestContext.Default);
+
+        Assert.Contains("Name: Test", md);
+        Assert.Contains("Version: 1.0.0", md);
+        // Null fields should be skipped
+        Assert.DoesNotContain("Informational Version", md);
+        Assert.DoesNotContain("Assembly Version", md);
+        Assert.DoesNotContain("Target Framework", md);
+    }
+
+    [Fact]
+    public void ComplexArray_RespectsNamingPolicy_PascalCaseWords()
+    {
+        var report = new AttributeReport
+        {
+            Title = "Attributes",
+            Attributes = [
+                new AttributeRow { Name = "CLSCompliant", TargetKind = "Assembly", AttributeValue = "true" },
+                new AttributeRow { Name = "Extension", TargetKind = "Assembly", AttributeValue = "" },
+            ]
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedTestContext.Default);
+
+        // Table column headers should have PascalCase split
+        Assert.Contains("Target Kind", md);
+        Assert.Contains("Attribute Value", md);
+        // Should NOT contain unsplit names
+        Assert.DoesNotContain("TargetKind", md);
+        Assert.DoesNotContain("AttributeValue", md);
     }
 }


### PR DESCRIPTION
Previously, `[MarkoutSerializable]` attributes on nested object and collection element types had their `NamingPolicy`, `FieldLayout`, and `[MarkoutSkipNull]` settings ignored. The source generator would fall back to defaults (no PascalCase splitting, OneLine layout, no skip-null).

### Changes

**TypeParser.cs:**
- `GetElementTypeSettings` now also reads `NamingPolicy` and `[MarkoutSkipNull]` from the nested type
- `GetTypeProperties` accepts and passes `namingPolicy` and `skipNullByDefault` to `ParseProperty`
- `NestedObject` classification calls `GetElementTypeSettings` instead of hardcoding `OneLine`/`AutoFields` defaults
- Both `ComplexArray` code paths pass naming policy to `GetTypeProperties`

**SerializerEmitter.cs:**
- `EmitSectionBody` passes `ElementAutoFields` and `ElementFieldLayout` when emitting nested object sections

### Enables

Declarative section types like:
```csharp
[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.LineBreaks)]
[MarkoutSkipNull]
public class LibraryInfoSection
{
    public string? Name { get; set; }
    public string? AssemblyVersion { get; set; }
}
```

Which renders as `Assembly Version: 11.0.0.0` with line breaks instead of `AssemblyVersion: 11.0.0.0` in a pipe-delimited field list.

### Tests

4 new tests covering NamingPolicy, FieldLayout, SkipNull on nested objects and NamingPolicy on collection elements. All 438 tests pass.