### PR TITLE
Fix SkipNull with non-nullable value types in LineBreaks/List emitters

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -206,12 +206,14 @@ internal static class FieldEmitter
             bool needsSkipNull = !needsSkipDefault && prop.SkipWhenNull && !prop.IsNullableValueType
                 && prop.Kind != PropertyKind.String
                 && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            bool emittedSkipBlock = false;
             if (needsSkipDefault)
             {
                 var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
                 sb.AppendLine($"{emitIndent}if ({condition})");
                 sb.AppendLine($"{emitIndent}{{");
                 emitIndent = emitIndent + "    ";
+                emittedSkipBlock = true;
             }
             else if (needsSkipNull)
             {
@@ -221,6 +223,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{emitIndent}if ({condition})");
                     sb.AppendLine($"{emitIndent}{{");
                     emitIndent = emitIndent + "    ";
+                    emittedSkipBlock = true;
                 }
             }
 
@@ -343,7 +346,7 @@ internal static class FieldEmitter
                 sb.AppendLine($"{emitIndent}writer.{methodName}(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess});");
             }
 
-            if (needsSkipDefault || needsSkipNull)
+            if (emittedSkipBlock)
             {
                 sb.AppendLine($"{(hasShowWhen ? indent + "    " : indent)}}}");
             }
@@ -399,12 +402,14 @@ internal static class FieldEmitter
             bool needsSkipNull = !needsSkipDefault && prop.SkipWhenNull && !prop.IsNullableValueType
                 && prop.Kind != PropertyKind.String
                 && !(prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            bool emittedSkipBlock = false;
             if (needsSkipDefault)
             {
                 var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
                 sb.AppendLine($"{emitIndent}if ({condition})");
                 sb.AppendLine($"{emitIndent}{{");
                 emitIndent = emitIndent + "    ";
+                emittedSkipBlock = true;
             }
             else if (needsSkipNull)
             {
@@ -414,6 +419,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{emitIndent}if ({condition})");
                     sb.AppendLine($"{emitIndent}{{");
                     emitIndent = emitIndent + "    ";
+                    emittedSkipBlock = true;
                 }
             }
 
@@ -476,7 +482,7 @@ internal static class FieldEmitter
                 sb.AppendLine($"{emitIndent}writer.WriteListItem($\"{EmitHelpers.EscapeString(prop.DisplayName)}: {{{valueStr}}}\");");
             }
 
-            if (needsSkipDefault || needsSkipNull)
+            if (emittedSkipBlock)
             {
                 sb.AppendLine($"{(hasShowWhen ? indent + "    " : indent)}}}");
             }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.9.4</Version>
+    <Version>0.9.5</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -275,6 +275,10 @@ public class Person
         public string? InformationalVersion { get; set; }
         public string? AssemblyVersion { get; set; }
         public string? TargetFramework { get; set; }
+        [MarkoutBoolFormat("Yes", "No")]
+        public bool Deterministic { get; set; }
+        [MarkoutBoolFormat("Yes", "No")]
+        public bool Reproducible { get; set; }
     }
 
     // Nested object in a collection with NamingPolicy
@@ -2001,5 +2005,30 @@ public class UnwrapTests
         // Should NOT contain unsplit names
         Assert.DoesNotContain("TargetKind", md);
         Assert.DoesNotContain("AttributeValue", md);
+    }
+
+    [Fact]
+    public void NestedObject_BoolWithSkipNull_DoesNotCorruptOutput()
+    {
+        var report = new LibraryReport
+        {
+            FileName = "Test.dll",
+            Info = new LibraryInfoSection
+            {
+                Name = "Test",
+                Version = "1.0.0",
+                Deterministic = true,
+                Reproducible = false,
+            }
+        };
+
+        var md = MarkoutSerializer.Serialize(report, NestedTestContext.Default);
+
+        // Bool fields should render with custom format despite class-level [MarkoutSkipNull]
+        Assert.Contains("Deterministic: Yes", md);
+        Assert.Contains("Reproducible: No", md);
+        // Null strings should still be skipped
+        Assert.DoesNotContain("Informational Version", md);
+        Assert.DoesNotContain("Assembly Version", md);
     }
 }


### PR DESCRIPTION
When a class has `[MarkoutSkipNull]` and contains non-nullable value type properties (bool, int, etc.), the LineBreaks and List emitters would emit a closing brace without a matching opening brace, producing uncompilable source.

### Root cause

`GetNonNullCondition` correctly returns `null` for non-nullable value types (they can't be null), so the skip-null `if` block is not opened. However, the closing brace was emitted unconditionally based on `needsSkipNull` being true.

### Fix

Track whether the skip block was actually opened with a new `emittedSkipBlock` flag. Only emit the closing brace when the block was opened. Applied to both `EmitLineBreaksScalars` and `EmitListScalars`.

### Test

Added test: `NestedObject_BoolWithSkipNull_DoesNotCorruptOutput` — verifies bool properties with `[MarkoutBoolFormat]` inside a `[MarkoutSkipNull]` class render correctly.

Also bumps version to 0.9.5.