### PR TITLE
Remove MARKOUT005 diagnostic

### DIFF
--- a/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
+++ b/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
@@ -62,17 +62,4 @@ internal static class DiagnosticDescriptors
                      "Either add [MarkoutSection] to collection properties, or remove AutoFields=false."
     );
 
-    public static readonly DiagnosticDescriptor DuplicateFieldAndSectionName = new(
-        id: "MARKOUT005",
-        title: "Field and section share the same name",
-        messageFormat: "Type '{0}' has a field '{1}' and a section '{2}' with the same display name. " +
-                       "This causes ambiguity for projection queries like --select. " +
-                       "Rename one using [MarkoutPropertyName] or [MarkoutSection(Name = ...)].",
-        category: Category,
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        description: "When a field and a section share the same display name (case-insensitive), " +
-                     "projection tools like --select cannot distinguish between them. " +
-                     "Use [MarkoutPropertyName] to rename the field or [MarkoutSection(Name = ...)] to rename the section."
-    );
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -195,28 +195,6 @@ internal static class TypeParser
             }
         }
 
-        // Warn if a field and a section share the same display name (ambiguous for --select)
-        var fieldNames = properties
-            .Where(p => !p.IsIgnored && !p.IsSection && p.Kind != PropertyKind.FieldCollection)
-            .Select(p => p.DisplayName)
-            .ToList();
-        var sectionNames = properties
-            .Where(p => !p.IsIgnored && p.IsSection)
-            .Select(p => p.SectionName ?? p.DisplayName)
-            .ToList();
-        foreach (var fieldName in fieldNames)
-        {
-            var collision = sectionNames.FirstOrDefault(s =>
-                string.Equals(s, fieldName, System.StringComparison.OrdinalIgnoreCase));
-            if (collision != null)
-            {
-                diagnostics.Add(new DiagnosticInfo(
-                    DiagnosticDescriptors.DuplicateFieldAndSectionName,
-                    typeSymbol.Locations.FirstOrDefault(),
-                    typeSymbol.Name, fieldName, collision));
-            }
-        }
-
         var ns = typeSymbol.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : typeSymbol.ContainingNamespace.ToDisplayString();

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.9.6</Version>
+    <Version>0.9.7</Version>
   </PropertyGroup>
 
   <!-- Include source generator in this package -->


### PR DESCRIPTION
## Problem

MARKOUT005 warned when a field and section shared the same display name. In practice, every instance was a false positive:

1. **Summary/detail pairs** — scalar counts (`Methods: 103`) and detail tables (`## Methods`) intentionally share names for different verbosity levels
2. **Column visibility variants** — multiple section properties with the same name but different `IgnoreProperty` settings (e.g. `ConstructorRows` and `ConstructorRowsWithDocs` both named "Constructors")
3. **AutoFields = false** — fields used only as titles never render as standalone fields

The only real naming collision found (`Source` origin string vs `Source` decompiled code section) was a code smell fixed by refactoring, not something a static name-match diagnostic could reliably catch.

## Changes

- Remove MARKOUT005 diagnostic descriptor and detection logic
- Bump version to 0.9.7