### PR TITLE
Rename formatters to *Formatter, update docs for capability interfaces architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,23 +218,23 @@ new CodeSection("csharp", "public class Foo { }")                 // verbatim co
 
 ## Renderers
 
-Markout ships four renderers. The serializer writes through `MarkoutWriter` — swap the writer, change the output.
+Markout ships four formatters. The serializer writes through `MarkoutWriter` (the orchestrator) — swap the formatter, change the output.
 
-| Renderer | Output | Use case |
+| Formatter | Output | Use case |
 |---|---|---|
 | **MarkdownFormatter** | GitHub-Flavored Markdown | Documentation, LLM tool output, rendered reports |
-| **MarkoutWriter** | Plain text, space-padded | Log files, piped output, terminals without ANSI |
+| **UnicodeWriter** | Plain text, space-padded | Log files, piped output, terminals without ANSI |
 | **OneLineFormatter** | Tables only, no headings | Compact summaries, grep-friendly output |
 | **DiagramWriter** | Trees and structural diagrams | Dependency graphs, file trees |
 
 Optional packages:
 
-| Package | Renderer | Use case |
+| Package | Formatter | Use case |
 |---|---|---|
 | **Markout.Ansi** | `AnsiWriter` | Colored terminal output with bold, gradients |
 | **Markout.Ansi.Spectre** | `SpectreWriter` | Rich terminal UI via Spectre.Console |
 
-Renderers declare which shapes they support via `SupportedShapes`. Unsupported shapes are silently skipped — the data is never lost, only the visual sophistication changes.
+Formatters declare which shapes they support by implementing capability interfaces (`ITableFormatter`, `IFieldFormatter`, `ITreeFormatter`, etc.). Unsupported shapes are silently skipped — the data is never lost, only the visual sophistication changes.
 
 ## Templates
 
@@ -278,8 +278,8 @@ template.Bind("commit-table", commitData);
 // Markdown output
 Console.WriteLine(template.Render(new MarkoutWriterOptions { PrettyTables = true }));
 
-// Plain text output — same template, different writer
-var plainWriter = new MarkoutWriter();
+// Plain text output — same template, different formatter
+var plainWriter = new MarkoutWriter(Console.Out, new UnicodeWriter());
 template.Render(plainWriter);
 ```
 
@@ -330,19 +330,17 @@ var options = new MarkoutWriterOptions
     IncludeSections = new HashSet<string> { "Summary", "Errors" },  // only these sections
     BoldFieldNames = true
 };
-var writer = new MarkdownFormatter(Console.Out, options);
+MarkoutSerializer.Serialize(view, Console.Out, new MarkdownFormatter(), context, options);
 ```
 
-**Layer 3 — Renderer Subclass** (code): Override any shape for custom visual treatment.
+**Layer 3 — Custom Formatter** (code): Implement capability interfaces for custom rendering.
 
 ```csharp
-public class MyWriter : MarkdownFormatter
+public class MyFormatter : IMarkoutFormatter, IFieldFormatter, ITableFormatter
 {
-    protected override void WriteDescription(Description item)
-    {
-        // Custom rendering for descriptions
-        Writer.WriteLine($"{item.Term}: {item.Text}");
-    }
+    // Implement only the interfaces your formatter supports
+    void IFieldFormatter.FormatFieldName(TextWriter w, string key, bool bold) { ... }
+    void ITableFormatter.FormatTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows, MarkoutWriterOptions options) { ... }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,16 +223,16 @@ Markout ships four formatters. The serializer writes through `MarkoutWriter` (th
 | Formatter | Output | Use case |
 |---|---|---|
 | **MarkdownFormatter** | GitHub-Flavored Markdown | Documentation, LLM tool output, rendered reports |
-| **UnicodeWriter** | Plain text, space-padded | Log files, piped output, terminals without ANSI |
+| **UnicodeFormatter** | Plain text, space-padded | Log files, piped output, terminals without ANSI |
 | **OneLineFormatter** | Tables only, no headings | Compact summaries, grep-friendly output |
-| **DiagramWriter** | Trees and structural diagrams | Dependency graphs, file trees |
+| **DiagramFormatter** | Trees and structural diagrams | Dependency graphs, file trees |
 
 Optional packages:
 
 | Package | Formatter | Use case |
 |---|---|---|
-| **Markout.Ansi** | `AnsiWriter` | Colored terminal output with bold, gradients |
-| **Markout.Ansi.Spectre** | `SpectreWriter` | Rich terminal UI via Spectre.Console |
+| **Markout.Ansi** | `AnsiFormatter` | Colored terminal output with bold, gradients |
+| **Markout.Ansi.Spectre** | `SpectreFormatter` | Rich terminal UI via Spectre.Console |
 
 Formatters declare which shapes they support by implementing capability interfaces (`ITableFormatter`, `IFieldFormatter`, `ITreeFormatter`, etc.). Unsupported shapes are silently skipped — the data is never lost, only the visual sophistication changes.
 
@@ -279,7 +279,7 @@ template.Bind("commit-table", commitData);
 Console.WriteLine(template.Render(new MarkoutWriterOptions { PrettyTables = true }));
 
 // Plain text output — same template, different formatter
-var plainWriter = new MarkoutWriter(Console.Out, new UnicodeWriter());
+var plainWriter = new MarkoutWriter(Console.Out, new UnicodeFormatter());
 template.Render(plainWriter);
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -161,7 +161,7 @@ MarkoutSerializer.Serialize(view, Console.Out, new MarkdownFormatter(), context)
 // Spectre terminal — colored, interactive
 using Markout.Ansi.Spectre;
 using Spectre.Console;
-MarkoutSerializer.Serialize(view, Console.Out, new SpectreWriter(AnsiConsole.Console), context);
+MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.Console), context);
 
 // One-line — compact table, grep-friendly
 MarkoutSerializer.Serialize(view, Console.Out, new OneLineFormatter(), context);
@@ -175,7 +175,7 @@ var options = new MarkoutWriterOptions
 MarkoutSerializer.Serialize(view, Console.Out, new OneLineFormatter(), context, options);
 
 // Plain text — log files, piped output
-MarkoutSerializer.Serialize(view, Console.Out, new UnicodeWriter(), context);
+MarkoutSerializer.Serialize(view, Console.Out, new UnicodeFormatter(), context);
 ```
 
 ## Common Recipe: JSON API to Report

--- a/SKILL.md
+++ b/SKILL.md
@@ -149,22 +149,22 @@ public CodeSection? SourceCode { get; set; }
 // Usage: new CodeSection("csharp", "public class Foo { }")
 ```
 
-## Choosing a Renderer
+## Choosing a Formatter
 
 ```csharp
 // Markdown (default) — documentation, LLM output, reports
 MarkoutSerializer.Serialize(view, Console.Out, context);
 
-// Markdown with writer instance
-MarkoutSerializer.Serialize(view, new MarkdownFormatter(Console.Out), context);
+// Markdown with explicit formatter
+MarkoutSerializer.Serialize(view, Console.Out, new MarkdownFormatter(), context);
 
 // Spectre terminal — colored, interactive
 using Markout.Ansi.Spectre;
 using Spectre.Console;
-MarkoutSerializer.Serialize(view, new SpectreWriter(AnsiConsole.Console), context);
+MarkoutSerializer.Serialize(view, Console.Out, new SpectreWriter(AnsiConsole.Console), context);
 
 // One-line — compact table, grep-friendly
-MarkoutSerializer.Serialize(view, new OneLineFormatter(Console.Out), context);
+MarkoutSerializer.Serialize(view, Console.Out, new OneLineFormatter(), context);
 
 // One-line with section filter — show only one table
 var options = new MarkoutWriterOptions
@@ -172,10 +172,10 @@ var options = new MarkoutWriterOptions
     IncludeDescription = false,
     IncludeSections = new HashSet<string> { "Results" }
 };
-MarkoutSerializer.Serialize(view, new OneLineFormatter(Console.Out, options), context);
+MarkoutSerializer.Serialize(view, Console.Out, new OneLineFormatter(), context, options);
 
 // Plain text — log files, piped output
-MarkoutSerializer.Serialize(view, new MarkoutWriter(Console.Out), context);
+MarkoutSerializer.Serialize(view, Console.Out, new UnicodeWriter(), context);
 ```
 
 ## Common Recipe: JSON API to Report

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -140,7 +140,7 @@ data relationship. Fails criterion #2 (semantically distinct).
 
 ## Diagram shapes
 
-Future diagram-oriented renderers (extending DiagramWriter):
+Future diagram-oriented renderers (extending DiagramFormatter):
 
 ### FlameGraph — Deferred
 
@@ -151,9 +151,9 @@ to express meaningfully in plain text. Needs more design work.
 
 Sequential labeled time spans. Same multi-renderer concern. Needs more design work.
 
-## SpectreWriter: adopt Spectre widgets for tables
+## SpectreFormatter: adopt Spectre widgets for tables
 
-SpectreWriter currently uses `IAnsiConsole` as a character-level ANSI markup emitter
+SpectreFormatter currently uses `IAnsiConsole` as a character-level ANSI markup emitter
 and hand-renders every shape — tables, trees, bars, breakdowns, rules, panels — with
 manual padding and `█` characters. It uses none of Spectre's built-in widgets (`Table`,
 `BarChart`, `BreakdownChart`, `Tree`, `Rule`, `Panel`).

--- a/docs/design/capability-interfaces.md
+++ b/docs/design/capability-interfaces.md
@@ -321,8 +321,8 @@ All tests pass.
 - `IStreamingTableFormatter` with BeginTable/WriteRow/EndTable pattern
 - LINQ-style cascade dispatch in orchestrator (field → table → streaming fallback)
 - `BufferFieldsAsTable` removed (cascade makes it unnecessary)
-- UnicodeWriter implements `IMarkoutFormatter` + all capability interfaces
-- 13 new orchestrator tests for cascade, streaming, aggregate, and UnicodeWriter
+- UnicodeFormatter implements `IMarkoutFormatter` + all capability interfaces
+- 13 new orchestrator tests for cascade, streaming, aggregate, and UnicodeFormatter
 
 ### Phase 4a (done)
 
@@ -333,7 +333,7 @@ All tests pass.
 
 - Update serializer to target orchestrator
 - Source generator emits orchestrator API
-- AnsiWriter + SpectreWriter implement IMarkoutFormatter (pure ANSI to TextWriter)
+- AnsiFormatter + SpectreFormatter implement IMarkoutFormatter (pure ANSI to TextWriter)
 - MarkoutSerializerContext gains IMarkoutFormatter + TextWriter overloads
 - OneLineFormatter parameterless constructor for orchestrator model
 

--- a/docs/design/data-writer-model.md
+++ b/docs/design/data-writer-model.md
@@ -77,9 +77,9 @@ public abstract class MarkoutWriter
 | **MarkoutWriter** | Plain text baseline | All |
 | **MarkdownFormatter** | GitHub-flavored markdown | All |
 | **OneLineFormatter** | Compact columnar (docker-style) | Tables, Lists, Fields |
-| **UnicodeWriter** | Box-drawing characters | All |
-| **AnsiWriter** | Terminal with color | All |
-| **DiagramWriter** | Visualization specialist | Headings, Trees, Metrics |
+| **UnicodeFormatter** | Box-drawing characters | All |
+| **AnsiFormatter** | Terminal with color | All |
+| **DiagramFormatter** | Visualization specialist | Headings, Trees, Metrics |
 
 ### Shape Support and Fallback
 

--- a/docs/design/projection.md
+++ b/docs/design/projection.md
@@ -51,7 +51,7 @@ var writer = new MarkdownFormatter(options);
 // ... serialize any markout object ...
 ```
 
-Tables render only the Name and TFM columns. Scalar fields render only Version and License. Everything else is silently trimmed. The same projection works identically with `OneLineFormatter`, `AnsiWriter`, `MarkoutWriter`, or any custom renderer.
+Tables render only the Name and TFM columns. Scalar fields render only Version and License. Everything else is silently trimmed. The same projection works identically with `OneLineFormatter`, `AnsiFormatter`, `MarkoutWriter`, or any custom renderer.
 
 ### Column Selection and Reordering
 
@@ -161,7 +161,7 @@ Source Generator → emits calls → MarkoutWriter (base)
                                     └── dispatches to virtual methods
                                             ├── MarkdownFormatter
                                             ├── OneLineFormatter
-                                            ├── AnsiWriter
+                                            ├── AnsiFormatter
                                             └── ...
 ```
 

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -61,10 +61,10 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
         var terminal = new AnsiTerminal(new SystemConsole());
         IMarkoutFormatter f = format switch
         {
-            "ansi" => new AnsiWriter(terminal),
-            "spectre" => new SpectreWriter(AnsiConsole.Console),
+            "ansi" => new AnsiFormatter(terminal),
+            "spectre" => new SpectreFormatter(AnsiConsole.Console),
             "oneline" => new OneLineFormatter(),
-            "diagram" => new DiagramWriter(),
+            "diagram" => new DiagramFormatter(),
             _ => new MarkdownFormatter(),
         };
         return (f, sw);

--- a/samples/DateBars/DateBars.cs
+++ b/samples/DateBars/DateBars.cs
@@ -29,7 +29,7 @@ var view = new DateProgressView
 
 // Serialize into a Spectre panel via a StringWriter, then frame it
 var sw = new StringWriter();
-MarkoutSerializer.Serialize(view, Console.Out, new SpectreWriter(AnsiConsole.Console), DateBarsContext.Default);
+MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.Console), DateBarsContext.Default);
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
 public class DateProgressView

--- a/samples/GitHubActivity/GitHubActivity.cs
+++ b/samples/GitHubActivity/GitHubActivity.cs
@@ -46,7 +46,7 @@ var view = new ActivityView
         GetDetail(e)))]
 };
 
-MarkoutSerializer.Serialize(view, Console.Out, new SpectreWriter(AnsiConsole.Console), ActivityContext.Default);
+MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.Console), ActivityContext.Default);
 
 // --- Helpers ---
 

--- a/samples/GitHubRepo/GitHubRepo.cs
+++ b/samples/GitHubRepo/GitHubRepo.cs
@@ -63,7 +63,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     {
         "markdown" => new MarkdownFormatter(),
         "oneline" => new OneLineFormatter(),
-        _ => new SpectreWriter(AnsiConsole.Console),
+        _ => new SpectreFormatter(AnsiConsole.Console),
     };
 
     var onelineOptions = format == "oneline"

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -106,7 +106,7 @@ var view = new LatestCvesView
         : null,
     Releases = tree
 };
-MarkoutSerializer.Serialize(view, Console.Out, new SpectreWriter(AnsiConsole.Console), LatestCvesContext.Default);
+MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.Console), LatestCvesContext.Default);
 
 // --- View Model ---
 

--- a/samples/Serialization/ShapeGallery.cs
+++ b/samples/Serialization/ShapeGallery.cs
@@ -49,7 +49,7 @@ public static class ShapeGallery
             ["Renderer", "Output", "Use Case"],
             [
                 ["MarkdownFormatter", "Markdown", "Documentation, GitHub issues"],
-                ["AnsiWriter", "ANSI terminal", "CLI tools with color"],
+                ["AnsiFormatter", "ANSI terminal", "CLI tools with color"],
                 ["MarkoutWriter", "Plain text", "Log files, piping"],
                 ["OneLineFormatter", "Columnar", "Compact summaries"],
             ]);
@@ -86,7 +86,7 @@ public static class ShapeGallery
             new TreeNode("src", null,
                 new TreeNode("Markout", null, new TreeNode("MarkoutWriter.cs"), new TreeNode("MarkoutShape.cs")),
                 new TreeNode("Markout.SourceGeneration", null, new TreeNode("Parser"), new TreeNode("Emitter")),
-                new TreeNode("Markout.Ansi", null, new TreeNode("AnsiWriter.cs"))),
+                new TreeNode("Markout.Ansi", null, new TreeNode("AnsiFormatter.cs"))),
             new TreeNode("tests", null,
                 new TreeNode("Markout.Tests")));
 

--- a/samples/Serialization/ShapeWriterUsage.cs
+++ b/samples/Serialization/ShapeWriterUsage.cs
@@ -58,7 +58,7 @@ public static class ShapeWriterUsage
     public static void RenderMetrics()
     {
         #region RenderMetrics
-        var formatter = new UnicodeWriter();
+        var formatter = new UnicodeFormatter();
         var metrics = new MetricsWriter(Console.Out, formatter);
 
         metrics.WriteMetrics([

--- a/src/Markout.Ansi.Spectre/SpectreFormatter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreFormatter.cs
@@ -1,39 +1,39 @@
 using Markout.Formatting;
-using Microsoft.Extensions.Terminal;
+using Spectre.Console;
 
-namespace Markout.Ansi;
+namespace Markout.Ansi.Spectre;
 
 /// <summary>
-/// A formatter that renders output as rich ANSI terminal text.
-/// Uses bold, color, and unicode characters for human-friendly terminal output.
+/// A formatter that renders output as rich ANSI terminal text using Spectre.Console.
+/// Drop-in alternative to Markout.Ansi.AnsiFormatter for projects already using Spectre.
 /// </summary>
-public class AnsiWriter : IMarkoutFormatter,
+public class SpectreFormatter : IMarkoutFormatter,
     IDocumentFormatter, IMetricsFormatter
 {
     private const int ColumnGap = 2;
-    private readonly ITerminal _terminal;
+    private readonly IAnsiConsole _console;
 
     /// <summary>
-    /// Creates an ANSI formatter targeting the specified terminal.
+    /// Creates a Spectre formatter targeting the specified console.
     /// </summary>
-    public AnsiWriter(ITerminal terminal)
+    public SpectreFormatter(IAnsiConsole console)
     {
-        _terminal = terminal;
+        _console = console;
     }
 
     /// <summary>
-    /// Gets the terminal width for layout calculations.
+    /// Gets the console width for layout calculations.
     /// </summary>
-    private int TerminalWidth => _terminal.Width == int.MaxValue ? 80 : _terminal.Width;
+    private int ConsoleWidth => _console.Profile.Width;
     /// <summary>
-    /// Color for the heading label text. Default is <see cref="TerminalColor.White"/>.
+    /// Color for the heading label text. Default is white.
     /// </summary>
-    public TerminalColor RuleLabelColor { get; set; } = TerminalColor.White;
+    public Color RuleLabelColor { get; set; } = Color.White;
 
     /// <summary>
-    /// Color for rule lines when gradient is disabled. Default is <see cref="TerminalColor.DarkGray"/>.
+    /// Color for rule lines when gradient is disabled. Default is grey.
     /// </summary>
-    public TerminalColor RuleLineColor { get; set; } = TerminalColor.DarkGray;
+    public Color RuleLineColor { get; set; } = Color.Grey;
 
     /// <summary>
     /// Whether to render rule lines as a gradient that fades toward the edges.
@@ -45,13 +45,25 @@ public class AnsiWriter : IMarkoutFormatter,
     /// RGB color for the bright end of the gradient (nearest the label).
     /// Default is (0, 180, 180) — teal/cyan.
     /// </summary>
-    public (byte R, byte G, byte B) RuleGradientStart { get; set; } = (0, 180, 180);
+    public Color RuleGradientStart { get; set; } = new Color(0, 180, 180);
 
     /// <summary>
     /// RGB color for the dim end of the gradient (at the edges).
     /// Default is (0, 40, 50) — near-black teal.
     /// </summary>
-    public (byte R, byte G, byte B) RuleGradientEnd { get; set; } = (0, 40, 50);
+    public Color RuleGradientEnd { get; set; } = new Color(0, 40, 50);
+
+    /// <summary>
+    /// Color for bar chart bars. Default is cyan.
+    /// </summary>
+    public Color BarColor { get; set; } = Color.Cyan1;
+
+    /// <summary>
+    /// Color for bar chart value labels. Default is grey.
+    /// </summary>
+    public Color BarValueColor { get; set; } = Color.Grey;
+
+    /// <inheritdoc/>
 
     // ── Formatter Interface Implementations ──
     // Pure rendering: write ANSI escape codes directly to the TextWriter w.
@@ -60,8 +72,8 @@ public class AnsiWriter : IMarkoutFormatter,
     private static void SgrReset(TextWriter w) => w.Write("\x1b[m");
     private static void SgrBold(TextWriter w, string text) { w.Write("\x1b[1m"); w.Write(text); w.Write("\x1b[22m"); }
     private static void SgrRgb(TextWriter w, byte r, byte g, byte b) => w.Write($"\x1b[38;2;{r};{g};{b}m");
+    private static void SgrColor(TextWriter w, Color c) => SgrRgb(w, c.R, c.G, c.B);
 
-    // SGR color codes matching TerminalColor enum values
     private const int SgrCyan = 36;
     private const int SgrDarkGray = 90;
     private const int SgrRed = 31;
@@ -70,16 +82,6 @@ public class AnsiWriter : IMarkoutFormatter,
     private const int SgrMagenta = 35;
     private const int SgrBlue = 34;
     private const int SgrWhite = 37;
-
-    /// <summary>
-    /// Color for bar chart bars. Default is <see cref="TerminalColor.Cyan"/>.
-    /// </summary>
-    public TerminalColor BarColor { get; set; } = TerminalColor.Cyan;
-
-    /// <summary>
-    /// Color for bar chart values. Default is <see cref="TerminalColor.DarkGray"/>.
-    /// </summary>
-    public TerminalColor BarValueColor { get; set; } = TerminalColor.DarkGray;
 
     private static readonly int[] DistributionSgrColors = [SgrRed, SgrYellow, SgrCyan, SgrGreen, SgrMagenta, SgrBlue];
 
@@ -98,7 +100,6 @@ public class AnsiWriter : IMarkoutFormatter,
 
     void IFieldFormatter.FormatFieldName(TextWriter w, string key, bool bold)
     {
-        // ANSI formatter always bolds field names for visual emphasis
         SgrBold(w, key);
         w.Write(": ");
     }
@@ -280,7 +281,7 @@ public class AnsiWriter : IMarkoutFormatter,
         if (maxTotal == 0) return;
 
         var labelWidth = items.Max(b => b.Label.Length);
-        var barWidth = maxBarWidth ?? (TerminalWidth - labelWidth - 4);
+        var barWidth = maxBarWidth ?? (ConsoleWidth - labelWidth - 4);
         var barScale = barWidth / (double)maxTotal;
         var maxBarChars = uniformBarWidth ? (int)Math.Round(maxTotal * barScale) : 0;
 
@@ -333,13 +334,13 @@ public class AnsiWriter : IMarkoutFormatter,
             var ratio = item.Value / maxValue;
             var fullBlocks = (int)(ratio * maxBarWidth);
             var halfBlock = (ratio * maxBarWidth) - fullBlocks >= 0.5;
-            Sgr(w, (int)BarColor);
+            SgrColor(w, BarColor);
             w.Write(new string('█', fullBlocks));
             if (halfBlock) w.Write('▌');
             SgrReset(w);
             var bw = fullBlocks + (halfBlock ? 1 : 0);
             w.Write(new string(' ', maxBarWidth - bw + 1));
-            Sgr(w, (int)BarValueColor);
+            SgrColor(w, BarValueColor);
             w.Write(FormatHelper.FormatBarValue(item.Value).PadLeft(valueWidth));
             SgrReset(w);
             w.WriteLine();
@@ -353,13 +354,13 @@ public class AnsiWriter : IMarkoutFormatter,
 
     private void FormatRuleTo(TextWriter w, string title)
     {
-        int width = TerminalWidth;
+        int width = ConsoleWidth;
         string padded = $" {title} ";
         int remaining = width - padded.Length;
 
         if (remaining <= 0)
         {
-            Sgr(w, (int)RuleLabelColor);
+            SgrColor(w, RuleLabelColor);
             SgrBold(w, title);
             SgrReset(w);
             return;
@@ -369,7 +370,7 @@ public class AnsiWriter : IMarkoutFormatter,
         int right = remaining - left;
 
         FormatGradientLine(w, left, fadeInward: true);
-        Sgr(w, (int)RuleLabelColor);
+        SgrColor(w, RuleLabelColor);
         SgrBold(w, padded);
         SgrReset(w);
         FormatGradientLine(w, right, fadeInward: false);
@@ -381,14 +382,14 @@ public class AnsiWriter : IMarkoutFormatter,
 
         if (!RuleGradient)
         {
-            Sgr(w, (int)RuleLineColor);
+            SgrColor(w, RuleLineColor);
             w.Write(new string('─', length));
             SgrReset(w);
             return;
         }
 
-        var (r1, g1, b1) = RuleGradientStart;
-        var (r2, g2, b2) = RuleGradientEnd;
+        var (r1, g1, b1) = (RuleGradientStart.R, RuleGradientStart.G, RuleGradientStart.B);
+        var (r2, g2, b2) = (RuleGradientEnd.R, RuleGradientEnd.G, RuleGradientEnd.B);
 
         for (int i = 0; i < length; i++)
         {

--- a/src/Markout.Ansi/AnsiFormatter.cs
+++ b/src/Markout.Ansi/AnsiFormatter.cs
@@ -1,39 +1,39 @@
 using Markout.Formatting;
-using Spectre.Console;
+using Microsoft.Extensions.Terminal;
 
-namespace Markout.Ansi.Spectre;
+namespace Markout.Ansi;
 
 /// <summary>
-/// A formatter that renders output as rich ANSI terminal text using Spectre.Console.
-/// Drop-in alternative to Markout.Ansi.AnsiWriter for projects already using Spectre.
+/// A formatter that renders output as rich ANSI terminal text.
+/// Uses bold, color, and unicode characters for human-friendly terminal output.
 /// </summary>
-public class SpectreWriter : IMarkoutFormatter,
+public class AnsiFormatter : IMarkoutFormatter,
     IDocumentFormatter, IMetricsFormatter
 {
     private const int ColumnGap = 2;
-    private readonly IAnsiConsole _console;
+    private readonly ITerminal _terminal;
 
     /// <summary>
-    /// Creates a Spectre formatter targeting the specified console.
+    /// Creates an ANSI formatter targeting the specified terminal.
     /// </summary>
-    public SpectreWriter(IAnsiConsole console)
+    public AnsiFormatter(ITerminal terminal)
     {
-        _console = console;
+        _terminal = terminal;
     }
 
     /// <summary>
-    /// Gets the console width for layout calculations.
+    /// Gets the terminal width for layout calculations.
     /// </summary>
-    private int ConsoleWidth => _console.Profile.Width;
+    private int TerminalWidth => _terminal.Width == int.MaxValue ? 80 : _terminal.Width;
     /// <summary>
-    /// Color for the heading label text. Default is white.
+    /// Color for the heading label text. Default is <see cref="TerminalColor.White"/>.
     /// </summary>
-    public Color RuleLabelColor { get; set; } = Color.White;
+    public TerminalColor RuleLabelColor { get; set; } = TerminalColor.White;
 
     /// <summary>
-    /// Color for rule lines when gradient is disabled. Default is grey.
+    /// Color for rule lines when gradient is disabled. Default is <see cref="TerminalColor.DarkGray"/>.
     /// </summary>
-    public Color RuleLineColor { get; set; } = Color.Grey;
+    public TerminalColor RuleLineColor { get; set; } = TerminalColor.DarkGray;
 
     /// <summary>
     /// Whether to render rule lines as a gradient that fades toward the edges.
@@ -45,25 +45,13 @@ public class SpectreWriter : IMarkoutFormatter,
     /// RGB color for the bright end of the gradient (nearest the label).
     /// Default is (0, 180, 180) — teal/cyan.
     /// </summary>
-    public Color RuleGradientStart { get; set; } = new Color(0, 180, 180);
+    public (byte R, byte G, byte B) RuleGradientStart { get; set; } = (0, 180, 180);
 
     /// <summary>
     /// RGB color for the dim end of the gradient (at the edges).
     /// Default is (0, 40, 50) — near-black teal.
     /// </summary>
-    public Color RuleGradientEnd { get; set; } = new Color(0, 40, 50);
-
-    /// <summary>
-    /// Color for bar chart bars. Default is cyan.
-    /// </summary>
-    public Color BarColor { get; set; } = Color.Cyan1;
-
-    /// <summary>
-    /// Color for bar chart value labels. Default is grey.
-    /// </summary>
-    public Color BarValueColor { get; set; } = Color.Grey;
-
-    /// <inheritdoc/>
+    public (byte R, byte G, byte B) RuleGradientEnd { get; set; } = (0, 40, 50);
 
     // ── Formatter Interface Implementations ──
     // Pure rendering: write ANSI escape codes directly to the TextWriter w.
@@ -72,8 +60,8 @@ public class SpectreWriter : IMarkoutFormatter,
     private static void SgrReset(TextWriter w) => w.Write("\x1b[m");
     private static void SgrBold(TextWriter w, string text) { w.Write("\x1b[1m"); w.Write(text); w.Write("\x1b[22m"); }
     private static void SgrRgb(TextWriter w, byte r, byte g, byte b) => w.Write($"\x1b[38;2;{r};{g};{b}m");
-    private static void SgrColor(TextWriter w, Color c) => SgrRgb(w, c.R, c.G, c.B);
 
+    // SGR color codes matching TerminalColor enum values
     private const int SgrCyan = 36;
     private const int SgrDarkGray = 90;
     private const int SgrRed = 31;
@@ -82,6 +70,16 @@ public class SpectreWriter : IMarkoutFormatter,
     private const int SgrMagenta = 35;
     private const int SgrBlue = 34;
     private const int SgrWhite = 37;
+
+    /// <summary>
+    /// Color for bar chart bars. Default is <see cref="TerminalColor.Cyan"/>.
+    /// </summary>
+    public TerminalColor BarColor { get; set; } = TerminalColor.Cyan;
+
+    /// <summary>
+    /// Color for bar chart values. Default is <see cref="TerminalColor.DarkGray"/>.
+    /// </summary>
+    public TerminalColor BarValueColor { get; set; } = TerminalColor.DarkGray;
 
     private static readonly int[] DistributionSgrColors = [SgrRed, SgrYellow, SgrCyan, SgrGreen, SgrMagenta, SgrBlue];
 
@@ -100,6 +98,7 @@ public class SpectreWriter : IMarkoutFormatter,
 
     void IFieldFormatter.FormatFieldName(TextWriter w, string key, bool bold)
     {
+        // ANSI formatter always bolds field names for visual emphasis
         SgrBold(w, key);
         w.Write(": ");
     }
@@ -281,7 +280,7 @@ public class SpectreWriter : IMarkoutFormatter,
         if (maxTotal == 0) return;
 
         var labelWidth = items.Max(b => b.Label.Length);
-        var barWidth = maxBarWidth ?? (ConsoleWidth - labelWidth - 4);
+        var barWidth = maxBarWidth ?? (TerminalWidth - labelWidth - 4);
         var barScale = barWidth / (double)maxTotal;
         var maxBarChars = uniformBarWidth ? (int)Math.Round(maxTotal * barScale) : 0;
 
@@ -334,13 +333,13 @@ public class SpectreWriter : IMarkoutFormatter,
             var ratio = item.Value / maxValue;
             var fullBlocks = (int)(ratio * maxBarWidth);
             var halfBlock = (ratio * maxBarWidth) - fullBlocks >= 0.5;
-            SgrColor(w, BarColor);
+            Sgr(w, (int)BarColor);
             w.Write(new string('█', fullBlocks));
             if (halfBlock) w.Write('▌');
             SgrReset(w);
             var bw = fullBlocks + (halfBlock ? 1 : 0);
             w.Write(new string(' ', maxBarWidth - bw + 1));
-            SgrColor(w, BarValueColor);
+            Sgr(w, (int)BarValueColor);
             w.Write(FormatHelper.FormatBarValue(item.Value).PadLeft(valueWidth));
             SgrReset(w);
             w.WriteLine();
@@ -354,13 +353,13 @@ public class SpectreWriter : IMarkoutFormatter,
 
     private void FormatRuleTo(TextWriter w, string title)
     {
-        int width = ConsoleWidth;
+        int width = TerminalWidth;
         string padded = $" {title} ";
         int remaining = width - padded.Length;
 
         if (remaining <= 0)
         {
-            SgrColor(w, RuleLabelColor);
+            Sgr(w, (int)RuleLabelColor);
             SgrBold(w, title);
             SgrReset(w);
             return;
@@ -370,7 +369,7 @@ public class SpectreWriter : IMarkoutFormatter,
         int right = remaining - left;
 
         FormatGradientLine(w, left, fadeInward: true);
-        SgrColor(w, RuleLabelColor);
+        Sgr(w, (int)RuleLabelColor);
         SgrBold(w, padded);
         SgrReset(w);
         FormatGradientLine(w, right, fadeInward: false);
@@ -382,14 +381,14 @@ public class SpectreWriter : IMarkoutFormatter,
 
         if (!RuleGradient)
         {
-            SgrColor(w, RuleLineColor);
+            Sgr(w, (int)RuleLineColor);
             w.Write(new string('─', length));
             SgrReset(w);
             return;
         }
 
-        var (r1, g1, b1) = (RuleGradientStart.R, RuleGradientStart.G, RuleGradientStart.B);
-        var (r2, g2, b2) = (RuleGradientEnd.R, RuleGradientEnd.G, RuleGradientEnd.B);
+        var (r1, g1, b1) = RuleGradientStart;
+        var (r2, g2, b2) = RuleGradientEnd;
 
         for (int i = 0; i < length; i++)
         {

--- a/src/Markout/DiagramFormatter.cs
+++ b/src/Markout/DiagramFormatter.cs
@@ -6,7 +6,7 @@ namespace Markout;
 /// A formatter for structural and hierarchical visualizations.
 /// Supports headings, trees, and metrics with plain-text rendering.
 /// </summary>
-public class DiagramWriter : IMarkoutFormatter,
+public class DiagramFormatter : IMarkoutFormatter,
     IHeadingFormatter, ITreeFormatter, IMetricsFormatter
 {
     // ── IHeadingFormatter ──
@@ -94,11 +94,11 @@ public class DiagramWriter : IMarkoutFormatter,
 
     void IMetricsFormatter.FormatBreakdown(TextWriter w, IReadOnlyList<Breakdown> items, int? maxBarWidth, bool uniformBarWidth, MarkoutWriterOptions options)
     {
-        // DiagramWriter does not render breakdowns
+        // DiagramFormatter does not render breakdowns
     }
 
     void IMetricsFormatter.FormatVerticalMetrics(TextWriter w, IReadOnlyList<Metric> items, int maxBarHeight, int? barWidth, MarkoutWriterOptions options)
     {
-        // DiagramWriter does not render vertical metrics
+        // DiagramFormatter does not render vertical metrics
     }
 }

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -7,7 +7,7 @@ namespace Markout;
 /// Provides a rich text presentation similar to Spectre but without dependencies or color.
 /// Uses ─│├└╭╮╰╯ for borders, █▆▄▂ for bars, and other Unicode decorations.
 /// </summary>
-public class UnicodeWriter : IMarkoutFormatter,
+public class UnicodeFormatter : IMarkoutFormatter,
     IDocumentFormatter, IMetricsFormatter
 {
     private const int ColumnGap = 2;

--- a/tests/Markout.Tests/AnsiFormatterTests.cs
+++ b/tests/Markout.Tests/AnsiFormatterTests.cs
@@ -4,10 +4,10 @@ using Microsoft.Extensions.Terminal;
 
 namespace Markout.Tests;
 
-public class AnsiWriterTests
+public class AnsiFormatterTests
 {
     /// <summary>
-    /// Simple ITerminal required by AnsiWriter constructor.
+    /// Simple ITerminal required by AnsiFormatter constructor.
     /// </summary>
     private class CapturingTerminal : ITerminal
     {
@@ -35,7 +35,7 @@ public class AnsiWriterTests
     {
         var sw = new StringWriter();
         var terminal = new CapturingTerminal();
-        var orch = MarkoutWriter.Create(sw, new AnsiWriter(terminal));
+        var orch = MarkoutWriter.Create(sw, new AnsiFormatter(terminal));
         return (orch, sw);
     }
 
@@ -43,7 +43,7 @@ public class AnsiWriterTests
     {
         var sw = new StringWriter();
         var terminal = new CapturingTerminal();
-        var orch = MarkoutWriter.Create(sw, new AnsiWriter(terminal), options);
+        var orch = MarkoutWriter.Create(sw, new AnsiFormatter(terminal), options);
         return (orch, sw);
     }
 

--- a/tests/Markout.Tests/DiagramFormatterTests.cs
+++ b/tests/Markout.Tests/DiagramFormatterTests.cs
@@ -4,12 +4,12 @@ using Markout.Formatting;
 namespace Markout.Tests;
 
 [Collection("ConsoleError")]
-public class DiagramWriterTests
+public class DiagramFormatterTests
 {
     [Fact]
-    public void DiagramWriter_ImplementsExpectedInterfaces()
+    public void DiagramFormatter_ImplementsExpectedInterfaces()
     {
-        var writer = new DiagramWriter();
+        var writer = new DiagramFormatter();
         Assert.IsAssignableFrom<IMarkoutFormatter>(writer);
         Assert.IsAssignableFrom<IHeadingFormatter>(writer);
         Assert.IsAssignableFrom<ITreeFormatter>(writer);
@@ -19,7 +19,7 @@ public class DiagramWriterTests
     [Fact]
     public void WriteTree_Renders()
     {
-        var orch = MarkoutWriter.Create(new DiagramWriter());
+        var orch = MarkoutWriter.Create(new DiagramFormatter());
         orch.WriteTree(
             new TreeNode("Root", null,
                 new TreeNode("Child A"),
@@ -35,7 +35,7 @@ public class DiagramWriterTests
     [Fact]
     public void WriteHeading_Renders()
     {
-        var orch = MarkoutWriter.Create(new DiagramWriter());
+        var orch = MarkoutWriter.Create(new DiagramFormatter());
         orch.WriteHeading(1, "My Diagram");
         Assert.Contains("My Diagram", orch.ToString());
     }
@@ -43,7 +43,7 @@ public class DiagramWriterTests
     [Fact]
     public void WriteTable_ReturnsFalse()
     {
-        var orch = MarkoutWriter.Create(new DiagramWriter());
+        var orch = MarkoutWriter.Create(new DiagramFormatter());
         var result = orch.WriteTable(["Col1"], [["val1"]]);
         Assert.False(result);
         Assert.Equal("", orch.ToString());
@@ -52,7 +52,7 @@ public class DiagramWriterTests
     [Fact]
     public void WriteFields_ReturnsFalse()
     {
-        var orch = MarkoutWriter.Create(new DiagramWriter());
+        var orch = MarkoutWriter.Create(new DiagramFormatter());
         var result = orch.WriteFields(new MarkoutField("Key", "Value"));
         Assert.False(result);
         Assert.Equal("", orch.ToString());
@@ -61,7 +61,7 @@ public class DiagramWriterTests
     [Fact]
     public void WriteMetrics_Renders()
     {
-        var orch = MarkoutWriter.Create(new DiagramWriter());
+        var orch = MarkoutWriter.Create(new DiagramFormatter());
         orch.WriteMetrics([
             new Metric("Toronto", 8),
             new Metric("Vancouver", 3),
@@ -77,7 +77,7 @@ public class DiagramWriterTests
     [Fact]
     public void WriteMetrics_ScalesProportionally()
     {
-        var orch = MarkoutWriter.Create(new DiagramWriter());
+        var orch = MarkoutWriter.Create(new DiagramFormatter());
         orch.WriteMetrics([
             new Metric("Big", 10),
             new Metric("Small", 1),

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ExcludeAnsi)' == 'true'">
-    <Compile Remove="AnsiWriterTests.cs" />
+    <Compile Remove="AnsiFormatterTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -941,12 +941,12 @@ public class MarkoutWriterTests
         Assert.Contains("# Title", sw.ToString());
     }
 
-    // ── UnicodeWriter as orchestrator formatter ──
+    // ── UnicodeFormatter as orchestrator formatter ──
 
     [Fact]
-    public void UnicodeWriter_Orchestrator_WritesHeading()
+    public void UnicodeFormatter_Orchestrator_WritesHeading()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
 
         var result = orch.WriteHeading(1, "Test");
 
@@ -956,9 +956,9 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void UnicodeWriter_Orchestrator_WritesTable()
+    public void UnicodeFormatter_Orchestrator_WritesTable()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
 
         var result = orch.WriteTable(["Name", "Age"], [["Alice", "30"]]);
 
@@ -969,9 +969,9 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void UnicodeWriter_Orchestrator_WritesFields()
+    public void UnicodeFormatter_Orchestrator_WritesFields()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
 
         var result = orch.WriteFields(new MarkoutField("Status", "OK"));
 
@@ -982,9 +982,9 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void UnicodeWriter_Orchestrator_WritesCallout()
+    public void UnicodeFormatter_Orchestrator_WritesCallout()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
 
         var result = orch.WriteCallout(CalloutSeverity.Warning, "Watch out!");
 
@@ -994,9 +994,9 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void UnicodeWriter_Orchestrator_WritesMetrics()
+    public void UnicodeFormatter_Orchestrator_WritesMetrics()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
 
         var result = orch.WriteMetrics([new Metric("CPU", 75)]);
 
@@ -1006,9 +1006,9 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void UnicodeWriter_Orchestrator_AllShapesReturn_True()
+    public void UnicodeFormatter_Orchestrator_AllShapesReturn_True()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
 
         Assert.True(orch.WriteHeading(1, "H1"));
         Assert.True(orch.WriteFields(new MarkoutField("K", "V")));

--- a/tests/Markout.Tests/ShapeSupportTests.cs
+++ b/tests/Markout.Tests/ShapeSupportTests.cs
@@ -50,10 +50,10 @@ public class ShapeSupportTests
         Console.SetError(errWriter);
         try
         {
-            // DiagramWriter doesn't support tables but state must be tracked
+            // DiagramFormatter doesn't support tables but state must be tracked
             // so WriteTableRow/End don't throw
             var sw = new StringWriter();
-            var orch = MarkoutWriter.Create(sw, new DiagramWriter());
+            var orch = MarkoutWriter.Create(sw, new DiagramFormatter());
             orch.WriteTableStart("Col");
             orch.WriteTableRow("val");
             orch.WriteTableEnd();
@@ -212,9 +212,9 @@ public class ShapeSupportTests
     }
 
     [Fact]
-    public void UnicodeWriter_ImplementsCapabilityInterfaces()
+    public void UnicodeFormatter_ImplementsCapabilityInterfaces()
     {
-        var writer = new UnicodeWriter();
+        var writer = new UnicodeFormatter();
         Assert.True(writer is IMarkoutFormatter);
         Assert.True(writer is IHeadingFormatter);
         Assert.True(writer is IFieldFormatter);
@@ -226,9 +226,9 @@ public class ShapeSupportTests
     }
 
     [Fact]
-    public void DiagramWriter_ImplementsSubsetOfInterfaces()
+    public void DiagramFormatter_ImplementsSubsetOfInterfaces()
     {
-        var writer = new DiagramWriter();
+        var writer = new DiagramFormatter();
         Assert.True(writer is IHeadingFormatter);
         Assert.True(writer is ITreeFormatter);
         Assert.True(writer is IMetricsFormatter);

--- a/tests/Markout.Tests/UnicodeFormatterTests.cs
+++ b/tests/Markout.Tests/UnicodeFormatterTests.cs
@@ -3,12 +3,12 @@ using Markout.Formatting;
 
 namespace Markout.Tests;
 
-public class UnicodeWriterTests
+public class UnicodeFormatterTests
 {
     [Fact]
     public void SupportedShapes_ReturnsAll()
     {
-        var writer = new UnicodeWriter();
+        var writer = new UnicodeFormatter();
         Assert.IsAssignableFrom<IDocumentFormatter>(writer);
         Assert.IsAssignableFrom<IMetricsFormatter>(writer);
     }
@@ -17,7 +17,7 @@ public class UnicodeWriterTests
     public void WriteHeading_Level1_UsesRuleCharacters()
     {
         var sw = new StringWriter();
-        var writer = new UnicodeWriter() { ConsoleWidth = 40 };
+        var writer = new UnicodeFormatter() { ConsoleWidth = 40 };
         var orch = MarkoutWriter.Create(sw, writer);
         orch.WriteHeading(1, "Test Title");
         var output = sw.ToString();
@@ -29,7 +29,7 @@ public class UnicodeWriterTests
     public void WriteHeading_Level2_PlainText()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteHeading(2, "Subtitle");
         var output = sw.ToString();
         Assert.Contains("Subtitle", output);
@@ -44,7 +44,7 @@ public class UnicodeWriterTests
     public void WriteFields_KeyValueFormat()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteFields([new("Name", "Alice")]);
         var output = sw.ToString();
         Assert.Contains("Name: Alice", output);
@@ -54,7 +54,7 @@ public class UnicodeWriterTests
     public void WriteTable_WithUnicodeRuleSeparator()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTable(
             ["Name", "Age"],
             [["Alice", "30"], ["Bob", "25"]]);
@@ -72,7 +72,7 @@ public class UnicodeWriterTests
     {
         var sw = new StringWriter();
         var options = new MarkoutWriterOptions { MaxItems = 1 };
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter(), options);
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter(), options);
         orch.WriteTable(
             ["Name"],
             [["Alice"], ["Bob"], ["Carol"]]);
@@ -87,7 +87,7 @@ public class UnicodeWriterTests
     {
         var sw = new StringWriter();
         var options = new MarkoutWriterOptions { MaxItems = 1 };
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter(), options);
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter(), options);
         orch.WriteTableStart("Name");
         orch.WriteTableRow("Alice");
         orch.WriteTableRow("Bob");
@@ -103,7 +103,7 @@ public class UnicodeWriterTests
     public void WriteTree_WithUnicodeConnectors()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTree(
             new TreeNode("Root", null,
                 new TreeNode("Child A"),
@@ -120,7 +120,7 @@ public class UnicodeWriterTests
     public void WriteTree_NestedStructure()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTree(
             new TreeNode("Root", null,
                 new TreeNode("Parent", null,
@@ -139,7 +139,7 @@ public class UnicodeWriterTests
     public void WriteTree_VerticalLineInPrefix()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTree(
             new TreeNode("Root", null,
                 new TreeNode("Parent 1", null,
@@ -154,7 +154,7 @@ public class UnicodeWriterTests
     {
         var sw = new StringWriter();
         var options = new MarkoutWriterOptions { IncludeBadges = true };
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter(), options);
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter(), options);
         orch.WriteTree([
             new TreeNode("Item") { Badge = "OK" }
         ]);
@@ -167,7 +167,7 @@ public class UnicodeWriterTests
     public void WriteListItem_WithBullet()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteListItem("Item one");
         var output = sw.ToString();
         Assert.Contains("• Item one", output);
@@ -177,7 +177,7 @@ public class UnicodeWriterTests
     public void WriteArray_WithBullets()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteArray("Colors", ["Red", "Green", "Blue"]);
         var output = sw.ToString();
         Assert.Contains("Colors:", output);
@@ -190,7 +190,7 @@ public class UnicodeWriterTests
     public void WriteFieldsInline_WithVerticalBar()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteFieldsInline([
             new MarkoutField("Name", "Alice"),
             new MarkoutField("Age", "30")
@@ -205,7 +205,7 @@ public class UnicodeWriterTests
     public void WriteDescriptions_WithBulletAndDash()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteDescriptions([
             new Description("Term", "Definition"),
             new Description("Label", "Description")
@@ -219,7 +219,7 @@ public class UnicodeWriterTests
     public void WriteCallout_Note()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteCallout(CalloutSeverity.Note, "Information");
         var output = sw.ToString();
         Assert.Contains("ℹ", output);
@@ -230,7 +230,7 @@ public class UnicodeWriterTests
     public void WriteCallout_Warning()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteCallout(CalloutSeverity.Warning, "Warning message");
         var output = sw.ToString();
         Assert.Contains("⚠", output);
@@ -241,7 +241,7 @@ public class UnicodeWriterTests
     public void WriteCallout_Caution()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteCallout(CalloutSeverity.Caution, "Danger!");
         var output = sw.ToString();
         Assert.Contains("✖", output);
@@ -252,7 +252,7 @@ public class UnicodeWriterTests
     public void WriteCallout_Tip()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteCallout(CalloutSeverity.Tip, "Helpful hint");
         var output = sw.ToString();
         Assert.Contains("💡", output);
@@ -263,7 +263,7 @@ public class UnicodeWriterTests
     public void WriteQuotation_WithVerticalBar()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteQuotation("This is a quote");
         var output = sw.ToString();
         Assert.Contains("│ This is a quote", output);
@@ -273,7 +273,7 @@ public class UnicodeWriterTests
     public void WriteQuotation_Multiline()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteQuotation("Line 1\nLine 2");
         var output = sw.ToString();
         Assert.Contains("│ Line 1", output);
@@ -284,7 +284,7 @@ public class UnicodeWriterTests
     public void WriteRule_UsesRuleCharacter()
     {
         var sw = new StringWriter();
-        var writer = new UnicodeWriter() { ConsoleWidth = 40 };
+        var writer = new UnicodeFormatter() { ConsoleWidth = 40 };
         var orch = MarkoutWriter.Create(sw, writer);
         orch.WriteRule();
         var output = sw.ToString();
@@ -295,7 +295,7 @@ public class UnicodeWriterTests
     public void WriteMetrics_WithBarCharacter()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteMetrics([
             new Metric("CPU", 80),
             new Metric("Memory", 60),
@@ -312,7 +312,7 @@ public class UnicodeWriterTests
     public void WriteBreakdown_WithBars()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteBreakdown([
             new Breakdown("Windows", [
                 new Segment("Critical", 10),
@@ -335,7 +335,7 @@ public class UnicodeWriterTests
     public void WriteVerticalMetrics_WithBarCharacter()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteVerticalMetrics([
             new Metric("Jan", 100),
             new Metric("Feb", 80),
@@ -351,21 +351,21 @@ public class UnicodeWriterTests
     [Fact]
     public void ConsoleWidth_DefaultIs80()
     {
-        var writer = new UnicodeWriter();
+        var writer = new UnicodeFormatter();
         Assert.Equal(80, writer.ConsoleWidth);
     }
 
     [Fact]
     public void ConsoleWidth_CanBeSet()
     {
-        var writer = new UnicodeWriter() { ConsoleWidth = 120 };
+        var writer = new UnicodeFormatter() { ConsoleWidth = 120 };
         Assert.Equal(120, writer.ConsoleWidth);
     }
 
     [Fact]
     public void ConsoleWidth_RejectsInvalidValues()
     {
-        var writer = new UnicodeWriter() { ConsoleWidth = -10 };
+        var writer = new UnicodeFormatter() { ConsoleWidth = -10 };
         Assert.Equal(80, writer.ConsoleWidth); // Should fall back to 80
     }
 
@@ -373,7 +373,7 @@ public class UnicodeWriterTests
     public void RuleCharacter_CanBeCustomized()
     {
         var sw = new StringWriter();
-        var writer = new UnicodeWriter() { RuleCharacter = '═', ConsoleWidth = 20 };
+        var writer = new UnicodeFormatter() { RuleCharacter = '═', ConsoleWidth = 20 };
         var orch = MarkoutWriter.Create(sw, writer);
         orch.WriteHeading(1, "Test");
         var output = sw.ToString();
@@ -385,7 +385,7 @@ public class UnicodeWriterTests
     public void BarCharacter_CanBeCustomized()
     {
         var sw = new StringWriter();
-        var writer = new UnicodeWriter() { BarCharacter = '▬' };
+        var writer = new UnicodeFormatter() { BarCharacter = '▬' };
         var orch = MarkoutWriter.Create(sw, writer);
         orch.WriteMetrics([
             new Metric("Test", 50)
@@ -399,7 +399,7 @@ public class UnicodeWriterTests
     public void WriteCodeStart_DoesNotThrow()
     {
         var sw = new StringWriter();
-        var orch = MarkoutWriter.Create(sw, new UnicodeWriter());
+        var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteCodeStart("csharp");
         orch.WriteCodeEnd();
         // Just verify it doesn't throw
@@ -408,7 +408,7 @@ public class UnicodeWriterTests
     [Fact]
     public void WriteCodeStart_Nested_Throws()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
         orch.WriteCodeStart();
         Assert.Throws<InvalidOperationException>(() => orch.WriteCodeStart());
     }
@@ -416,7 +416,7 @@ public class UnicodeWriterTests
     [Fact]
     public void WriteCodeEnd_WithoutStart_Throws()
     {
-        var orch = MarkoutWriter.Create(new UnicodeWriter());
+        var orch = MarkoutWriter.Create(new UnicodeFormatter());
         Assert.Throws<InvalidOperationException>(() => orch.WriteCodeEnd());
     }
 }


### PR DESCRIPTION
## Summary

Standardize formatter naming and update documentation for the PR #80 architecture changes.

### Formatter renames

All formatter types now use the `*Formatter` naming convention:

| Before | After |
|--------|-------|
| `UnicodeWriter` | `UnicodeFormatter` |
| `DiagramWriter` | `DiagramFormatter` |
| `AnsiWriter` | `AnsiFormatter` |
| `SpectreWriter` | `SpectreFormatter` |

`MarkdownFormatter` and `OneLineFormatter` were already correct. `MarkoutWriter` is unchanged — it's the orchestrator, not a formatter.

### Documentation updates

- Renderers table: `MarkoutWriter` → `UnicodeFormatter`, column headers renamed to "Formatter"
- `SupportedShapes` → capability interfaces (`ITableFormatter`, `IFieldFormatter`, etc.)
- Fixed stale code examples: formatters no longer accept `TextWriter`/options in constructors
- Layer 3 customization: subclass model → interface implementation model
- SKILL.md: fixed all `Serialize` call signatures to match new API

### Testing

- 447 tests pass, 0 failures
- Build: 0 warnings
- Markdownlint: clean