### PR TITLE
Make PascalCaseWords the default naming policy, remove View suffix from types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 **Markup adds instructions to content. Markout removes structure from data.**
 
-Markout is a source-generated .NET serializer that projects objects into human-readable documents instead of data formats like JSON. You annotate view models with attributes that describe data relationships — identity, enumeration, tabulation, measurement, hierarchy — and the source generator emits code that writes through an abstract renderer. The same object graph produces Markdown tables, ANSI terminal output with colored bars, plain text with aligned columns, or one-line summaries, without the developer making visual decisions.
+Markout is a source-generated .NET serializer that projects objects into human-readable documents instead of data formats like JSON. You annotate your models with attributes that describe data relationships — identity, enumeration, tabulation, measurement, hierarchy — and the source generator emits code that writes through an abstract renderer. The same object graph produces Markdown tables, ANSI terminal output with colored bars, plain text with aligned columns, or one-line summaries, without the developer making visual decisions.
 
 ## Quick Start
 
 ```csharp
 using Markout;
 
-var artist = new ArtistView(
+var artist = new Artist(
     Name: "Sarah McLachlan",
     Genre: "Pop / Adult Contemporary",
     Origin: "Halifax, Nova Scotia",
@@ -18,15 +18,15 @@ var artist = new ArtistView(
 
 MarkoutSerializer.Serialize(artist, Console.Out, ArtistContext.Default);
 
-[MarkoutSerializable(TitleProperty = nameof(ArtistView.Name))]
-public record ArtistView(
+[MarkoutSerializable(TitleProperty = nameof(Artist.Name))]
+public record Artist(
     string Name,
     string Genre,
     string Origin,
     int DebutYear,
     string BestKnownFor);
 
-[MarkoutContext(typeof(ArtistView))]
+[MarkoutContext(typeof(Artist))]
 public partial class ArtistContext : MarkoutSerializerContext { }
 ```
 
@@ -35,7 +35,7 @@ public partial class ArtistContext : MarkoutSerializerContext { }
 ```markdown
 # Sarah McLachlan
 
-Genre: Pop / Adult Contemporary | Origin: Halifax, Nova Scotia | DebutYear: 1988 | BestKnownFor: Angel, Building a Mystery, Adia
+Genre: Pop / Adult Contemporary | Origin: Halifax, Nova Scotia | Debut Year: 1988 | Best Known For: Angel, Building a Mystery, Adia
 ```
 
 Three things: a record, a context, one line of serialization. The `TitleProperty` becomes a heading; everything else renders as fields.
@@ -90,11 +90,11 @@ Population: 2632000
 
 ## Real-World Example: GitHub Repository Report
 
-The [GitHubRepo](samples/GitHubRepo) sample fetches four GitHub API endpoints in parallel and projects the combined JSON into a single report — fields, bar charts, contributor metrics, and release tables — all from one view model:
+The [GitHubRepo](samples/GitHubRepo) sample fetches four GitHub API endpoints in parallel and projects the combined JSON into a single report — fields, bar charts, contributor metrics, and release tables — all from one model:
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
-public class RepoView
+public class RepoInfo
 {
     public string Title { get; set; } = "";
 
@@ -174,7 +174,7 @@ Stars: 17,698 | Forks: 5,350 | Open Issues: 8,385 | Language: C# | License: MIT 
 | v9.0.13 | v9.0.13     | 2026-02-10 |
 ```
 
-**One-line output** — same view model, `--oneline` flag, shows the Releases table only:
+**One-line output** — same model, `--oneline` flag, shows the Releases table only:
 
 ```text
 TAG      NAME         PUBLISHED
@@ -183,11 +183,11 @@ v9.0.13  v9.0.13      2026-02-10
 v10.0.3  .NET 10.0.3  2026-02-10
 ```
 
-The pattern is always the same: deserialize your API data, project to a view model, serialize. Markout handles the rest.
+The pattern is always the same: deserialize your API data, project to a model, serialize. Markout handles the rest.
 
 ## Shape Library
 
-Each property on a view model maps to a data relationship, not a visual element. Renderers decide how to present each shape.
+Each property on a model maps to a data relationship, not a visual element. Renderers decide how to present each shape.
 
 | Relationship | C# type | What it means | Markdown | ANSI |
 |---|---|---|---|---|
@@ -355,7 +355,7 @@ The package includes the source generator — no additional packages needed.
 ## Samples
 
 - **[HelloMarkout](samples/HelloMarkout)** — Simplest possible example: a class, a context, one line of serialization
-- **[RecordDemo](samples/RecordDemo)** — Records as view models
+- **[RecordDemo](samples/RecordDemo)** — Records as data models
 - **[GitHubRepo](samples/GitHubRepo)** — GitHub API → fields, breakdowns, metrics, and tables with Spectre/Markdown/OneLineFormatter output
 - **[GitHubActivity](samples/GitHubActivity)** — User profile and recent events from the GitHub API
 - **[CanadianContent](samples/CanadianContent)** — Canadian actors and shows with tables, trees, metrics, and multiple renderers
@@ -370,7 +370,7 @@ If you are an LLM or coding agent building a CLI tool that needs structured, rea
 
 ## Real-World Usage
 
-Markout was created for [dotnet-inspect](https://github.com/richlander/dotnet-inspect), which uses all ten data relationships across 49 view models to generate API inspection reports, diff analysis, dependency trees, and security summaries.
+Markout was created for [dotnet-inspect](https://github.com/richlander/dotnet-inspect), which uses all ten data relationships across 49 models to generate API inspection reports, diff analysis, dependency trees, and security summaries.
 
 ## Documentation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,7 +20,7 @@ dotnet add package Markout.Ansi.Spectre
 
 Every markout integration follows three steps:
 
-### 1. Define a view model
+### 1. Define a model
 
 Annotate a class or record with `[MarkoutSerializable]`. Scalar properties become fields. `List<T>` properties become tables. Built-in types like `Metric`, `Breakdown`, `Callout`, and `TreeNode` produce charts, bars, alerts, and trees.
 
@@ -48,7 +48,7 @@ public class ResultRow
 
 ### 2. Define a context
 
-Create a partial class that registers your view models for source generation:
+Create a partial class that registers your models for source generation:
 
 ```csharp
 [MarkoutContext(typeof(ToolReport))]
@@ -71,7 +71,7 @@ That's it. The output is Markdown by default.
 | Attribute | Purpose | Example |
 |---|---|---|
 | `[MarkoutSerializable]` | Mark type for serialization | `[MarkoutSerializable(TitleProperty = "Name")]` |
-| `[MarkoutContext(typeof(T))]` | Register type with context | `[MarkoutContext(typeof(MyView))]` |
+| `[MarkoutContext(typeof(T))]` | Register type with context | `[MarkoutContext(typeof(MyReport))]` |
 
 `MarkoutSerializable` properties:
 
@@ -111,7 +111,7 @@ That's it. The output is Markdown by default.
 
 ## Built-in Shape Types
 
-Use these types as properties on your view model to get rich output:
+Use these types as properties on your model to get rich output:
 
 ```csharp
 // Bar chart — comparative quantities
@@ -153,18 +153,18 @@ public CodeSection? SourceCode { get; set; }
 
 ```csharp
 // Markdown (default) — documentation, LLM output, reports
-MarkoutSerializer.Serialize(view, Console.Out, context);
+MarkoutSerializer.Serialize(report, Console.Out, context);
 
 // Markdown with explicit formatter
-MarkoutSerializer.Serialize(view, Console.Out, new MarkdownFormatter(), context);
+MarkoutSerializer.Serialize(report, Console.Out, new MarkdownFormatter(), context);
 
 // Spectre terminal — colored, interactive
 using Markout.Ansi.Spectre;
 using Spectre.Console;
-MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.Console), context);
+MarkoutSerializer.Serialize(report, Console.Out, new SpectreFormatter(AnsiConsole.Console), context);
 
 // One-line — compact table, grep-friendly
-MarkoutSerializer.Serialize(view, Console.Out, new OneLineFormatter(), context);
+MarkoutSerializer.Serialize(report, Console.Out, new OneLineFormatter(), context);
 
 // One-line with section filter — show only one table
 var options = new MarkoutWriterOptions
@@ -172,15 +172,15 @@ var options = new MarkoutWriterOptions
     IncludeDescription = false,
     IncludeSections = new HashSet<string> { "Results" }
 };
-MarkoutSerializer.Serialize(view, Console.Out, new OneLineFormatter(), context, options);
+MarkoutSerializer.Serialize(report, Console.Out, new OneLineFormatter(), context, options);
 
 // Plain text — log files, piped output
-MarkoutSerializer.Serialize(view, Console.Out, new UnicodeFormatter(), context);
+MarkoutSerializer.Serialize(report, Console.Out, new UnicodeFormatter(), context);
 ```
 
 ## Common Recipe: JSON API to Report
 
-This is the most common pattern — fetch JSON, project to view model, serialize:
+This is the most common pattern — fetch JSON, project to a model, serialize:
 
 ```csharp
 using System.Text.Json;
@@ -192,8 +192,8 @@ using var http = new HttpClient();
 var json = await http.GetStringAsync("https://api.example.com/data");
 var data = JsonSerializer.Deserialize(json, ApiJsonContext.Default.ApiResponse)!;
 
-// 2. Project to view model
-var view = new ReportView
+// 2. Project to model
+var report = new Report
 {
     Title = data.Name,
     Count = data.Items.Count,
@@ -205,11 +205,11 @@ var view = new ReportView
 };
 
 // 3. Serialize
-MarkoutSerializer.Serialize(view, Console.Out, ReportContext.Default);
+MarkoutSerializer.Serialize(report, Console.Out, ReportContext.Default);
 
-// --- View Model ---
+// --- Model ---
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ReportView
+public class Report
 {
     public string Title { get; set; } = "";
     public int Count { get; set; }
@@ -225,11 +225,11 @@ public class ItemRow
     public string Status { get; set; } = "";
 }
 
-[MarkoutContext(typeof(ReportView))]
+[MarkoutContext(typeof(Report))]
 [MarkoutContext(typeof(ItemRow))]
 public partial class ReportContext : MarkoutSerializerContext { }
 
-// --- JSON Model (separate from view model) ---
+// --- JSON Model (separate from report model) ---
 public class ApiResponse { public string Name { get; set; } = ""; public List<ApiItem> Items { get; set; } = []; }
 public class ApiItem { public string Name { get; set; } = ""; public string Status { get; set; } = ""; }
 
@@ -239,7 +239,7 @@ internal partial class ApiJsonContext : JsonSerializerContext { }
 
 ## Key Principles
 
-1. **View models are not domain models.** Keep your JSON/API models separate. The view model is the projection layer — it decides what the user sees.
+1. **Data models work directly with Markout.** In the simplest case, your data model is your Markout model — no separate projection layer needed. For more complex scenarios (e.g., combining multiple API responses), a dedicated report model is fine, but it's still just a data model.
 2. **Attributes describe data relationships, not visuals.** Say "this is a measurement" (`Metric`), not "draw a bar."
 3. **Register every type.** Every class used in serialization needs `[MarkoutSerializable]` and must be registered via `[MarkoutContext(typeof(T))]` on the context.
 4. **The context must be `partial`.** The source generator fills in the implementation.

--- a/docs/design/projection.md
+++ b/docs/design/projection.md
@@ -1,6 +1,6 @@
 # Projection
 
-**Projection trims markout output to specific sections, columns, and fields at runtime, without changing view models or source generation.**
+**Projection trims markout output to specific sections, columns, and fields at runtime, without changing models or source generation.**
 
 ## The Problem
 

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -52,11 +52,11 @@ public class PackageReport
     public string License { get; set; }                      // → License: MIT
 
     [MarkoutSection(Name = "Assemblies")]                    // → ## Assemblies
-    public List<AssemblyView> Assemblies { get; set; }       //   each item → ### name
+    public List<Assembly> Assemblies { get; set; }       //   each item → ### name
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Name))]          // → ### Foo.dll
-public class AssemblyView
+public class Assembly
 {
     [MarkoutIgnore] public string Name { get; set; }
     public string Architecture { get; set; }                 //   Architecture: AnyCPU

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,7 +4,7 @@ Markout is a source-generated .NET library that serializes objects to clean, rea
 
 - [Quick Start](#quick-start)
 - [Quick Tweaks](#quick-tweaks)
-- [Defining Models](#defining-view-models)
+- [Defining Models](#defining-models)
 - [Serialization](#serialization)
 - [Scalar Fields](#scalar-fields)
 - [Field Layout](#field-layout)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,10 +1,10 @@
 # Markout User Guide
 
-Markout is a source-generated .NET library that serializes objects to clean, readable Markdown. Define your view models with attributes, and Markout generates efficient serialization code at compile time — no reflection, no runtime overhead.
+Markout is a source-generated .NET library that serializes objects to clean, readable Markdown. Define your models with attributes, and Markout generates efficient serialization code at compile time — no reflection, no runtime overhead.
 
 - [Quick Start](#quick-start)
 - [Quick Tweaks](#quick-tweaks)
-- [Defining View Models](#defining-view-models)
+- [Defining Models](#defining-view-models)
 - [Serialization](#serialization)
 - [Scalar Fields](#scalar-fields)
 - [Field Layout](#field-layout)
@@ -21,12 +21,12 @@ Markout is a source-generated .NET library that serializes objects to clean, rea
 
 ## Quick Start
 
-The simplest Markout program is a view model, a context, and a serialize call.
+The simplest Markout program is a model, a context, and a serialize call.
 
 ```csharp
 using Markout;
 
-var city = new CityView
+var city = new City
 {
     Name = "Vancouver",
     Country = "Canada",
@@ -40,7 +40,7 @@ var city = new CityView
 MarkoutSerializer.Serialize(city, Console.Out, CityContext.Default);
 
 [MarkoutSerializable(TitleProperty = nameof(Name))]
-public class CityView
+public class City
 {
     public string Name { get; set; } = "";
     public string Country { get; set; } = "";
@@ -62,7 +62,7 @@ public class CityView
     public double Temperature { get; set; }
 }
 
-[MarkoutContext(typeof(CityView))]
+[MarkoutContext(typeof(City))]
 public partial class CityContext : MarkoutSerializerContext { }
 ```
 
@@ -82,7 +82,7 @@ Latitude: 49.2827 | Longitude: -123.1207 | Altitude (m): 0 | Temperature: 6.2 °
 
 Three things are required:
 
-1. **A view model** — a class, optionally decorated with `[MarkoutSerializable]` for customization.
+1. **A model** — a class, optionally decorated with `[MarkoutSerializable]` for customization.
 2. **A context** — a `partial class` inheriting `MarkoutSerializerContext` with `[MarkoutContext(typeof(...))]` for each type.
 3. **A serialize call** — `MarkoutSerializer.Serialize(value, context)`.
 
@@ -94,7 +94,7 @@ The same city can be rendered differently by changing just the `FieldLayout`. `V
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.Vertical)]
-public class CityView { /* same properties */ }
+public class City { /* same properties */ }
 ```
 
 ```markdown
@@ -117,7 +117,7 @@ Temperature: 6.2 °C
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.Bulleted)]
-public class CityView { /* same properties */ }
+public class City { /* same properties */ }
 ```
 
 ```markdown
@@ -134,9 +134,9 @@ public class CityView { /* same properties */ }
 - Temperature: 6.2 °C
 ```
 
-## Defining View Models
+## Defining Models
 
-Markout has two kinds of attributes: **type-level attributes** on the view model class, and **property-level attributes** on individual properties.
+Markout has two kinds of attributes: **type-level attributes** on the model class, and **property-level attributes** on individual properties.
 
 A type becomes serializable when it is registered on a context class with `[MarkoutContext(typeof(T))]`. The `[MarkoutSerializable]` attribute on the type itself is **optional** — use it only when you need to customize behavior like `TitleProperty`, `FieldLayout`, or `AutoFields`. Without it, the type uses sensible defaults (all fields rendered, `Inline` layout, no title heading).
 
@@ -159,7 +159,7 @@ For top-level document types, use `[MarkoutSerializable]` to configure the title
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ReleasesView
+public class Releases
 {
     public string Title { get; set; } = "";
 
@@ -175,7 +175,7 @@ public class ReleasesView
 All types must be registered on the context class:
 
 ```csharp
-[MarkoutContext(typeof(ReleasesView))]
+[MarkoutContext(typeof(Releases))]
 [MarkoutContext(typeof(ReleaseRow))]
 public partial class ReleasesContext : MarkoutSerializerContext { }
 ```
@@ -192,7 +192,7 @@ Use `TitleContextProperty` when you want a secondary identifier rendered in pare
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), TitleContextProperty = nameof(Version))]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
     public string Version { get; set; } = "";
@@ -206,7 +206,7 @@ Set `DescriptionProperty` to render a property as a paragraph below the heading:
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Summary))]
-public class ApiView
+public class ApiReport
 {
     public string Name { get; set; } = "";
     public string Summary { get; set; } = "";
@@ -278,7 +278,7 @@ Or set at compile time on the context class with `[MarkoutContextOptions]`, so e
 
 ```csharp
 [MarkoutContextOptions(BoldFieldNames = true, SuppressTableWarnings = true)]
-[MarkoutContext(typeof(ProductView))]
+[MarkoutContext(typeof(Product))]
 public partial class SampleContext : MarkoutSerializerContext { }
 ```
 
@@ -353,7 +353,7 @@ Each field on its own line with trailing double-spaces:
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.Vertical)]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
     public string? Homepage { get; set; }
@@ -374,7 +374,7 @@ Each field as a bullet list item:
 
 ```csharp
 [MarkoutSerializable(FieldLayout = FieldLayout.Bulleted)]
-public class ConfigView
+public class Config
 {
     public string Host { get; set; } = "";
     public int Port { get; set; }
@@ -467,7 +467,7 @@ Use `[MarkoutSkipNull]` to omit fields when their value is null, empty, or (for 
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name))]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
     [MarkoutSkipNull]
@@ -502,7 +502,7 @@ Use `[MarkoutShowWhen]` to render a field only when a bool property on the same 
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.Vertical)]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
 
@@ -549,7 +549,7 @@ When scalar properties share the same section name, they are grouped under a sin
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
 
@@ -586,7 +586,7 @@ When a `List<T>` of complex objects has `[MarkoutSection]`, it renders as a head
 
 ```csharp
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ShowDetailView
+public class ShowDetail
 {
     public string Title { get; set; } = "";
     public string Type { get; set; } = "";
@@ -672,7 +672,7 @@ Use `List<MarkoutField>` for dynamic key-value fields built at runtime:
 
 ```csharp
 [MarkoutSerializable(AutoFields = false)]
-public class DynamicView
+public class DynamicReport
 {
     public List<MarkoutField>? Fields { get; set; }
 }
@@ -686,7 +686,7 @@ Properties that cannot be rendered in table context (nested objects, arrays) emi
 
 ```csharp
 [MarkoutSerializable]
-public class LatestCvesView
+public class CveReport
 {
     public string Span { get; set; } = "";
 
@@ -710,7 +710,7 @@ If you register many types and most table warnings are expected, use `[MarkoutCo
 
 ```csharp
 [MarkoutContextOptions(SuppressTableWarnings = true)]
-[MarkoutContext(typeof(MyView))]
+[MarkoutContext(typeof(MyReport))]
 public partial class MyContext : MarkoutSerializerContext { }
 ```
 
@@ -856,7 +856,7 @@ Set defaults via `[MarkoutContextOptions]`:
 
 ```csharp
 [MarkoutContextOptions(BoldFieldNames = true, SuppressTableWarnings = true)]
-[MarkoutContext(typeof(MyView))]
+[MarkoutContext(typeof(MyReport))]
 public partial class MyContext : MarkoutSerializerContext { }
 ```
 

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -170,7 +170,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
         var (fmt, output) = CreateWriter();
         var show = shows.First(s => s.Title.Contains(titleFragment, StringComparison.OrdinalIgnoreCase));
         var castActors = actors.Where(a => show.CanadianActors.Contains(a.Name)).ToList();
-        var view = new ShowDetailView
+        var view = new ShowDetail
         {
             Title = show.Title,
             Type = show.Type,
@@ -233,7 +233,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     StringWriter FilmographyTrees()
     {
         var (fmt, output) = CreateWriter();
-        var view = new FilmographyTreeView
+        var view = new FilmographyTree
         {
             Title = "Canadian Content — Filmography Trees",
             Filmography = actors
@@ -287,7 +287,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     StringWriter GenreBreakdown()
     {
         var (fmt, output) = CreateWriter();
-        var view = new GenreBreakdownView
+        var view = new GenreBreakdown
         {
             Title = "Canadian Content — Genre Breakdown",
             Breakdown = [new Breakdown("All Shows", shows
@@ -304,7 +304,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     {
         var (fmt, output) = CreateWriter();
         var topActors = actors.Take(3).ToList();
-        var view = new CanConReportView
+        var view = new CanConReport
         {
             Title = "Canadian Content Report",
             Description = "The CRTC's Canadian content regulations require broadcasters to air a minimum percentage of Canadian programming. This report covers top actors, filming locations, and genre distribution.",
@@ -461,7 +461,7 @@ public class LocationSearchResult
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ShowDetailView
+public class ShowDetail
 {
     public string Title { get; set; } = "";
 
@@ -489,7 +489,7 @@ public class ActorFilmography
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class FilmographyTreeView
+public class FilmographyTree
 {
     public string Title { get; set; } = "";
 
@@ -507,7 +507,7 @@ public class ShowsByLocationChart
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class GenreBreakdownView
+public class GenreBreakdown
 {
     public string Title { get; set; } = "";
 
@@ -516,7 +516,7 @@ public class GenreBreakdownView
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
-public class CanConReportView
+public class CanConReport
 {
     public string Title { get; set; } = "";
     public string Description { get; set; } = "";
@@ -544,9 +544,9 @@ public class CanConReportView
     public string? Quote { get; set; }
 }
 
-public partial class CanConReportViewMarkoutTypeInfo
+public partial class CanConReportMarkoutTypeInfo
 {
-    partial void OnSerialized(MarkoutWriter writer, CanConReportView value)
+    partial void OnSerialized(MarkoutWriter writer, CanConReport value)
     {
         if (value.Quote != null)
         {
@@ -562,10 +562,10 @@ public partial class CanConReportViewMarkoutTypeInfo
 [MarkoutContext(typeof(CityRow))]
 [MarkoutContext(typeof(ActorSearchResult))]
 [MarkoutContext(typeof(LocationSearchResult))]
-[MarkoutContext(typeof(ShowDetailView))]
+[MarkoutContext(typeof(ShowDetail))]
 [MarkoutContext(typeof(ActorFilmography))]
-[MarkoutContext(typeof(FilmographyTreeView))]
+[MarkoutContext(typeof(FilmographyTree))]
 [MarkoutContext(typeof(ShowsByLocationChart))]
-[MarkoutContext(typeof(GenreBreakdownView))]
-[MarkoutContext(typeof(CanConReportView))]
+[MarkoutContext(typeof(GenreBreakdown))]
+[MarkoutContext(typeof(CanConReport))]
 public partial class CanConContext : MarkoutSerializerContext { }

--- a/samples/DateBars/DateBars.cs
+++ b/samples/DateBars/DateBars.cs
@@ -14,7 +14,7 @@ var icon = now.Hour switch
     _ => "🌙"
 };
 
-var view = new DateProgressView
+var view = new DateProgress
 {
     Title = $"{icon}  {now:dddd, MMMM d, yyyy — h:mm tt}",
     Progress =
@@ -32,7 +32,7 @@ var sw = new StringWriter();
 MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.Console), DateBarsContext.Default);
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class DateProgressView
+public class DateProgress
 {
     public string Title { get; set; } = "";
 
@@ -40,5 +40,5 @@ public class DateProgressView
     public IReadOnlyList<Breakdown>? Progress { get; set; }
 }
 
-[MarkoutContext(typeof(DateProgressView))]
+[MarkoutContext(typeof(DateProgress))]
 public partial class DateBarsContext : MarkoutSerializerContext { }

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -13,7 +13,7 @@ var index = JsonSerializer.Deserialize(json, ReleasesJsonContext.Default.Release
 var releases = index.Embedded?.Releases ?? [];
 var unsupported = releases.Where(r => !r.Supported).ToList();
 
-var view = new ReleasesView
+var view = new Releases
 {
     Title = index.Title ?? ".NET Releases",
     LatestMajor = index.LatestMajor,
@@ -40,7 +40,7 @@ MarkoutSerializer.Serialize(view, Console.Out, ReleasesContext.Default);
 // --- View Models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ReleasesView
+public class Releases
 {
     public string Title { get; set; } = "";
 
@@ -73,7 +73,7 @@ public class ReleaseRow
     public bool Supported { get; set; }
 }
 
-[MarkoutContext(typeof(ReleasesView))]
+[MarkoutContext(typeof(Releases))]
 [MarkoutContext(typeof(ReleaseRow))]
 public partial class ReleasesContext : MarkoutSerializerContext { }
 

--- a/samples/GitHubActivity/GitHubActivity.cs
+++ b/samples/GitHubActivity/GitHubActivity.cs
@@ -33,7 +33,7 @@ catch (HttpRequestException ex)
 var profile = JsonSerializer.Deserialize(profileJson, GitHubJsonContext.Default.GitHubUser)!;
 var events = JsonSerializer.Deserialize(eventsJson, GitHubJsonContext.Default.ListGitHubEvent) ?? [];
 
-var view = new ActivityView
+var view = new Activity
 {
     Title = profile.Login,
     Name = profile.Name ?? profile.Login,
@@ -90,9 +90,9 @@ static string? RunCommand(string cmd, string args)
 
 // --- View Models ---
 
-[MarkoutSerializable(TitleProperty = nameof(Title), NamingPolicy = NamingPolicy.PascalCaseWords)]
+[MarkoutSerializable(TitleProperty = nameof(Title))]
 [MarkoutSkipNull]
-public record ActivityView
+public record Activity
 {
     [MarkoutIgnore] public string Title { get; init; } = "";
     public string Name { get; init; } = "";
@@ -105,7 +105,7 @@ public record ActivityView
 [MarkoutSerializable]
 public record EventRow(string Type, string Repository, string Date, string Detail);
 
-[MarkoutContext(typeof(ActivityView))]
+[MarkoutContext(typeof(Activity))]
 [MarkoutContext(typeof(EventRow))]
 partial class ActivityContext : MarkoutSerializerContext;
 

--- a/samples/GitHubRepo/GitHubRepo.cs
+++ b/samples/GitHubRepo/GitHubRepo.cs
@@ -84,7 +84,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     int maxPreviewReleases = 5;
     int maxReleaseNameLength = 40;
 
-    var view = new RepoView
+    var view = new RepoInfo
     {
         Title = repoData.FullName ?? repo,
         Description = repoData.Description ?? "",
@@ -147,7 +147,7 @@ static string Truncate(string s, int max) => s.Length <= max ? s : s[..(max - 1)
 // --- View Models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
-public class RepoView
+public class RepoInfo
 {
     public string Title { get; set; } = "";
 
@@ -213,7 +213,7 @@ public class ReleaseRow
     public string Published { get; set; } = "";
 }
 
-[MarkoutContext(typeof(RepoView))]
+[MarkoutContext(typeof(RepoInfo))]
 [MarkoutContext(typeof(ContributorRow))]
 [MarkoutContext(typeof(ReleaseRow))]
 public partial class RepoContext : MarkoutSerializerContext { }

--- a/samples/HelloMarkout/HelloMarkout.cs
+++ b/samples/HelloMarkout/HelloMarkout.cs
@@ -1,6 +1,6 @@
 using Markout;
 
-var city = new CityView
+var city = new City
 {
     Name = "Vancouver",
     Country = "Canada",
@@ -14,7 +14,7 @@ var city = new CityView
 MarkoutSerializer.Serialize(city, Console.Out, CityContext.Default);
 
 [MarkoutSerializable(TitleProperty = nameof(Name))]
-public class CityView
+public class City
 {
     public string Name { get; set; } = "";
     public string Country { get; set; } = "";
@@ -36,5 +36,5 @@ public class CityView
     public double Temperature { get; set; }
 }
 
-[MarkoutContext(typeof(CityView))]
+[MarkoutContext(typeof(City))]
 public partial class CityContext : MarkoutSerializerContext { }

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -94,7 +94,7 @@ var severityCounts = cveInfo.Values
 var criticalCount = severityCounts.GetValueOrDefault("CRITICAL");
 
 // Serialize to markdown
-var view = new LatestCvesView
+var view = new CveReport
 {
     Title = ".NET Security Advisories",
     Span = $"{cutoff:MMM yyyy} \u2013 {DateTimeOffset.UtcNow:MMM yyyy}",
@@ -111,7 +111,7 @@ MarkoutSerializer.Serialize(view, Console.Out, new SpectreFormatter(AnsiConsole.
 // --- View Model ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class LatestCvesView
+public class CveReport
 {
     public string Title { get; set; } = "";
 
@@ -129,7 +129,7 @@ public class LatestCvesView
     public List<TreeNode>? Releases { get; set; }
 }
 
-[MarkoutContext(typeof(LatestCvesView))]
+[MarkoutContext(typeof(CveReport))]
 public partial class LatestCvesContext : MarkoutSerializerContext { }
 
 // --- JSON Models (snake_case via options; explicit for HAL _embedded/_links) ---

--- a/samples/RecordDemo/RecordDemo.cs
+++ b/samples/RecordDemo/RecordDemo.cs
@@ -1,6 +1,6 @@
 using Markout;
 
-var artist = new ArtistView(
+var artist = new Artist(
     Name: "Sarah McLachlan",
     Genre: "Pop / Adult Contemporary",
     Origin: "Halifax, Nova Scotia",
@@ -9,13 +9,13 @@ var artist = new ArtistView(
 
 MarkoutSerializer.Serialize(artist, Console.Out, ArtistContext.Default);
 
-[MarkoutSerializable(TitleProperty = nameof(ArtistView.Name))]
-public record ArtistView(
+[MarkoutSerializable(TitleProperty = nameof(Artist.Name))]
+public record Artist(
     string Name,
     string Genre,
     string Origin,
     int DebutYear,
     string BestKnownFor);
 
-[MarkoutContext(typeof(ArtistView))]
+[MarkoutContext(typeof(Artist))]
 public partial class ArtistContext : MarkoutSerializerContext { }

--- a/samples/Serialization/AdvancedFeatures.cs
+++ b/samples/Serialization/AdvancedFeatures.cs
@@ -4,7 +4,7 @@ namespace Markout.Samples.Serialization;
 
 #region SkipNullAndDisplayFormat
 [MarkoutSerializable(TitleProperty = nameof(Name))]
-public class ServerView
+public class Server
 {
     public string Name { get; set; } = "";
 
@@ -61,7 +61,7 @@ public class MetricRow
 
 #region ShowWhenAndLink
 [MarkoutSerializable(TitleProperty = nameof(Name), FieldLayout = FieldLayout.Table)]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
 
@@ -85,10 +85,10 @@ public class PackageView
 }
 #endregion
 
-[MarkoutContext(typeof(ServerView))]
+[MarkoutContext(typeof(Server))]
 [MarkoutContext(typeof(AuditReport))]
 [MarkoutContext(typeof(MetricRow))]
-[MarkoutContext(typeof(PackageView))]
+[MarkoutContext(typeof(Package))]
 public partial class AdvancedContext : MarkoutSerializerContext { }
 
 /// <summary>
@@ -103,7 +103,7 @@ public static class AdvancedFeatures
     public static void SkipNullAndDisplayFormat()
     {
         #region SkipNullAndDisplayFormatUsage
-        var server = new ServerView
+        var server = new Server
         {
             Name = "prod-web-01",
             Region = "us-east-1",
@@ -122,7 +122,7 @@ public static class AdvancedFeatures
         Console.WriteLine();
 
         // With nulls — Region and CpuUsage are omitted
-        var minimal = new ServerView
+        var minimal = new Server
         {
             Name = "staging-01",
             RequestsPerSecond = 50,
@@ -162,7 +162,7 @@ public static class AdvancedFeatures
     public static void ShowWhenAndLinks()
     {
         #region ShowWhenAndLinkUsage
-        var pkg = new PackageView
+        var pkg = new Package
         {
             Name = "dotnet-inspect",
             Homepage = "https://github.com/richlander/dotnet-inspect",
@@ -184,7 +184,7 @@ public static class AdvancedFeatures
         Console.WriteLine();
 
         // With IsVerified=false, IsTool=false — those fields are hidden
-        var basic = new PackageView
+        var basic = new Package
         {
             Name = "SomeLib",
             IsVerified = false,

--- a/samples/Serialization/BasicUsage.cs
+++ b/samples/Serialization/BasicUsage.cs
@@ -2,9 +2,9 @@ using Markout;
 
 namespace Markout.Samples.Serialization;
 
-#region ProductViewObject
+#region ProductObject
 [MarkoutSerializable(TitleProperty = nameof(Name))]
-public class ProductView
+public class Product
 {
     public string Name { get; set; } = "";
     public string Category { get; set; } = "";
@@ -12,7 +12,7 @@ public class ProductView
     public bool InStock { get; set; }
 }
 
-[MarkoutContext(typeof(ProductView))]
+[MarkoutContext(typeof(Product))]
 public partial class SampleContext : MarkoutSerializerContext
 {
 }
@@ -29,7 +29,7 @@ public static class BasicUsage
     public static void SerializeSimpleType()
     {
         #region SerializeSimpleType
-        ProductView product = new ProductView
+        Product product = new Product
         {
             Name = "Widget Pro",
             Category = "Electronics",
@@ -54,7 +54,7 @@ public static class BasicUsage
     public static void WriteToStream()
     {
         #region WriteToStream
-        ProductView product = new ProductView
+        Product product = new Product
         {
             Name = "Gadget X",
             Category = "Tools",

--- a/samples/Serialization/SectionFiltering.cs
+++ b/samples/Serialization/SectionFiltering.cs
@@ -82,7 +82,7 @@ public static class SectionFiltering
             BoldFieldNames = true                       // Enable bold field names
         });
 
-        ProductView product = new ProductView
+        Product product = new Product
         {
             Name = "Widget Pro",
             Category = "Electronics",

--- a/samples/SkipNullDemo/SkipNullDemo.cs
+++ b/samples/SkipNullDemo/SkipNullDemo.cs
@@ -4,7 +4,7 @@
 using Markout;
 
 // Only Name and License are set — Repository and Stars are omitted from output
-var pkg = new PackageView
+var pkg = new Package
 {
     Name = "Markout",
     License = "MIT",
@@ -17,7 +17,7 @@ MarkoutSerializer.Serialize(pkg, Console.Out, PackageContext.Default);
 
 [MarkoutSerializable(TitleProperty = nameof(Name))]
 [MarkoutSkipNull]
-public class PackageView
+public class Package
 {
     public string Name { get; set; } = "";
     public string? License { get; set; }
@@ -26,5 +26,5 @@ public class PackageView
     public int? Stars { get; set; }
 }
 
-[MarkoutContext(typeof(PackageView))]
+[MarkoutContext(typeof(Package))]
 public partial class PackageContext : MarkoutSerializerContext { }

--- a/src/Markout.Demo/DemoData.cs
+++ b/src/Markout.Demo/DemoData.cs
@@ -26,12 +26,12 @@ internal static class DemoData
     /// <summary>
     /// Simple view: first shoe with basic fields.
     /// </summary>
-    public static SimpleShoeView GetSimpleView(string shoeId)
+    public static SimpleShoe GetSimpleShoe(string shoeId)
     {
         var shoe = Data.GetShoe(shoeId) ?? Data.Shoes?.First()
             ?? throw new InvalidOperationException("No shoes found");
             
-        return new SimpleShoeView
+        return new SimpleShoe
         {
             Name = $"Altra {shoe.Model}",
             Description = "This demo shows a basic product with scalar fields.",
@@ -45,11 +45,11 @@ internal static class DemoData
     /// <summary>
     /// Bullet list view: shoes as formatted strings.
     /// </summary>
-    public static ShoeBulletListView GetBulletListView()
+    public static ShoeBulletList GetShoeBulletList()
     {
         var shoes = Data.Shoes ?? new List<Shoe>();
         
-        return new ShoeBulletListView
+        return new ShoeBulletList
         {
             Name = Data.Catalog?.Name ?? "Shoes",
             Description = "This demo shows products as a bullet list with custom formatting.",
@@ -64,11 +64,11 @@ internal static class DemoData
     /// <summary>
     /// Table view: all shoes as table rows.
     /// </summary>
-    public static ShoeTableView GetTableView()
+    public static ShoeTable GetShoeTable()
     {
         var shoes = Data.Shoes ?? new List<Shoe>();
         
-        return new ShoeTableView
+        return new ShoeTable
         {
             Name = Data.Catalog?.Name ?? "Shoes",
             Description = "This demo shows products as a table with a section heading.",
@@ -87,11 +87,11 @@ internal static class DemoData
     /// <summary>
     /// Detail view: shoes with nested features and reviews.
     /// </summary>
-    public static ShoeDetailView GetDetailView()
+    public static ShoeDetail GetShoeDetail()
     {
         var shoes = Data.Shoes ?? new List<Shoe>();
         
-        return new ShoeDetailView
+        return new ShoeDetail
         {
             Name = Data.Catalog?.Name ?? "Shoes",
             Description = "This demo shows detailed products with nested features and reviews.",
@@ -111,12 +111,12 @@ internal static class DemoData
     /// <summary>
     /// Sections view: single shoe with specs and reviews.
     /// </summary>
-    public static ShoeSectionsView GetSectionsView(string shoeId)
+    public static ShoeSections GetShoeSections(string shoeId)
     {
         var shoe = Data.GetShoe(shoeId) ?? Data.Shoes?.First()
             ?? throw new InvalidOperationException("No shoes found");
             
-        return new ShoeSectionsView
+        return new ShoeSections
         {
             Name = $"Altra {shoe.Model}",
             Description = "This demo shows a product with separate sections for specs and reviews.",
@@ -130,7 +130,7 @@ internal static class DemoData
     /// <summary>
     /// Inventory view: pivoted by size and color.
     /// </summary>
-    public static ShoeInventoryView GetInventoryView(string shoeId)
+    public static ShoeInventory GetShoeInventory(string shoeId)
     {
         var shoe = Data.GetShoe(shoeId) ?? Data.Shoes?.First()
             ?? throw new InvalidOperationException("No shoes found");
@@ -138,7 +138,7 @@ internal static class DemoData
         var entries = Data.Inventory?.Where(i => i.ShoeId == shoeId).ToList()
             ?? new List<InventoryEntry>();
             
-        return new ShoeInventoryView
+        return new ShoeInventory
         {
             Name = $"Altra {shoe.Model}",
             Description = "This demo shows pivoted inventory data: rows are sizes, columns are colors.",

--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -31,8 +31,8 @@ public static class Demos
     /// </summary>
     private static void Simple(TextWriter output)
     {
-        var view = DemoData.GetSimpleView("torin-7");
-        MarkoutSerializer.Serialize(view, output, DemoContext.Default);
+        var data = DemoData.GetSimpleShoe("torin-7");
+        MarkoutSerializer.Serialize(data, output, DemoContext.Default);
     }
 
     /// <summary>
@@ -40,8 +40,8 @@ public static class Demos
     /// </summary>
     private static void ListDemo(TextWriter output)
     {
-        var view = DemoData.GetBulletListView();
-        MarkoutSerializer.Serialize(view, output, DemoContext.Default);
+        var data = DemoData.GetShoeBulletList();
+        MarkoutSerializer.Serialize(data, output, DemoContext.Default);
     }
 
     /// <summary>
@@ -49,8 +49,8 @@ public static class Demos
     /// </summary>
     private static void TableDemo(TextWriter output)
     {
-        var view = DemoData.GetTableView();
-        MarkoutSerializer.Serialize(view, output, DemoContext.Default);
+        var data = DemoData.GetShoeTable();
+        MarkoutSerializer.Serialize(data, output, DemoContext.Default);
     }
 
     /// <summary>
@@ -58,8 +58,8 @@ public static class Demos
     /// </summary>
     private static void Nested(TextWriter output)
     {
-        var view = DemoData.GetDetailView();
-        MarkoutSerializer.Serialize(view, output, DemoContext.Default);
+        var data = DemoData.GetShoeDetail();
+        MarkoutSerializer.Serialize(data, output, DemoContext.Default);
     }
 
     /// <summary>
@@ -67,8 +67,8 @@ public static class Demos
     /// </summary>
     private static void Sections(TextWriter output)
     {
-        var view = DemoData.GetSectionsView("lone-peak-8");
-        MarkoutSerializer.Serialize(view, output, DemoContext.Default);
+        var data = DemoData.GetShoeSections("lone-peak-8");
+        MarkoutSerializer.Serialize(data, output, DemoContext.Default);
     }
 
     /// <summary>
@@ -76,8 +76,8 @@ public static class Demos
     /// </summary>
     private static void Pivot(TextWriter output)
     {
-        var view = DemoData.GetInventoryView("torin-7");
-        MarkoutSerializer.Serialize(view, output, DemoContext.Default);
+        var data = DemoData.GetShoeInventory("torin-7");
+        MarkoutSerializer.Serialize(data, output, DemoContext.Default);
     }
 
     /// <summary>

--- a/src/Markout.Demo/Models.cs
+++ b/src/Markout.Demo/Models.cs
@@ -60,13 +60,13 @@ public class InventoryEntry
 
 #endregion
 
-#region Markout View Models
+#region Markout Models
 
 /// <summary>
 /// Simple view: single shoe with basic scalar fields.
 /// </summary>
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Description))]
-public class SimpleShoeView
+public class SimpleShoe
 {
     public string Name { get; set; } = "";
     
@@ -83,7 +83,7 @@ public class SimpleShoeView
 /// List view: catalog with shoes as bullet list.
 /// </summary>
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Description))]
-public class ShoeBulletListView
+public class ShoeBulletList
 {
     public string Name { get; set; } = "";
     
@@ -98,7 +98,7 @@ public class ShoeBulletListView
 /// Table view: catalog with shoes as table rows.
 /// </summary>
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Description))]
-public class ShoeTableView
+public class ShoeTable
 {
     public string Name { get; set; } = "";
     
@@ -129,7 +129,7 @@ public class ShoeTableRow
 /// Nested view: detailed shoes with features and reviews.
 /// </summary>
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Description))]
-public class ShoeDetailView
+public class ShoeDetail
 {
     public string Name { get; set; } = "";
     
@@ -163,7 +163,7 @@ public class ShoeDetailItem
 /// Sections view: single shoe with specs and reviews sections.
 /// </summary>
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Description))]
-public class ShoeSectionsView
+public class ShoeSections
 {
     public string Name { get; set; } = "";
     
@@ -184,7 +184,7 @@ public class ShoeSectionsView
 /// Pivot view: inventory pivoted by size and color.
 /// </summary>
 [MarkoutSerializable(TitleProperty = nameof(Name), DescriptionProperty = nameof(Description))]
-public class ShoeInventoryView
+public class ShoeInventory
 {
     public string Name { get; set; } = "";
     
@@ -238,13 +238,13 @@ public class Review
 [MarkoutContext(typeof(Feature))]
 [MarkoutContext(typeof(Review))]
 // View types (for serialization)
-[MarkoutContext(typeof(SimpleShoeView))]
-[MarkoutContext(typeof(ShoeBulletListView))]
-[MarkoutContext(typeof(ShoeTableView))]
+[MarkoutContext(typeof(SimpleShoe))]
+[MarkoutContext(typeof(ShoeBulletList))]
+[MarkoutContext(typeof(ShoeTable))]
 [MarkoutContext(typeof(ShoeTableRow))]
-[MarkoutContext(typeof(ShoeDetailView))]
-[MarkoutContext(typeof(ShoeSectionsView))]
-[MarkoutContext(typeof(ShoeInventoryView))]
+[MarkoutContext(typeof(ShoeDetail))]
+[MarkoutContext(typeof(ShoeSections))]
+[MarkoutContext(typeof(ShoeInventory))]
 public partial class DemoContext : MarkoutSerializerContext
 {
 }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -53,7 +53,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         bool autoFields = true,
         int autoFieldsCount = 0,
         FieldLayoutKind fieldLayout = FieldLayoutKind.Table,
-        NamingPolicyKind namingPolicy = NamingPolicyKind.Default,
+        NamingPolicyKind namingPolicy = NamingPolicyKind.PascalCaseWords,
         bool skipNullByDefault = false,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
@@ -392,8 +392,8 @@ internal enum FieldLayoutKind
 /// </summary>
 internal enum NamingPolicyKind
 {
-    Default = 0,
-    PascalCaseWords = 1
+    PascalCaseWords = 0,
+    Verbatim = 1
 }
 
 /// <summary>

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -140,7 +140,7 @@ internal static class TypeParser
         // Default to OneLine
         fieldLayout ??= FieldLayoutKind.Table;
         // Default naming policy
-        namingPolicy ??= NamingPolicyKind.Default;
+        namingPolicy ??= NamingPolicyKind.PascalCaseWords;
 
         // Check for type-level [MarkoutSkipNull]
         bool skipNullByDefault = typeSymbol.GetAttributes()
@@ -218,7 +218,7 @@ internal static class TypeParser
         KnownTypeSymbols knownTypes,
         List<DiagnosticInfo> diagnostics,
         HashSet<ITypeSymbol>? visitedTypes = null,
-        NamingPolicyKind namingPolicy = NamingPolicyKind.Default,
+        NamingPolicyKind namingPolicy = NamingPolicyKind.PascalCaseWords,
         bool skipNullByDefault = false)
     {
         var isIgnored = HasAttribute(prop, MarkoutIgnoreAttribute);
@@ -706,13 +706,13 @@ internal static class TypeParser
     private static (string? TitleProperty, string? TitleContextProperty, bool AutoFields, FieldLayoutKind FieldLayout, NamingPolicyKind NamingPolicy, bool SkipNullByDefault) GetElementTypeSettings(ITypeSymbol type)
     {
         if (type is not INamedTypeSymbol namedType)
-            return (null, null, true, FieldLayoutKind.Table, NamingPolicyKind.Default, false);
+            return (null, null, true, FieldLayoutKind.Table, NamingPolicyKind.PascalCaseWords, false);
 
         string? titleProperty = null;
         string? titleContextProperty = null;
         bool autoFields = true;
         FieldLayoutKind fieldLayout = FieldLayoutKind.Table;
-        NamingPolicyKind namingPolicy = NamingPolicyKind.Default;
+        NamingPolicyKind namingPolicy = NamingPolicyKind.PascalCaseWords;
 
         var serializableAttr = namedType.GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutSerializableAttribute);
@@ -746,7 +746,7 @@ internal static class TypeParser
         KnownTypeSymbols? knownTypes = null,
         List<DiagnosticInfo>? diagnostics = null,
         HashSet<ITypeSymbol>? visitedTypes = null,
-        NamingPolicyKind namingPolicy = NamingPolicyKind.Default,
+        NamingPolicyKind namingPolicy = NamingPolicyKind.PascalCaseWords,
         bool skipNullByDefault = false)
     {
         var properties = new List<PropertyMetadata>();

--- a/src/Markout/Attributes/MarkoutSerializableAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSerializableAttribute.cs
@@ -50,7 +50,7 @@ public sealed class MarkoutSerializableAttribute : Attribute
     /// <summary>
     /// Gets or sets the naming policy for transforming property names into display names.
     /// Only applies to properties without an explicit [MarkoutPropertyName] attribute.
-    /// Default is Default (use property name as-is).
+    /// Default is PascalCaseWords (split PascalCase into separate words).
     /// </summary>
-    public NamingPolicy NamingPolicy { get; set; } = NamingPolicy.Default;
+    public NamingPolicy NamingPolicy { get; set; } = NamingPolicy.PascalCaseWords;
 }

--- a/src/Markout/NamingPolicy.cs
+++ b/src/Markout/NamingPolicy.cs
@@ -6,13 +6,14 @@ namespace Markout;
 public enum NamingPolicy
 {
     /// <summary>
-    /// Use the property name as-is (or [MarkoutPropertyName] if specified).
-    /// </summary>
-    Default,
-
-    /// <summary>
     /// Split PascalCase into separate words.
     /// Example: InformationalVersion → "Informational Version", PublicKeyToken → "Public Key Token".
+    /// This is the default.
     /// </summary>
-    PascalCaseWords
+    PascalCaseWords = 0,
+
+    /// <summary>
+    /// Use the property name as-is (or [MarkoutPropertyName] if specified).
+    /// </summary>
+    Verbatim = 1
 }

--- a/tests/Markout.Tests/IgnoreColumnWhenTests.cs
+++ b/tests/Markout.Tests/IgnoreColumnWhenTests.cs
@@ -16,7 +16,7 @@ public class FindRow
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
-public class FindResultView
+public class FindResult
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
 
@@ -33,7 +33,7 @@ public class FindResultView
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
-public class SingleConditionView
+public class SingleCondition
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
 
@@ -46,7 +46,7 @@ public class SingleConditionView
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
-public class MixedIgnoreView
+public class MixedIgnore
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
 
@@ -70,7 +70,7 @@ public class GroupedFindRow
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
-public class GroupByWithIgnoreColumnWhenView
+public class GroupByWithIgnoreColumnWhen
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
 
@@ -85,7 +85,7 @@ public class GroupByWithIgnoreColumnWhenView
 // --- OneLineFormatter + IgnoreColumnWhen integration ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class OneLineIgnoreColumnWhenView
+public class OneLineIgnoreColumnWhen
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
     public int Count { get; set; }
@@ -99,12 +99,12 @@ public class OneLineIgnoreColumnWhenView
 }
 
 [MarkoutContext(typeof(FindRow))]
-[MarkoutContext(typeof(FindResultView))]
-[MarkoutContext(typeof(SingleConditionView))]
-[MarkoutContext(typeof(MixedIgnoreView))]
-[MarkoutContext(typeof(GroupByWithIgnoreColumnWhenView))]
+[MarkoutContext(typeof(FindResult))]
+[MarkoutContext(typeof(SingleCondition))]
+[MarkoutContext(typeof(MixedIgnore))]
+[MarkoutContext(typeof(GroupByWithIgnoreColumnWhen))]
 [MarkoutContext(typeof(GroupedFindRow))]
-[MarkoutContext(typeof(OneLineIgnoreColumnWhenView))]
+[MarkoutContext(typeof(OneLineIgnoreColumnWhen))]
 public partial class IgnoreColumnWhenTestContext : MarkoutSerializerContext
 {
 }
@@ -117,7 +117,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void UniformPattern_HidesPatternColumn()
     {
-        var view = new FindResultView
+        var view = new FindResult
         {
             Title = "Search",
             Results = new List<FindRow>
@@ -141,7 +141,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void NonUniformPattern_ShowsAllColumns()
     {
-        var view = new FindResultView
+        var view = new FindResult
         {
             Title = "Search",
             Results = new List<FindRow>
@@ -164,7 +164,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void BothUniform_HidesBothColumns()
     {
-        var view = new FindResultView
+        var view = new FindResult
         {
             Title = "Search",
             Results = new List<FindRow>
@@ -185,7 +185,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void NeitherUniform_ShowsAllColumns()
     {
-        var view = new FindResultView
+        var view = new FindResult
         {
             Title = "Search",
             Results = new List<FindRow>
@@ -206,7 +206,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void SingleCondition_HidesWhenTrue()
     {
-        var view = new SingleConditionView
+        var view = new SingleCondition
         {
             Title = "Test",
             Items = new List<FindRow>
@@ -229,7 +229,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void SingleCondition_ShowsWhenFalse()
     {
-        var view = new SingleConditionView
+        var view = new SingleCondition
         {
             Title = "Test",
             Items = new List<FindRow>
@@ -249,7 +249,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void MixedWithStaticIgnore_BothApply()
     {
-        var view = new MixedIgnoreView
+        var view = new MixedIgnore
         {
             Title = "Test",
             Items = new List<FindRow>
@@ -273,7 +273,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void MixedWithStaticIgnore_DynamicShowsWhenNotUniform()
     {
-        var view = new MixedIgnoreView
+        var view = new MixedIgnore
         {
             Title = "Test",
             Items = new List<FindRow>
@@ -297,7 +297,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void GroupBy_WithIgnoreColumnWhen_HidesUniformColumn()
     {
-        var view = new GroupByWithIgnoreColumnWhenView
+        var view = new GroupByWithIgnoreColumnWhen
         {
             Title = "Search",
             Results = new List<GroupedFindRow>
@@ -323,7 +323,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void GroupBy_WithIgnoreColumnWhen_ShowsNonUniformColumn()
     {
-        var view = new GroupByWithIgnoreColumnWhenView
+        var view = new GroupByWithIgnoreColumnWhen
         {
             Title = "Search",
             Results = new List<GroupedFindRow>
@@ -348,7 +348,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void OneLineFormatter_WithIgnoreColumnWhen_HidesUniformColumn()
     {
-        var view = new OneLineIgnoreColumnWhenView
+        var view = new OneLineIgnoreColumnWhen
         {
             Title = "Search",
             Count = 2,
@@ -373,7 +373,7 @@ public class IgnoreColumnWhenTests
     [Fact]
     public void OneLineFormatter_WithIgnoreColumnWhen_ShowsNonUniformColumn()
     {
-        var view = new OneLineIgnoreColumnWhenView
+        var view = new OneLineIgnoreColumnWhen
         {
             Title = "Search",
             Count = 2,
@@ -401,7 +401,7 @@ public class IgnoreColumnWhenTests
         Console.SetError(errWriter);
         try
         {
-            var view = new OneLineIgnoreColumnWhenView
+            var view = new OneLineIgnoreColumnWhen
             {
                 Title = "Search",
                 Count = 42,

--- a/tests/Markout.Tests/IgnoreFieldsTests.cs
+++ b/tests/Markout.Tests/IgnoreFieldsTests.cs
@@ -5,7 +5,7 @@ namespace Markout.Tests;
 // --- Test types ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ViewWithFields
+public class TypeWithFields
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
     public int Count { get; set; }
@@ -22,7 +22,7 @@ public class SimpleRow
 }
 
 [MarkoutContext(typeof(SimpleRow))]
-[MarkoutContext(typeof(ViewWithFields))]
+[MarkoutContext(typeof(TypeWithFields))]
 public partial class IgnoreFieldsTestContext : MarkoutSerializerContext
 {
 }
@@ -35,7 +35,7 @@ public class IgnoreFieldsTests
     [Fact]
     public void Serialize_OneLineFormatter_RendersFieldsAsTable()
     {
-        var view = new ViewWithFields
+        var view = new TypeWithFields
         {
             Title = "Test",
             Count = 42,
@@ -53,7 +53,7 @@ public class IgnoreFieldsTests
     [Fact]
     public void Serialize_MarkdownFormatter_RendersFields()
     {
-        var view = new ViewWithFields
+        var view = new TypeWithFields
         {
             Title = "Test",
             Count = 42,

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -266,7 +266,7 @@ public class Person
         public LibraryInfoSection? Info { get; set; }
     }
 
-    [MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+    [MarkoutSerializable(FieldLayout = FieldLayout.Table)]
     [MarkoutSkipNull]
     public class LibraryInfoSection
     {
@@ -282,7 +282,7 @@ public class Person
     }
 
     // Nested object in a collection with NamingPolicy
-    [MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords)]
+    [MarkoutSerializable]
     public class AttributeRow
     {
         public string Name { get; set; } = "";
@@ -1094,7 +1094,7 @@ public class ParameterRow
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ApiMethodView
+public class ApiMethod
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
     public string Kind { get; set; } = "";
@@ -1103,17 +1103,17 @@ public class ApiMethodView
 }
 
 [MarkoutContext(typeof(ConstructorOverload))]
-[MarkoutContext(typeof(ApiMethodView))]
-[MarkoutContext(typeof(ILView))]
+[MarkoutContext(typeof(ApiMethod))]
+[MarkoutContext(typeof(ILDetail))]
 [MarkoutContext(typeof(VulnerabilityReport))]
-[MarkoutContext(typeof(CtorEmphasisView))]
+[MarkoutContext(typeof(CtorEmphasis))]
 public partial class CodeSectionTestContext : MarkoutSerializerContext
 {
 }
 
 // Sectioned CodeSection: [MarkoutSection] on CodeSection renders heading + code block
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ILView
+public class ILDetail
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
     public string Kind { get; set; } = "";
@@ -1149,7 +1149,7 @@ public class VulnRow
 
 // Nested ctor overloads: List<ConstructorOverload> with CodeSection + table
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class CtorEmphasisView
+public class CtorEmphasis
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
     public string Kind { get; set; } = "";
@@ -1180,7 +1180,7 @@ public partial class DistributionTestContext : MarkoutSerializerContext
 public record ApiMemberRow(string? Select, string Name, string Signature, string? Description);
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class MultiIgnoreView
+public class MultiIgnore
 {
     [MarkoutIgnore] public string Title { get; set; } = "";
 
@@ -1197,7 +1197,7 @@ public class MultiIgnoreView
     public List<ApiMemberRow>? MembersAll { get; set; }
 }
 
-[MarkoutContext(typeof(MultiIgnoreView))]
+[MarkoutContext(typeof(MultiIgnore))]
 public partial class MultiIgnoreTestContext : MarkoutSerializerContext
 {
 }
@@ -1329,7 +1329,7 @@ public class CodeSectionTests
     [Fact]
     public void Serialize_CodeSection_RendersCodeBlock()
     {
-        var view = new ApiMethodView
+        var view = new ApiMethod
         {
             Title = "JsonSerializer.Serialize",
             Kind = "Method",
@@ -1373,7 +1373,7 @@ public class CodeSectionTests
     [Fact]
     public void Serialize_CodeSection_DefaultContent_SkipsBlock()
     {
-        var view = new ApiMethodView
+        var view = new ApiMethod
         {
             Title = "Test",
             Kind = "Method",
@@ -1390,7 +1390,7 @@ public class CodeSectionTests
     [Fact]
     public void Serialize_SectionedCodeSection_RendersHeadingAndCodeBlock()
     {
-        var view = new ILView
+        var view = new ILDetail
         {
             Title = "JsonSerializer.Serialize",
             Kind = "Method",
@@ -1417,7 +1417,7 @@ public class CodeSectionTests
     [Fact]
     public void Serialize_SectionedCodeSection_SkipsWhenDefault()
     {
-        var view = new ILView
+        var view = new ILDetail
         {
             Title = "Test",
             Kind = "Method",
@@ -1482,7 +1482,7 @@ public class CodeSectionTests
     [Fact]
     public void Serialize_NestedCtorOverloads_RendersSubsections()
     {
-        var view = new CtorEmphasisView
+        var view = new CtorEmphasis
         {
             Title = "JsonSerializerOptions",
             Kind = "Class",
@@ -1547,7 +1547,7 @@ public class DistributionTests
         var mdf = MarkoutSerializer.Serialize(summary, DistributionTestContext.Default);
 
         Assert.Contains("# .NET 9", mdf);
-        Assert.Contains("| TotalCves | 12 |", mdf);
+        Assert.Contains("| Total Cves | 12 |", mdf);
         Assert.Contains("## Severity Distribution", mdf);
         Assert.Contains("Jan 2025", mdf);
         Assert.Contains("Feb 2025", mdf);
@@ -1583,7 +1583,7 @@ public class MultiIgnorePropertyTests
     [Fact]
     public void Serialize_IgnoreTwoProperties_ShowsOnlyNameAndSignature()
     {
-        var view = new MultiIgnoreView
+        var view = new MultiIgnore
         {
             Title = "TestType",
             MembersCompact = TestRows
@@ -1600,7 +1600,7 @@ public class MultiIgnorePropertyTests
     [Fact]
     public void Serialize_IgnoreSelect_ShowsNameSignatureDescription()
     {
-        var view = new MultiIgnoreView
+        var view = new MultiIgnore
         {
             Title = "TestType",
             MembersWithDocs = TestRows
@@ -1618,7 +1618,7 @@ public class MultiIgnorePropertyTests
     [Fact]
     public void Serialize_IgnoreDescription_ShowsSelectNameSignature()
     {
-        var view = new MultiIgnoreView
+        var view = new MultiIgnore
         {
             Title = "TestType",
             MembersWithSelect = TestRows
@@ -1636,7 +1636,7 @@ public class MultiIgnorePropertyTests
     [Fact]
     public void Serialize_NoIgnore_ShowsAllColumns()
     {
-        var view = new MultiIgnoreView
+        var view = new MultiIgnore
         {
             Title = "TestType",
             MembersAll = TestRows

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -241,8 +241,8 @@ public class SerializerTests
         var mdf = context.Serialize(audit);
 
         // Should use custom symbols instead of yes/no
-        Assert.Contains("| IsDeterministic | ✓ |", mdf);
-        Assert.Contains("| HasSourceLink | ✗ |", mdf);
+        Assert.Contains("| Is Deterministic | ✓ |", mdf);
+        Assert.Contains("| Has Source Link | ✗ |", mdf);
     }
 
     [Fact]
@@ -582,11 +582,11 @@ public class SerializerTests
         var mdf = MarkoutSerializer.Serialize(status, SkipDefaultTestContext.Default);
 
         Assert.Contains("| Name | Server1 |", mdf);
-        Assert.Contains("| IsOnline |", mdf);
-        Assert.Contains("| ConnectionCount |", mdf);
-        Assert.Contains("| AlertLevel |", mdf);
-        Assert.Contains("| BytesTransferred |", mdf);
-        Assert.Contains("| CpuUsage |", mdf);
+        Assert.Contains("| Is Online |", mdf);
+        Assert.Contains("| Connection Count |", mdf);
+        Assert.Contains("| Alert Level |", mdf);
+        Assert.Contains("| Bytes Transferred |", mdf);
+        Assert.Contains("| Cpu Usage |", mdf);
     }
 
     [Fact]
@@ -596,8 +596,8 @@ public class SerializerTests
         var mdf = MarkoutSerializer.Serialize(status, SkipDefaultLineBreaksContext.Default);
 
         Assert.Contains("Name", mdf);
-        Assert.DoesNotContain("IsOnline", mdf);
-        Assert.DoesNotContain("ConnectionCount", mdf);
+        Assert.DoesNotContain("Is Online", mdf);
+        Assert.DoesNotContain("Connection Count", mdf);
     }
 
     [Fact]
@@ -606,8 +606,8 @@ public class SerializerTests
         var status = new ServerStatusLineBreaks { Name = "Server1", IsOnline = true, ConnectionCount = 5 };
         var mdf = MarkoutSerializer.Serialize(status, SkipDefaultLineBreaksContext.Default);
 
-        Assert.Contains("IsOnline", mdf);
-        Assert.Contains("ConnectionCount", mdf);
+        Assert.Contains("Is Online", mdf);
+        Assert.Contains("Connection Count", mdf);
     }
 
     [Fact]
@@ -617,8 +617,8 @@ public class SerializerTests
         var mdf = MarkoutSerializer.Serialize(status, SkipDefaultListContext.Default);
 
         Assert.Contains("Name", mdf);
-        Assert.DoesNotContain("IsOnline", mdf);
-        Assert.DoesNotContain("ConnectionCount", mdf);
+        Assert.DoesNotContain("Is Online", mdf);
+        Assert.DoesNotContain("Connection Count", mdf);
     }
 
     [Fact]
@@ -627,8 +627,8 @@ public class SerializerTests
         var status = new ServerStatusList { Name = "Server1", IsOnline = true, ConnectionCount = 10 };
         var mdf = MarkoutSerializer.Serialize(status, SkipDefaultListContext.Default);
 
-        Assert.Contains("IsOnline", mdf);
-        Assert.Contains("ConnectionCount", mdf);
+        Assert.Contains("Is Online", mdf);
+        Assert.Contains("Connection Count", mdf);
     }
 
     [Fact]
@@ -857,7 +857,7 @@ public class SerializerTests
     [Fact]
     public void Serialize_TableDisplay_FormatsInTableContext()
     {
-        var view = new InventoryView
+        var view = new Inventory
         {
             Title = "Inventory",
             Items = new()
@@ -891,8 +891,8 @@ public class SerializerTests
         var pkg = new VerifiedPackage { Name = "MyPkg", IsVerified = true, VerifiedBy = "Microsoft", IsTool = false, ToolFormat = "global" };
         var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
 
-        Assert.Contains("| VerifiedBy | Microsoft |", mdf);
-        Assert.DoesNotContain("| ToolFormat |", mdf);
+        Assert.Contains("| Verified By | Microsoft |", mdf);
+        Assert.DoesNotContain("| Tool Format |", mdf);
     }
 
     [Fact]
@@ -901,8 +901,8 @@ public class SerializerTests
         var pkg = new VerifiedPackage { Name = "MyPkg", IsVerified = false, VerifiedBy = "Microsoft", IsTool = false, ToolFormat = "global" };
         var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
 
-        Assert.DoesNotContain("VerifiedBy", mdf);
-        Assert.DoesNotContain("ToolFormat", mdf);
+        Assert.DoesNotContain("Verified By", mdf);
+        Assert.DoesNotContain("Tool Format", mdf);
     }
 
     [Fact]
@@ -911,7 +911,7 @@ public class SerializerTests
         var pkg = new VerifiedPackageOneLine { Name = "MyPkg", IsVerified = true, VerifiedBy = "Microsoft" };
         var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
 
-        Assert.Contains("| VerifiedBy | Microsoft |", mdf);
+        Assert.Contains("| Verified By | Microsoft |", mdf);
     }
 
     [Fact]
@@ -920,7 +920,7 @@ public class SerializerTests
         var pkg = new VerifiedPackageOneLine { Name = "MyPkg", IsVerified = false, VerifiedBy = "Microsoft" };
         var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
 
-        Assert.DoesNotContain("VerifiedBy", mdf);
+        Assert.DoesNotContain("Verified By", mdf);
     }
 
     [Fact]
@@ -929,7 +929,7 @@ public class SerializerTests
         var pkg = new VerifiedPackageList { Name = "MyPkg", IsVerified = true, VerifiedBy = "Microsoft" };
         var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
 
-        Assert.Contains("VerifiedBy: Microsoft", mdf);
+        Assert.Contains("Verified By: Microsoft", mdf);
     }
 
     [Fact]
@@ -938,7 +938,7 @@ public class SerializerTests
         var pkg = new VerifiedPackageList { Name = "MyPkg", IsVerified = false, VerifiedBy = "Microsoft" };
         var mdf = MarkoutSerializer.Serialize(pkg, ShowWhenTestContext.Default);
 
-        Assert.DoesNotContain("VerifiedBy", mdf);
+        Assert.DoesNotContain("Verified By", mdf);
     }
 
     // --- Link tests ---
@@ -993,7 +993,7 @@ public class SerializerTests
     [Fact]
     public void Serialize_Link_InTable()
     {
-        var view = new LinkProjectListView
+        var doc = new ProjectListDocument
         {
             Title = "Projects",
             Projects = new List<LinkProjectRow>
@@ -1002,7 +1002,7 @@ public class SerializerTests
                 new() { Name = "Beta", Url = "https://beta.com" }
             }
         };
-        var mdf = MarkoutSerializer.Serialize(view, LinkTestContext.Default);
+        var mdf = MarkoutSerializer.Serialize(doc, LinkTestContext.Default);
 
         Assert.Contains("[https://alpha.com](https://alpha.com)", mdf);
         Assert.Contains("[https://beta.com](https://beta.com)", mdf);
@@ -1178,7 +1178,7 @@ public class SerializerTests
     [Fact]
     public void Serialize_ScalarSection_MultipleSectionGroups()
     {
-        var view = new MultiSectionView
+        var view = new MultiSection
         {
             Name = "TestView",
             Author = "Alice",
@@ -1204,7 +1204,7 @@ public class SerializerTests
     [Fact]
     public void Serialize_ScalarSection_MixedWithCollectionSection()
     {
-        var view = new MixedSectionView
+        var view = new MixedSection
         {
             Name = "MixedView",
             Downloads = 100,
@@ -1353,7 +1353,7 @@ public class SerializerTests
     [Fact]
     public void Serialize_ScalarSection_ExcludeScalarSection_OtherSectionsRender()
     {
-        var view = new MixedSectionView
+        var view = new MixedSection
         {
             Name = "TestPkg",
             Downloads = 500,
@@ -1374,7 +1374,7 @@ public class SerializerTests
     [Fact]
     public void Serialize_ScalarSection_IncludeScalarSection_OnlyThatSectionRenders()
     {
-        var view = new MixedSectionView
+        var view = new MixedSection
         {
             Name = "TestPkg",
             Downloads = 500,
@@ -1635,8 +1635,8 @@ public partial class AutoFieldsCountTestContext : MarkoutSerializerContext
 {
 }
 
-// Test type for NamingPolicy — PascalCase → space-separated words
-[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords)]
+// Test type for NamingPolicy — PascalCase → space-separated words (now the default)
+[MarkoutSerializable]
 public class NamingPolicyTest
 {
     public string AssemblyVersion { get; set; } = "";
@@ -1975,7 +1975,7 @@ public class ItemRow
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
-public class InventoryView
+public class Inventory
 {
     [MarkoutIgnore]
     public string? Title { get; set; }
@@ -1983,7 +1983,7 @@ public class InventoryView
     public List<ItemRow>? Items { get; set; }
 }
 
-[MarkoutContext(typeof(InventoryView))]
+[MarkoutContext(typeof(Inventory))]
 [MarkoutContext(typeof(ItemRow))]
 public partial class TableDisplayTestContext : MarkoutSerializerContext
 {
@@ -2060,7 +2060,7 @@ public class LinkProjectRow
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
-public class LinkProjectListView
+public class ProjectListDocument
 {
     [MarkoutIgnore]
     public string? Title { get; set; }
@@ -2071,7 +2071,7 @@ public class LinkProjectListView
 [MarkoutContext(typeof(LinkProjectInfo))]
 [MarkoutContext(typeof(LinkProjectOneLine))]
 [MarkoutContext(typeof(LinkProjectList))]
-[MarkoutContext(typeof(LinkProjectListView))]
+[MarkoutContext(typeof(ProjectListDocument))]
 [MarkoutContext(typeof(LinkProjectRow))]
 public partial class LinkTestContext : MarkoutSerializerContext
 {
@@ -2101,7 +2101,7 @@ public class PackageWithScalarSection
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
-public class MultiSectionView
+public class MultiSection
 {
     [MarkoutIgnore] public string Name { get; set; } = "";
 
@@ -2121,7 +2121,7 @@ public class MultiSectionView
 }
 
 [MarkoutSerializable(TitleProperty = nameof(Name), AutoFields = false)]
-public class MixedSectionView
+public class MixedSection
 {
     [MarkoutIgnore] public string Name { get; set; } = "";
 
@@ -2203,8 +2203,8 @@ public class FieldCollectionBeforeSections
 }
 
 [MarkoutContext(typeof(PackageWithScalarSection))]
-[MarkoutContext(typeof(MultiSectionView))]
-[MarkoutContext(typeof(MixedSectionView))]
+[MarkoutContext(typeof(MultiSection))]
+[MarkoutContext(typeof(MixedSection))]
 [MarkoutContext(typeof(ConditionalScalarSection))]
 [MarkoutContext(typeof(FormattedScalarSection))]
 [MarkoutContext(typeof(ScalarSectionLineBreaks))]


### PR DESCRIPTION
## Summary

Two related changes that align the library's defaults and naming with its core value proposition: data models integrate directly with Markout.

### PascalCaseWords as default naming policy

Property names like `DebutYear` and `BestKnownFor` now automatically render as "Debut Year" and "Best Known For" without opting in. The old `NamingPolicy.Default` enum value is renamed to `NamingPolicy.Verbatim` for explicit opt-out.

**Before:** `Genre: Pop | DebutYear: 1988 | BestKnownFor: Angel`
**After:** `Genre: Pop | Debut Year: 1988 | Best Known For: Angel`

### Remove `*View` suffix from all types

The `View` suffix implies a separate view model layer is needed, which dilutes Markout's pitch that your data models are directly renderable. Renamed ~34 types across samples, demo, and tests (e.g., `ArtistView` → `Artist`, `CityView` → `City`, `RepoView` → `RepoInfo`).

Updated all documentation (README, SKILL.md, user-guide, design docs) from "view model" language to "model" language.

### Breaking changes (no package pushed yet)

- `NamingPolicy.Default` → `NamingPolicy.Verbatim` (enum value swap)
- `NamingPolicy.PascalCaseWords` is now the default (was opt-in)

### Validation

- 447 tests pass, 0 failures, 0 warnings
- Build clean across entire solution