### PR TITLE
Fix Quick Start output and add Field Layouts section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Population: 2632000
 
 ## Landmarks
 
-| Name             | Type       | Year |
-| ---------------- | ---------- | ---- |
-| Stanley Park     | Park       | 1888 |
-| Gastown          | Historic   | 1867 |
-| Science World    | Museum     | 1989 |
+| Name | Type | Year |
+| ----- | ----- | ----- |
+| Stanley Park | Park | 1888 |
+| Gastown | Historic | 1867 |
+| Science World | Museum | 1989 |
 ```
 
 ## Real-World Example: GitHub Repository Report
@@ -211,27 +211,27 @@ Stars: 17,698 | Forks: 5,350 | Open Issues: 8,385 | Language: C# | License: MIT 
 ## Languages
 
 | Category | Count | % |
-| -------- | ----- | - |
-| C#       | 80    | 83 |
-| C++      | 9     | 9  |
-| C        | 7     | 7  |
+| ----- | ----- | ----- |
+| C# | 80 | 83 |
+| C++ | 9 | 9 |
+| C | 7 | 7 |
 
 ## Top Contributors
 
-| Label       | Value |
-| ----------- | ----- |
-| vargaz      | 11910 |
+| Label | Value |
+| ----- | ----- |
+| vargaz | 11910 |
 | stephentoub | 10417 |
-| kumpera     | 4074  |
-| jkotas      | 3244  |
+| kumpera | 4074 |
+| jkotas | 3244 |
 
 ## Releases
 
-| Tag     | Name        | Published  |
-| ------- | ----------- | ---------- |
+| Tag | Name | Published |
+| ----- | ----- | ----- |
 | v10.0.3 | .NET 10.0.3 | 2026-02-10 |
 | v10.0.2 | .NET 10.0.2 | 2026-01-14 |
-| v9.0.13 | v9.0.13     | 2026-02-10 |
+| v9.0.13 | v9.0.13 | 2026-02-10 |
 ```
 
 **One-line output** — same model, `--oneline` flag, shows the Releases table only:

--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ MarkoutSerializer.Serialize(city, Console.Out, ReportContext.Default);
 ```markdown
 # Vancouver
 
-Province: British Columbia
-Population: 2632000
+| Field | Value |
+| ----- | ----- |
+| Province | British Columbia |
+| Population | 2632000 |
 
 ## Landmarks
 
@@ -167,7 +169,6 @@ public class RepoInfo
     [MarkoutDisplayFormat("{0:N0}")]
     public int Forks { get; set; }
 
-    [MarkoutPropertyName("Open Issues")]
     [MarkoutDisplayFormat("{0:N0}")]
     public int OpenIssues { get; set; }
 
@@ -206,12 +207,18 @@ dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format oneline  
 
 .NET is a cross-platform runtime for cloud, mobile, desktop, and IoT apps.
 
-Stars: 17,698 | Forks: 5,350 | Open Issues: 8,385 | Language: C# | License: MIT License
+| Field | Value |
+| ----- | ----- |
+| Stars | 17,703 |
+| Forks | 5,353 |
+| Open Issues | 8,371 |
+| Language | C# |
+| License | MIT License |
 
 ## Languages
 
 | Category | Count | % |
-| ----- | ----- | ----- |
+| -------- | ----- | - |
 | C# | 80 | 83 |
 | C++ | 9 | 9 |
 | C | 7 | 7 |
@@ -221,22 +228,29 @@ Stars: 17,698 | Forks: 5,350 | Open Issues: 8,385 | Language: C# | License: MIT 
 | Label | Value |
 | ----- | ----- |
 | vargaz | 11910 |
-| stephentoub | 10417 |
+| stephentoub | 10418 |
 | kumpera | 4074 |
-| jkotas | 3244 |
+| jkotas | 3245 |
 
 ## Releases
 
 | Tag | Name | Published |
-| ----- | ----- | ----- |
-| v10.0.3 | .NET 10.0.3 | 2026-02-10 |
-| v10.0.2 | .NET 10.0.2 | 2026-01-14 |
+| --- | ---- | --------- |
+| v8.0.24 | .NET 8.0.24 | 2026-02-10 |
 | v9.0.13 | v9.0.13 | 2026-02-10 |
+| v10.0.3 | .NET 10.0.3 | 2026-02-10 |
 ```
 
-**One-line output** — same model, `--oneline` flag, shows the Releases table only:
+**One-line output** — same model, `--oneline` flag:
 
 ```text
+FIELD        VALUE
+Stars        17,703
+Forks        5,353
+Open Issues  8,371
+Language     C#
+License      MIT License
+
 TAG      NAME         PUBLISHED
 v8.0.24  .NET 8.0.24  2026-02-10
 v9.0.13  v9.0.13      2026-02-10

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ public record Artist( ... );
 - Best Known For: Angel, Building a Mystery, Adia
 ```
 
+Or `Numbered`:
+
+```markdown
+# Sarah McLachlan
+
+1. Genre: Pop / Adult Contemporary
+2. Origin: Halifax, Nova Scotia
+3. Debut Year: 1988
+4. Best Known For: Angel, Building a Mystery, Adia
+```
+
 The data model doesn't change — only the attribute controls the shape.
 
 ## Adding Sections and Tables

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ Or `Numbered`:
 4. Best Known For: Angel, Building a Mystery, Adia
 ```
 
+Or `Plain` — bare lines, no markers:
+
+```markdown
+# Sarah McLachlan
+
+Genre: Pop / Adult Contemporary
+Origin: Halifax, Nova Scotia
+Debut Year: 1988
+Best Known For: Angel, Building a Mystery, Adia
+```
+
 The data model doesn't change — only the attribute controls the shape.
 
 ## Adding Sections and Tables

--- a/README.md
+++ b/README.md
@@ -35,10 +35,48 @@ public partial class ArtistContext : MarkoutSerializerContext { }
 ```markdown
 # Sarah McLachlan
 
+| Field | Value |
+| ----- | ----- |
+| Genre | Pop / Adult Contemporary |
+| Origin | Halifax, Nova Scotia |
+| Debut Year | 1988 |
+| Best Known For | Angel, Building a Mystery, Adia |
+```
+
+Three things: a record, a context, one line of serialization. The `TitleProperty` becomes a heading; everything else renders as a field table.
+
+## Field Layouts
+
+The same model renders differently with `FieldLayout`. The default is a two-column table. Switch to `Inline` for a compact summary line:
+
+```csharp
+[MarkoutSerializable(TitleProperty = nameof(Artist.Name), FieldLayout = FieldLayout.Inline)]
+public record Artist( ... );
+```
+
+```markdown
+# Sarah McLachlan
+
 Genre: Pop / Adult Contemporary | Origin: Halifax, Nova Scotia | Debut Year: 1988 | Best Known For: Angel, Building a Mystery, Adia
 ```
 
-Three things: a record, a context, one line of serialization. The `TitleProperty` becomes a heading; everything else renders as fields.
+Or `Bulleted` for a list:
+
+```csharp
+[MarkoutSerializable(TitleProperty = nameof(Artist.Name), FieldLayout = FieldLayout.Bulleted)]
+public record Artist( ... );
+```
+
+```markdown
+# Sarah McLachlan
+
+- Genre: Pop / Adult Contemporary
+- Origin: Halifax, Nova Scotia
+- Debut Year: 1988
+- Best Known For: Angel, Building a Mystery, Adia
+```
+
+The data model doesn't change — only the attribute controls the shape.
 
 ## Adding Sections and Tables
 

--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ Or `Numbered`:
 4. Best Known For: Angel, Building a Mystery, Adia
 ```
 
-Or `Plain` — bare lines, no markers:
+Or `Plain` — bare lines, no markers. Each line ends with two trailing spaces, which is the markdown signal for `<br>`:
 
 ```markdown
 # Sarah McLachlan
 
-Genre: Pop / Adult Contemporary
-Origin: Halifax, Nova Scotia
-Debut Year: 1988
-Best Known For: Angel, Building a Mystery, Adia
+Genre: Pop / Adult Contemporary  
+Origin: Halifax, Nova Scotia  
+Debut Year: 1988  
+Best Known For: Angel, Building a Mystery, Adia  
 ```
 
 The data model doesn't change — only the attribute controls the shape.

--- a/SKILL.md
+++ b/SKILL.md
@@ -78,7 +78,7 @@ That's it. The output is Markdown by default.
 - `TitleProperty` — Property to render as the H1 heading
 - `DescriptionProperty` — Property to render as a paragraph below the heading
 - `AutoFields` — Auto-render scalar properties as fields (default: `true`)
-- `FieldLayout` — `Line` (pipe-separated), `List` (bullets), or `BareList` (one per line)
+- `FieldLayout` — `Table` (two-column, default), `Inline` (pipe-separated), `Bulleted`, `Numbered`, or `Plain` (bare lines)
 
 ### Property-level attributes
 

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -38,6 +38,10 @@ internal static class FieldEmitter
                 EmitFieldsNumbered(sb, scalarProps, valueExpr, indentLevel, nestingDepth, sectionHeading, sectionLevel);
                 break;
 
+            case FieldLayoutKind.Plain:
+                EmitFieldsPlain(sb, scalarProps, valueExpr, indentLevel, nestingDepth, sectionHeading, sectionLevel);
+                break;
+
             default:
                 EmitFieldsTable(sb, scalarProps, valueExpr, indentLevel, nestingDepth, sectionHeading, sectionLevel);
                 break;
@@ -482,6 +486,114 @@ internal static class FieldEmitter
             if (sectionHeading != null)
                 sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
             sb.AppendLine($"{indent}writer.WriteFieldsNumbered(new global::Markout.MarkoutField[] {{ {string.Join(", ", fields)} }});");
+        }
+    }
+
+    private static void EmitFieldsPlain(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        int nestingDepth = 0,
+        string? sectionHeading = null,
+        int sectionLevel = 2)
+    {
+        var indent = new string(' ', indentLevel * 4);
+        bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
+            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
+        var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
+
+        if (useBuilder)
+        {
+            sb.AppendLine($"{indent}var {fieldsVar} = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+            foreach (var prop in scalarProps)
+            {
+                var propAccess = $"{valueExpr}.{prop.Name}";
+                var fieldIndent = indent;
+
+                if (prop.ShowWhenProperty != null)
+                {
+                    sb.AppendLine($"{indent}if ({valueExpr}.{prop.ShowWhenProperty})");
+                    sb.AppendLine($"{indent}{{");
+                    fieldIndent = indent + "    ";
+                }
+
+                if (prop.IsNullableValueType)
+                {
+                    var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
+                    valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+                    sb.AppendLine($"{fieldIndent}if ({propAccess}.HasValue)");
+                    sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+                else if (prop.Kind == PropertyKind.String)
+                {
+                    var valueStr = EmitHelpers.WrapWithValueMap(prop, propAccess);
+                    valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+                    sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
+                    sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                }
+                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                {
+                    var countProp = prop.IsArray ? "Length" : "Count";
+                    sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+                    sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {EmitHelpers.GetScalarValueExpression(prop, propAccess)}));");
+                }
+                else
+                {
+                    var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                    valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+                    if (prop.SkipWhenDefault)
+                    {
+                        var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
+                        sb.AppendLine($"{fieldIndent}if ({condition})");
+                        sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    }
+                    else if (prop.SkipWhenNull)
+                    {
+                        var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
+                        if (condition != null)
+                        {
+                            sb.AppendLine($"{fieldIndent}if ({condition})");
+                            sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                        }
+                        else
+                        {
+                            sb.AppendLine($"{fieldIndent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                        }
+                    }
+                    else
+                    {
+                        sb.AppendLine($"{fieldIndent}{fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
+                    }
+                }
+
+                if (prop.ShowWhenProperty != null)
+                {
+                    sb.AppendLine($"{indent}}}");
+                }
+            }
+            sb.AppendLine($"{indent}if ({fieldsVar}.Count > 0)");
+            sb.AppendLine($"{indent}{{");
+            if (sectionHeading != null)
+                sb.AppendLine($"{indent}    writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
+            sb.AppendLine($"{indent}    writer.WriteFields(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({fieldsVar}));");
+            sb.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            var fields = new List<string>();
+            foreach (var prop in scalarProps)
+            {
+                var propAccess = $"{valueExpr}.{prop.Name}";
+                var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+                valueStr = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+                fields.Add($"new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr})");
+            }
+
+            if (sectionHeading != null)
+                sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
+            sb.AppendLine($"{indent}writer.WriteFields(new global::Markout.MarkoutField[] {{ {string.Join(", ", fields)} }});");
         }
     }
 

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -384,7 +384,8 @@ internal enum FieldLayoutKind
     Table = 0,
     Inline = 1,
     Bulleted = 2,
-    Numbered = 3
+    Numbered = 3,
+    Plain = 4
 }
 
 /// <summary>

--- a/src/Markout/FieldLayout.cs
+++ b/src/Markout/FieldLayout.cs
@@ -32,5 +32,13 @@ public enum FieldLayout
     /// Example: 1. Birthplace: London
     ///          2. Born: 1980
     /// </summary>
-    Numbered
+    Numbered,
+
+    /// <summary>
+    /// Fields as plain lines, one per line with no markers.
+    /// Uses markdown hard line breaks (trailing double space).
+    /// Example: Birthplace: London
+    ///          Born: 1980
+    /// </summary>
+    Plain
 }

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -632,6 +632,35 @@ public class SerializerTests
     }
 
     [Fact]
+    public void Serialize_SkipDefault_PlainLayout()
+    {
+        var status = new ServerStatusPlain { Name = "Server1", IsOnline = false, ConnectionCount = 0 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultPlainContext.Default);
+
+        Assert.Contains("Name", mdf);
+        Assert.DoesNotContain("Is Online", mdf);
+        Assert.DoesNotContain("Connection Count", mdf);
+        // Plain layout: no bullets, no numbers, no table pipes
+        Assert.DoesNotContain("- ", mdf);
+        Assert.DoesNotContain("1.", mdf);
+        Assert.DoesNotContain("| ", mdf);
+    }
+
+    [Fact]
+    public void Serialize_SkipDefault_PlainRendersNonDefault()
+    {
+        var status = new ServerStatusPlain { Name = "Server1", IsOnline = true, ConnectionCount = 10 };
+        var mdf = MarkoutSerializer.Serialize(status, SkipDefaultPlainContext.Default);
+
+        Assert.Contains("Is Online", mdf);
+        Assert.Contains("Connection Count", mdf);
+        // Plain layout: no bullets, no numbers, no table pipes
+        Assert.DoesNotContain("- ", mdf);
+        Assert.DoesNotContain("1.", mdf);
+        Assert.DoesNotContain("| ", mdf);
+    }
+
+    [Fact]
     public void Serialize_SkipNull_SuppressesNullStrings()
     {
         var pkg = new PackageInfo { Name = "MyPackage", License = null, Repository = null, Downloads = 100 };
@@ -1776,6 +1805,21 @@ public class ServerStatusList
 
 [MarkoutContext(typeof(ServerStatusList))]
 public partial class SkipDefaultListContext : MarkoutSerializerContext
+{
+}
+
+[MarkoutSerializable(FieldLayout = FieldLayout.Plain)]
+public class ServerStatusPlain
+{
+    public string? Name { get; set; }
+    [MarkoutSkipDefault]
+    public bool IsOnline { get; set; }
+    [MarkoutSkipDefault]
+    public int ConnectionCount { get; set; }
+}
+
+[MarkoutContext(typeof(ServerStatusPlain))]
+public partial class SkipDefaultPlainContext : MarkoutSerializerContext
 {
 }
 


### PR DESCRIPTION
The Quick Start output was wrong — it showed inline pipe-separated fields, but `FieldLayout.Table` (the default) produces a two-column table.

Added a new **Field Layouts** section between Quick Start and Adding Sections and Tables that shows the same Artist record rendered three ways:

- **Table** (default) — two-column `| Field | Value |` table
- **Inline** — compact single-line `Key: Value | Key: Value`
- **Bulleted** — list with `- Key: Value`

This creates a smoother progression: simple record → layout variations → sections with real tabular data (`List<T>`).