### PR TITLE
Add Headless property to MarkoutSection for addressable preamble sections

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -482,13 +482,15 @@ internal static class SerializerEmitter
         string sectionName,
         string? rootTypeName = null)
     {
+        var headlessArg = prop.SectionHeadless ? ", headless: true" : "";
 
         if (prop.Kind == PropertyKind.FieldCollection)
         {
+            var writeMethod = prop.SectionHeadless ? "WriteFieldsInline" : "WriteFieldsTable";
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
-            sb.AppendLine($"{indent}    writer.WriteFieldsTable(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({propAccess}));");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+            sb.AppendLine($"{indent}    writer.{writeMethod}(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({propAccess}));");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
         }
@@ -507,7 +509,7 @@ internal static class SerializerEmitter
             }
             else
             {
-                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
 
                 if (prop.SectionGroupByProperty != null)
                 {
@@ -548,7 +550,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({EmitHelpers.GetCollectionCountCheck(prop, propAccess)})");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             if (prop.MaxItems != null)
             {
                 var innerIndent = indent + "    ";
@@ -567,7 +569,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             if (prop.MaxItems != null)
             {
                 var innerIndent = indent + "    ";
@@ -586,7 +588,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    writer.WriteMetrics({propAccess});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
@@ -595,7 +597,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    writer.WriteDescriptions({propAccess});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
@@ -604,7 +606,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
@@ -613,7 +615,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess}.Content != null)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    writer.WriteCodeStart({propAccess}.Language);");
             sb.AppendLine($"{indent}    writer.WriteParagraph({propAccess}.Content);");
             sb.AppendLine($"{indent}    writer.WriteCodeEnd();");
@@ -624,7 +626,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess} != null)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             EmitPropertySerializations(sb, prop.ElementProperties, propAccess, indentLevel + 1, effectiveSectionLevel + 1, nestingDepth + 1, autoFields: prop.ElementAutoFields, fieldLayout: prop.ElementFieldLayout);
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
@@ -633,7 +635,7 @@ internal static class SerializerEmitter
         {
             sb.AppendLine($"{indent}if ({propAccess} != null)");
             sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    ((global::Markout.IMarkoutFormattable){propAccess}).WriteTo(writer);");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
@@ -641,7 +643,7 @@ internal static class SerializerEmitter
         else
         {
             // For other types, just write the heading unconditionally
-            sb.AppendLine($"{indent}writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\");");
+            sb.AppendLine($"{indent}writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}writer.WriteSectionEnd();");
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -148,6 +148,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? SectionColumnName { get; }
     public string? SectionShowWhenProperty { get; }
     public string? SectionGroupByProperty { get; }
+    public bool SectionHeadless { get; }
     public IReadOnlyList<(string MethodName, string ColumnName)>? SectionIgnoreColumnWhen { get; }
     public string? ElementTypeName { get; }
     public IReadOnlyList<PropertyMetadata>? ElementProperties { get; }
@@ -192,6 +193,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? sectionColumnName = null,
         string? sectionShowWhenProperty = null,
         string? sectionGroupByProperty = null,
+        bool sectionHeadless = false,
         IReadOnlyList<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null,
         string? elementTypeName = null,
         IReadOnlyList<PropertyMetadata>? elementProperties = null,
@@ -235,6 +237,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         SectionColumnName = sectionColumnName;
         SectionShowWhenProperty = sectionShowWhenProperty;
         SectionGroupByProperty = sectionGroupByProperty;
+        SectionHeadless = sectionHeadless;
         SectionIgnoreColumnWhen = sectionIgnoreColumnWhen;
         ElementTypeName = elementTypeName;
         ElementProperties = elementProperties;
@@ -283,6 +286,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                SectionColumnName == other.SectionColumnName &&
                SectionShowWhenProperty == other.SectionShowWhenProperty &&
                SectionGroupByProperty == other.SectionGroupByProperty &&
+               SectionHeadless == other.SectionHeadless &&
                IgnoreColumnWhenEqual(SectionIgnoreColumnWhen, other.SectionIgnoreColumnWhen) &&
                ElementTypeName == other.ElementTypeName &&
                ElementHasNestedContent == other.ElementHasNestedContent &&
@@ -333,6 +337,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionColumnName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionGroupByProperty?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ SectionHeadless.GetHashCode();
             hash = hash * 397 ^ (SectionIgnoreColumnWhen?.Count ?? 0);
             hash = hash * 397 ^ (ValueFormatterTypeName?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (ShowWhenProperty?.GetHashCode() ?? 0);

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -233,6 +233,7 @@ internal static class TypeParser
         string? sectionColumnName = null;
         string? sectionShowWhenProperty = null;
         string? sectionGroupByProperty = null;
+        bool sectionHeadless = false;
         List<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null;
 
         if (isSection)
@@ -259,6 +260,8 @@ internal static class TypeParser
                         sectionShowWhenProperty = swp;
                     else if (named.Key == "GroupBy" && named.Value.Value is string gb)
                         sectionGroupByProperty = gb;
+                    else if (named.Key == "Headless" && named.Value.Value is bool hl)
+                        sectionHeadless = hl;
                 }
             }
         }
@@ -469,6 +472,7 @@ internal static class TypeParser
             sectionColumnName,
             sectionShowWhenProperty,
             sectionGroupByProperty,
+            sectionHeadless,
             sectionIgnoreColumnWhen,
             elementTypeName,
             elementProperties,

--- a/src/Markout/Attributes/MarkoutSectionAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSectionAttribute.cs
@@ -53,4 +53,11 @@ public sealed class MarkoutSectionAttribute : Attribute
     /// The group-by property is excluded from per-item rendering (it becomes the heading).
     /// </summary>
     public string? GroupBy { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the section heading is suppressed.
+    /// When true, the section is addressable and filterable via <see cref="MarkoutWriterOptions.IncludeSections"/>
+    /// but no heading (e.g., ##) is emitted. Use for preamble content that should be a named section.
+    /// </summary>
+    public bool Headless { get; set; }
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -45,10 +45,6 @@ public class MarkoutWriter
         _writer = writer;
         _formatter = formatter;
         _options = opts;
-
-        // When filtering to specific sections, suppress unsectioned content by default.
-        // Content before the first H2 only renders when no section filter is active.
-        _sectionExcluded = opts.IncludeSections is { Count: > 0 };
     }
 
     /// <summary>
@@ -121,11 +117,14 @@ public class MarkoutWriter
     /// when projection is active.
     /// </summary>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support headings.</returns>
-    public bool WriteSectionStart(int level, string text, string? context = null)
+    public bool WriteSectionStart(int level, string text, string? context = null, bool headless = false)
     {
         UpdateSectionState(level, text);
 
         if (_sectionExcluded)
+            return true;
+
+        if (headless)
             return true;
 
         if (_formatter is not IHeadingFormatter)

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -45,6 +45,10 @@ public class MarkoutWriter
         _writer = writer;
         _formatter = formatter;
         _options = opts;
+
+        // When filtering to specific sections, suppress unsectioned content by default.
+        // Content before the first H2 only renders when no section filter is active.
+        _sectionExcluded = opts.IncludeSections is { Count: > 0 };
     }
 
     /// <summary>


### PR DESCRIPTION
Headless sections participate in `IncludeSections`/`ExcludeSections` filtering but emit no heading. This lets preamble content be a named, filterable section without rendering a `##` heading.

## Changes

- Add `Headless` bool to `MarkoutSectionAttribute`
- Thread `SectionHeadless` through `PropertyMetadata`/`TypeParser`/`SerializerEmitter`
- `WriteSectionStart(headless: true)` calls `UpdateSectionState` for filtering but skips heading render
- Headless `FieldCollection` sections use `WriteFieldsInline` (inline format) instead of `WriteFieldsTable`
- Remove `_sectionExcluded` initialization hack from constructor

## Usage

```csharp
[MarkoutSection(Name = "Summary", Headless = true)]
public List<MarkoutField> Summary => GetCompactFields();
```

The section is addressable and filterable via `IncludeSections`, but no `## Summary` heading is emitted. This eliminates the need for `ExcludeSections` workarounds when preamble content needs to be suppressed during section filtering.

All 449 tests pass.