### PR TITLE
Schema query, projection globs, tree layout, and section API cleanup

### DIFF
--- a/docs/comparison-report.md
+++ b/docs/comparison-report.md
@@ -1237,13 +1237,11 @@ The package command actively uses section filtering for verbosity control:
 ```csharp
 var context = new MarkoutContext(new MarkoutWriterOptions
 {
-    IncludeSections = options.IncludeSections,
-    ExcludeSections = GetExcludeSections(options),
-    IncludeDescription = options.Verbosity != Verbosity.Quiet
+    IncludeSections = options.IncludeSections
 });
 ```
 
-Verbosity maps to section exclusions:
+Verbosity maps to section inclusions via the pipeline:
 - **Quiet**: Title + compact line only
 - **Minimal**: Title + description + compact line
 - **Normal**: Metadata section only

--- a/docs/design/capability-interfaces.md
+++ b/docs/design/capability-interfaces.md
@@ -30,7 +30,7 @@ Three roles, separated:
 The thing the serializer (and hand-written callers) talk to. Owns:
 
 - Shape vocabulary (WriteHeading, WriteFields, WriteTable, etc.)
-- Section tracking and filtering (IncludeSections/ExcludeSections)
+- Section tracking and filtering (IncludeSections)
 - Blank line and spacing management
 - State (HasContent, NeedsBlankLine, InCode, InTable)
 - Streaming table buffering (WriteTableStart/Row/End)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -840,12 +840,6 @@ var options = new MarkoutWriterOptions
 {
     IncludeSections = ["Overview", "Reviews"]
 };
-
-// Render all sections except these
-var options = new MarkoutWriterOptions
-{
-    ExcludeSections = ["Specifications"]
-};
 ```
 
 > From the [SectionFiltering](../samples/Serialization/SectionFiltering.cs) sample.
@@ -865,7 +859,7 @@ Or pass options to the context constructor:
 ```csharp
 var context = new SampleContext(new MarkoutWriterOptions
 {
-    ExcludeSections = ["Specifications"],
+    IncludeSections = ["Overview", "Reviews"],
     BoldFieldNames = true
 });
 

--- a/samples/Serialization/SectionFiltering.cs
+++ b/samples/Serialization/SectionFiltering.cs
@@ -44,33 +44,6 @@ public static class SectionFiltering
     }
 
     /// <summary>
-    /// Shows how to exclude specific sections from output.
-    /// </summary>
-    public static void ExcludeSpecificSections()
-    {
-        #region ExcludeSpecificSections
-        var writer = new MarkoutWriter(new MarkdownFormatter(), new MarkoutWriterOptions
-        {
-            // Exclude the Specifications section
-            ExcludeSections = ["Specifications"]
-        });
-
-        writer.WriteHeading(1, "Product Details");
-
-        writer.WriteHeading(2, "Overview");        // included
-        writer.WriteFields([new("Name", "Widget Pro")]);
-
-        writer.WriteHeading(2, "Specifications");  // excluded
-        writer.WriteFields([new("Weight", "1.5 kg")]);
-
-        writer.WriteHeading(2, "Reviews");         // included
-        writer.WriteFields([new("Rating", "4.5 stars")]);
-
-        Console.WriteLine(writer.ToString());
-        #endregion
-    }
-
-    /// <summary>
     /// Shows section filtering via MarkoutSerializerContext.
     /// </summary>
     public static void FilterViaContext()
@@ -78,7 +51,7 @@ public static class SectionFiltering
         #region FilterViaContext
         var context = new SampleContext(new MarkoutWriterOptions
         {
-            ExcludeSections = ["Specifications"],  // Skip Specifications section
+            IncludeSections = ["Overview", "Reviews"],  // Only include these sections
             BoldFieldNames = true                       // Enable bold field names
         });
 

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -52,6 +52,36 @@ internal static class SerializerEmitter
 
         sb.AppendLine("        OnSerializing(writer, value);");
 
+        // Tree layout: title as plain-text root node, then tree properties only
+        if (type.Layout == DocumentLayoutKind.Tree)
+        {
+            if (!string.IsNullOrEmpty(type.TitleProperty))
+            {
+                var titleProp = type.Properties.FirstOrDefault(p => p.Name == type.TitleProperty);
+                if (titleProp != null)
+                {
+                    sb.AppendLine($"        if (value.{titleProp.Name} != null)");
+                    sb.AppendLine($"            writer.WriteTreeNode(value.{titleProp.Name});");
+                    sb.AppendLine();
+                }
+            }
+
+            // Emit only tree properties
+            foreach (var prop in type.Properties)
+            {
+                if (prop.IsIgnored || prop.Kind != PropertyKind.Tree) continue;
+                var propAccess = $"value.{prop.Name}";
+                sb.AppendLine($"        if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"            writer.WriteTree(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({propAccess}));");
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("        OnSerialized(writer, value);");
+            sb.AppendLine("    }");
+        }
+        else
+        {
+
         // Emit title (H1) if TitleProperty is set — opens document section
         var hasTitle = false;
         if (!string.IsNullOrEmpty(type.TitleProperty))
@@ -107,8 +137,9 @@ internal static class SerializerEmitter
         if (hasTitle)
             sb.AppendLine("        writer.WriteSectionEnd();");
         sb.AppendLine("    }");
-        sb.AppendLine();
 
+        } // end else (Document layout)
+        sb.AppendLine();
         // Emit partial method declarations for hooks
         sb.AppendLine($"    partial void OnSerializing(global::Markout.MarkoutWriter writer, {type.FullTypeName} value);");
         sb.AppendLine($"    partial void OnSerialized(global::Markout.MarkoutWriter writer, {type.FullTypeName} value);");

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -38,6 +38,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
     public int AutoFieldsCount { get; }
     public FieldLayoutKind FieldLayout { get; }
     public NamingPolicyKind NamingPolicy { get; }
+    public DocumentLayoutKind Layout { get; }
     public bool SkipNullByDefault { get; }
     public IReadOnlyList<DiagnosticInfo> Diagnostics { get; }
 
@@ -54,6 +55,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         int autoFieldsCount = 0,
         FieldLayoutKind fieldLayout = FieldLayoutKind.Table,
         NamingPolicyKind namingPolicy = NamingPolicyKind.PascalCaseWords,
+        DocumentLayoutKind layout = DocumentLayoutKind.Document,
         bool skipNullByDefault = false,
         IReadOnlyList<DiagnosticInfo>? diagnostics = null)
     {
@@ -69,6 +71,7 @@ internal sealed class TypeMetadata : IEquatable<TypeMetadata>
         AutoFieldsCount = autoFieldsCount;
         FieldLayout = fieldLayout;
         NamingPolicy = namingPolicy;
+        Layout = layout;
         SkipNullByDefault = skipNullByDefault;
         Diagnostics = diagnostics ?? Array.Empty<DiagnosticInfo>();
     }
@@ -400,6 +403,15 @@ internal enum NamingPolicyKind
 {
     PascalCaseWords = 0,
     Verbatim = 1
+}
+
+/// <summary>
+/// Internal representation of DocumentLayout. Values mirror the runtime Markout.DocumentLayout enum.
+/// </summary>
+internal enum DocumentLayoutKind
+{
+    Document = 0,
+    Tree = 1
 }
 
 /// <summary>

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -100,6 +100,7 @@ internal static class TypeParser
         int? autoFieldsCount = null,
         FieldLayoutKind? fieldLayout = null,
         NamingPolicyKind? namingPolicy = null,
+        DocumentLayoutKind? layout = null,
         bool suppressTableWarnings = false)
     {
         // If titleProperty/descriptionProperty not passed, try to get them from the type's [MarkoutSerializable] attribute
@@ -125,6 +126,8 @@ internal static class TypeParser
                         fieldLayout ??= (FieldLayoutKind)fl;
                     else if (named.Key == "NamingPolicy" && named.Value.Value is int np)
                         namingPolicy ??= (NamingPolicyKind)np;
+                    else if (named.Key == "Layout" && named.Value.Value is int lay)
+                        layout ??= (DocumentLayoutKind)lay;
                 }
             }
         }
@@ -141,6 +144,8 @@ internal static class TypeParser
         fieldLayout ??= FieldLayoutKind.Table;
         // Default naming policy
         namingPolicy ??= NamingPolicyKind.PascalCaseWords;
+        // Default layout
+        layout ??= DocumentLayoutKind.Document;
 
         // Check for type-level [MarkoutSkipNull]
         bool skipNullByDefault = typeSymbol.GetAttributes()
@@ -208,6 +213,7 @@ internal static class TypeParser
             autoFieldsCount.Value,
             fieldLayout.Value,
             namingPolicy.Value,
+            layout.Value,
             skipNullByDefault,
             filteredDiagnostics);
     }

--- a/src/Markout/Attributes/MarkoutSerializableAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSerializableAttribute.cs
@@ -53,4 +53,12 @@ public sealed class MarkoutSerializableAttribute : Attribute
     /// Default is PascalCaseWords (split PascalCase into separate words).
     /// </summary>
     public NamingPolicy NamingPolicy { get; set; } = NamingPolicy.PascalCaseWords;
+
+    /// <summary>
+    /// Gets or sets the overall document layout.
+    /// When set to <see cref="DocumentLayout.Tree"/>, the title renders as a plain-text root node
+    /// and TreeNode list properties render as children. No headings, fields, or sections are emitted.
+    /// Default is <see cref="DocumentLayout.Document"/>.
+    /// </summary>
+    public DocumentLayout Layout { get; set; } = DocumentLayout.Document;
 }

--- a/src/Markout/DocumentLayout.cs
+++ b/src/Markout/DocumentLayout.cs
@@ -1,0 +1,19 @@
+namespace Markout;
+
+/// <summary>
+/// Specifies the overall document layout for a serializable type.
+/// </summary>
+public enum DocumentLayout
+{
+    /// <summary>
+    /// Standard document layout with headings, fields, tables, and sections (default).
+    /// </summary>
+    Document,
+
+    /// <summary>
+    /// Tree layout: the title renders as a plain-text root node,
+    /// and <see cref="TreeNode"/> list properties render as children with connectors.
+    /// No headings, fields, or sections are emitted.
+    /// </summary>
+    Tree
+}

--- a/src/Markout/DocumentSchema.cs
+++ b/src/Markout/DocumentSchema.cs
@@ -1,0 +1,186 @@
+namespace Markout;
+
+/// <summary>
+/// A name-kind pair representing a discoverable schema element.
+/// </summary>
+public readonly record struct SchemaItem(string Name, string Kind);
+
+/// <summary>
+/// Describes a section's schema: its items and their kind.
+/// </summary>
+public sealed class SectionSchema
+{
+    public SectionSchema(string name, string itemKind, string[] itemNames)
+    {
+        Name = name;
+        ItemKind = itemKind;
+        Items = itemNames.Select(n => new SchemaItem(n, itemKind)).ToArray();
+    }
+
+    public string Name { get; }
+    public string ItemKind { get; }
+    public SchemaItem[] Items { get; }
+}
+
+/// <summary>
+/// Describes the schema of a Markout document: its sections and the items within them.
+/// Used for discovery (-D), projection validation (--fields/--columns), and diagnostics.
+/// </summary>
+/// <remarks>
+/// <para>Built manually today via <see cref="Add"/>. Will be source-generated from
+/// Markout attributes in a future release.</para>
+/// <para>All name lookups are case-insensitive.</para>
+/// </remarks>
+public sealed class DocumentSchema
+{
+    private readonly List<string> _sectionOrder = [];
+    private readonly Dictionary<string, SectionSchema> _sections = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Registers a section with typed items (fields, columns, tree nodes, or list items).
+    /// </summary>
+    public DocumentSchema Add(string sectionName, string itemKind, params string[] itemNames)
+    {
+        var schema = new SectionSchema(sectionName, itemKind, itemNames);
+        _sections[sectionName] = schema;
+        if (!_sectionOrder.Contains(sectionName, StringComparer.OrdinalIgnoreCase))
+            _sectionOrder.Add(sectionName);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a section with no explicit items (e.g., a headless summary section).
+    /// </summary>
+    public DocumentSchema AddSection(string sectionName)
+    {
+        if (!_sections.ContainsKey(sectionName))
+            _sections[sectionName] = new SectionSchema(sectionName, "section", []);
+        if (!_sectionOrder.Contains(sectionName, StringComparer.OrdinalIgnoreCase))
+            _sectionOrder.Add(sectionName);
+        return this;
+    }
+
+    /// <summary>
+    /// All section names in registration order.
+    /// </summary>
+    public string[] SectionNames => [.. _sectionOrder];
+
+    /// <summary>
+    /// Returns the schema for a section, or null if not registered.
+    /// </summary>
+    public SectionSchema? GetSection(string sectionName)
+        => _sections.GetValueOrDefault(sectionName);
+
+    // ── Discovery ──
+
+    /// <summary>
+    /// Discovers schema elements. Bare call returns sections.
+    /// With a section name, returns items within that section.
+    /// Returns null if the section name is not found.
+    /// </summary>
+    public SchemaItem[]? Discover(string? sectionName = null)
+    {
+        if (string.IsNullOrEmpty(sectionName))
+            return _sectionOrder.Select(n => new SchemaItem(n, "section")).ToArray();
+
+        var section = GetSection(sectionName);
+        return section?.Items;
+    }
+
+    /// <summary>
+    /// Resolves a section name with case-insensitive matching.
+    /// Returns the canonical section name if found, null otherwise.
+    /// </summary>
+    public string? ResolveSection(string name)
+    {
+        if (_sections.TryGetValue(name, out var schema))
+            return schema.Name;
+        return null;
+    }
+
+    // ── Projection validation ──
+
+    /// <summary>
+    /// Validates requested field/column names against a section's schema.
+    /// Returns which names are valid and which are unknown.
+    /// </summary>
+    public ProjectionValidation ValidateProjection(string sectionName, string[]? requestedNames)
+    {
+        if (requestedNames is not { Length: > 0 })
+            return ProjectionValidation.Empty;
+
+        var section = GetSection(sectionName);
+        if (section == null)
+            return new ProjectionValidation([], requestedNames, new Dictionary<string, string[]>());
+
+        var knownNames = new HashSet<string>(
+            section.Items.Select(i => i.Name), StringComparer.OrdinalIgnoreCase);
+
+        var resolved = new List<string>();
+        var unresolved = new List<string>();
+        var suggestions = new Dictionary<string, string[]>();
+
+        foreach (var name in requestedNames)
+        {
+            if (knownNames.Contains(name))
+            {
+                resolved.Add(name);
+            }
+            else
+            {
+                unresolved.Add(name);
+                var prefixMatches = section.Items
+                    .Where(i => i.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                    .Select(i => i.Name)
+                    .ToArray();
+                if (prefixMatches.Length > 0)
+                    suggestions[name] = prefixMatches;
+            }
+        }
+
+        return new ProjectionValidation([.. resolved], [.. unresolved], suggestions);
+    }
+
+    // ── Post-render diagnostics ──
+
+    /// <summary>
+    /// Compares requested names against rendered output to find names that were
+    /// valid but produced no data. Uses case-insensitive substring matching.
+    /// </summary>
+    public static string[] DiagnoseRendered(string[]? requestedNames, string renderedOutput)
+    {
+        if (requestedNames is not { Length: > 0 } || string.IsNullOrEmpty(renderedOutput))
+            return requestedNames ?? [];
+
+        return requestedNames
+            .Where(name => !renderedOutput.Contains(name, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Result of validating projection names against a section schema.
+/// </summary>
+public sealed class ProjectionValidation
+{
+    public static readonly ProjectionValidation Empty = new([], [], new Dictionary<string, string[]>());
+
+    public ProjectionValidation(string[] resolved, string[] unresolved,
+        IReadOnlyDictionary<string, string[]> suggestions)
+    {
+        Resolved = resolved;
+        Unresolved = unresolved;
+        Suggestions = suggestions;
+    }
+
+    /// <summary>Names that matched the schema.</summary>
+    public string[] Resolved { get; }
+
+    /// <summary>Names that did not match any schema item.</summary>
+    public string[] Unresolved { get; }
+
+    /// <summary>Prefix-based suggestions for unresolved names, keyed by the unresolved name.</summary>
+    public IReadOnlyDictionary<string, string[]> Suggestions { get; }
+
+    public bool IsValid => Unresolved.Length == 0;
+}

--- a/src/Markout/DocumentSchema.cs
+++ b/src/Markout/DocumentSchema.cs
@@ -126,6 +126,11 @@ public sealed class DocumentSchema
             {
                 resolved.Add(name);
             }
+            else if (name.Contains('*') || name.Contains('?'))
+            {
+                // Glob patterns are resolved at render time by Markout
+                resolved.Add(name);
+            }
             else
             {
                 unresolved.Add(name);

--- a/src/Markout/MarkoutProjection.cs
+++ b/src/Markout/MarkoutProjection.cs
@@ -139,7 +139,7 @@ public class MarkoutProjection
         {
             foreach (var col in _includeColumns)
             {
-                if (string.Equals(col, header, _comparison))
+                if (MatchesName(col, header))
                     return true;
             }
             return false;
@@ -149,7 +149,7 @@ public class MarkoutProjection
         {
             foreach (var col in _excludeColumns)
             {
-                if (string.Equals(col, header, _comparison))
+                if (MatchesName(col, header))
                     return false;
             }
         }
@@ -166,7 +166,7 @@ public class MarkoutProjection
         {
             foreach (var field in _includeFields)
             {
-                if (string.Equals(field, key, _comparison))
+                if (MatchesName(field, key))
                     return true;
             }
             return false;
@@ -176,7 +176,7 @@ public class MarkoutProjection
         {
             foreach (var field in _excludeFields)
             {
-                if (string.Equals(field, key, _comparison))
+                if (MatchesName(field, key))
                     return false;
             }
         }
@@ -213,12 +213,13 @@ public class MarkoutProjection
             var map = new List<int>(_includeColumns.Count);
             foreach (var col in _includeColumns)
             {
+                bool isGlob = col.Contains('*') || col.Contains('?');
                 for (int i = 0; i < headers.Length; i++)
                 {
-                    if (string.Equals(col, headers[i], _comparison))
+                    if (MatchesName(col, headers[i]))
                     {
                         map.Add(i);
-                        break;
+                        if (!isGlob) break;
                     }
                 }
             }
@@ -234,7 +235,7 @@ public class MarkoutProjection
                 bool excluded = false;
                 foreach (var col in _excludeColumns)
                 {
-                    if (string.Equals(col, headers[i], _comparison))
+                    if (MatchesName(col, headers[i]))
                     {
                         excluded = true;
                         break;
@@ -273,4 +274,48 @@ public class MarkoutProjection
         }
         return result;
     }
+
+    /// <summary>
+    /// Matches a pattern against a name. Supports exact match and glob patterns (* and ?).
+    /// </summary>
+    internal bool MatchesName(string pattern, string name)
+    {
+        if (!pattern.Contains('*') && !pattern.Contains('?'))
+            return string.Equals(pattern, name, _comparison);
+
+        return GlobMatch(pattern, name, _comparison == StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool GlobMatch(string pattern, string text, bool ignoreCase)
+    {
+        int pi = 0, ti = 0, starPi = -1, starTi = -1;
+        while (ti < text.Length)
+        {
+            if (pi < pattern.Length && pattern[pi] == '?')
+            {
+                pi++; ti++;
+            }
+            else if (pi < pattern.Length && pattern[pi] == '*')
+            {
+                starPi = pi++; starTi = ti;
+            }
+            else if (pi < pattern.Length && CharEquals(pattern[pi], text[ti], ignoreCase))
+            {
+                pi++; ti++;
+            }
+            else if (starPi >= 0)
+            {
+                pi = starPi + 1; ti = ++starTi;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        while (pi < pattern.Length && pattern[pi] == '*') pi++;
+        return pi == pattern.Length;
+    }
+
+    private static bool CharEquals(char a, char b, bool ignoreCase)
+        => ignoreCase ? char.ToUpperInvariant(a) == char.ToUpperInvariant(b) : a == b;
 }

--- a/src/Markout/MarkoutProjection.cs
+++ b/src/Markout/MarkoutProjection.cs
@@ -17,7 +17,6 @@ public class MarkoutProjection
     private HashSet<string>? _excludeColumns;
     private IReadOnlyList<string>? _includeFields;
     private HashSet<string>? _excludeFields;
-    private IReadOnlyList<string>? _includeSections;
     private StringComparison _comparison = StringComparison.OrdinalIgnoreCase;
 
     // ── Factory Methods ──
@@ -45,24 +44,6 @@ public class MarkoutProjection
     /// </summary>
     public static MarkoutProjection WithoutFields(params ReadOnlySpan<string> fields)
         => new() { ExcludeFields = [..fields] };
-
-    /// <summary>
-    /// Creates a projection that includes the specified sections
-    /// (overriding section exclusion from writer options).
-    /// </summary>
-    public static MarkoutProjection WithSections(params ReadOnlySpan<string> sections)
-        => new() { IncludeSections = sections.ToArray() };
-
-    /// <summary>
-    /// If set, sections whose name matches are included even if excluded by
-    /// <see cref="MarkoutWriterOptions.IncludeSections"/>/<see cref="MarkoutWriterOptions.ExcludeSections"/>.
-    /// Content within projection-included sections is rendered without field/column filtering.
-    /// </summary>
-    public IReadOnlyList<string>? IncludeSections
-    {
-        get => _includeSections;
-        set => _includeSections = value;
-    }
 
     /// <summary>
     /// If set, only table columns whose header text matches are rendered, in the specified order.
@@ -182,22 +163,6 @@ public class MarkoutProjection
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Returns true if the given section name is included by this projection.
-    /// </summary>
-    internal bool IsSectionIncluded(string sectionName)
-    {
-        if (_includeSections == null)
-            return false;
-
-        foreach (var s in _includeSections)
-        {
-            if (string.Equals(s, sectionName, _comparison))
-                return true;
-        }
-        return false;
     }
 
     /// <summary>

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -24,7 +24,6 @@ public class MarkoutWriter
     // Section tracking
     private string? _currentSectionName;
     private bool _sectionExcluded;
-    private bool _projectionSectionActive;
 
     // Table delegation
     private TableWriter? _tableWriter;
@@ -39,8 +38,6 @@ public class MarkoutWriter
     public MarkoutWriter(TextWriter writer, IMarkoutFormatter formatter, MarkoutWriterOptions? options = null)
     {
         var opts = options ?? new MarkoutWriterOptions();
-        if (opts.IncludeSections != null && opts.ExcludeSections != null)
-            throw new InvalidOperationException("Cannot set both IncludeSections and ExcludeSections. Use one or the other.");
 
         _writer = writer;
         _formatter = formatter;
@@ -453,7 +450,7 @@ public class MarkoutWriter
         var headerArray = headers as string[] ?? headers.ToArray();
 
         // Apply column projection
-        var columnMap = _projectionSectionActive ? null : _options.Projection?.ComputeColumnMap(headerArray);
+        var columnMap = _options.Projection?.ComputeColumnMap(headerArray);
         if (columnMap != null)
             headerArray = MarkoutProjection.ProjectHeaders(headerArray, columnMap);
 
@@ -496,7 +493,7 @@ public class MarkoutWriter
         if (headers.Length == 0)
             throw new ArgumentException("At least one header is required.", nameof(headers));
 
-        _columnMap = _projectionSectionActive ? null : _options.Projection?.ComputeColumnMap(headers);
+        _columnMap = _options.Projection?.ComputeColumnMap(headers);
 
         EnsureBlankLineIfNeeded();
         _tableWriter = CreateTableWriter();
@@ -822,8 +819,6 @@ public class MarkoutWriter
         {
             _currentSectionName = text;
             _sectionExcluded = !IsSectionIncluded();
-            _projectionSectionActive = !_sectionExcluded
-                && _options.Projection?.IsSectionIncluded(text) == true;
         }
     }
 
@@ -832,12 +827,7 @@ public class MarkoutWriter
         if (_currentSectionName == null)
             return true;
 
-        if (_options.Projection?.IsSectionIncluded(_currentSectionName) == true)
-            return true;
-
         if (_options.IncludeSections != null && !_options.IncludeSections.Contains(_currentSectionName))
-            return false;
-        if (_options.ExcludeSections?.Contains(_currentSectionName) == true)
             return false;
         return true;
     }
@@ -845,7 +835,7 @@ public class MarkoutWriter
     private MarkoutField[] ProjectFields(ReadOnlySpan<MarkoutField> fields)
     {
         var projection = _options.Projection;
-        if (projection == null || _projectionSectionActive)
+        if (projection == null)
             return fields.ToArray();
 
         if (projection.IncludeFields != null)

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -853,12 +853,13 @@ public class MarkoutWriter
             var result = new List<MarkoutField>(projection.IncludeFields.Count);
             foreach (var name in projection.IncludeFields)
             {
+                bool isGlob = name.Contains('*') || name.Contains('?');
                 for (int i = 0; i < fields.Length; i++)
                 {
-                    if (string.Equals(name, fields[i].Key, projection.Comparison))
+                    if (projection.MatchesName(name, fields[i].Key))
                     {
                         result.Add(fields[i]);
-                        break;
+                        if (!isGlob) break;
                     }
                 }
             }

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -12,7 +12,6 @@ public class MarkoutWriterOptions
     private bool _prettyTables;
     private int? _maxItems;
     private HashSet<string>? _includeSections;
-    private HashSet<string>? _excludeSections;
     private MarkoutProjection? _projection;
     private MarkoutShape _suppressedShapes;
 
@@ -107,19 +106,6 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _includeSections = value;
-        }
-    }
-
-    /// <summary>
-    /// If set, sections whose heading text matches are excluded from output.
-    /// </summary>
-    public HashSet<string>? ExcludeSections
-    {
-        get => _excludeSections;
-        set
-        {
-            ThrowIfReadOnly();
-            _excludeSections = value;
         }
     }
 

--- a/tests/Markout.Tests/AnsiFormatterTests.cs
+++ b/tests/Markout.Tests/AnsiFormatterTests.cs
@@ -232,7 +232,7 @@ public class AnsiFormatterTests
     [Fact]
     public void SectionExcluded_SuppressesOutput()
     {
-        var (orch, sw) = Create(new MarkoutWriterOptions { ExcludeSections = ["Hidden"] });
+        var (orch, sw) = Create(new MarkoutWriterOptions { IncludeSections = [] });
         orch.WriteHeading(2, "Hidden");
         orch.WriteFields([new("Key", "Value")]);
 

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -281,34 +281,6 @@ public class MarkoutWriterTests
     }
 
     [Fact]
-    public void ExcludeSections_FiltersContent()
-    {
-        var options = new MarkoutWriterOptions { ExcludeSections = ["Hidden"] };
-        var orch = MarkoutWriter.Create(new MarkdownFormatter(), options);
-
-        orch.WriteHeading(2, "Visible");
-        orch.WriteParagraph("Included");
-        orch.WriteHeading(2, "Hidden");
-        orch.WriteParagraph("Excluded");
-
-        var output = orch.ToString();
-        Assert.Contains("Included", output);
-        Assert.DoesNotContain("Excluded", output);
-    }
-
-    [Fact]
-    public void BothIncludeAndExcludeSections_Throws()
-    {
-        var options = new MarkoutWriterOptions
-        {
-            IncludeSections = ["A"],
-            ExcludeSections = ["B"]
-        };
-        Assert.Throws<InvalidOperationException>(() =>
-            MarkoutWriter.Create(new MarkdownFormatter(), options));
-    }
-
-    [Fact]
     public void EmptyIncludeSections_PreambleOnly()
     {
         var options = new MarkoutWriterOptions { IncludeSections = [] };
@@ -500,7 +472,8 @@ public class MarkoutWriterTests
     {
         var options = new MarkoutWriterOptions
         {
-            Projection = MarkoutProjection.WithSections("Data")
+            IncludeSections = ["Data"],
+            Projection = new MarkoutProjection()
         };
         var orch = MarkoutWriter.Create(new MarkdownFormatter(), options);
 
@@ -520,8 +493,8 @@ public class MarkoutWriterTests
     {
         var options = new MarkoutWriterOptions
         {
-            Projection = MarkoutProjection.WithSections("Data"),
-            ExcludeSections = ["Other"]
+            IncludeSections = ["Data"],
+            Projection = new MarkoutProjection()
         };
         var orch = MarkoutWriter.Create(new MarkdownFormatter(), options);
 

--- a/tests/Markout.Tests/ProjectionTests.cs
+++ b/tests/Markout.Tests/ProjectionTests.cs
@@ -627,13 +627,6 @@ public class ProjectionTests
     }
 
     [Fact]
-    public void WithSections_CreatesProjectionWithIncludeSections()
-    {
-        var projection = MarkoutProjection.WithSections("Details", "API Surface");
-        Assert.Equal(["Details", "API Surface"], projection.IncludeSections);
-    }
-
-    [Fact]
     public void FactoryMethod_WorksWithWriterOptions()
     {
         var options = new MarkoutWriterOptions

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -182,7 +182,7 @@ public class SerializerTests
     }
 
     [Fact]
-    public void Serialize_WithExcludeSections_SkipsSpecifiedSections()
+    public void Serialize_WithIncludeSections_SkipsUnspecifiedSections()
     {
         var package = new PackageWithSections
         {
@@ -198,7 +198,7 @@ public class SerializerTests
             }
         };
 
-        var context = new SectionTestContext(new MarkoutWriterOptions { ExcludeSections = ["Dependencies"] });
+        var context = new SectionTestContext(new MarkoutWriterOptions { IncludeSections = ["Assemblies"] });
         var mdf = context.Serialize(package);
 
         // Dependencies section should be excluded
@@ -1359,7 +1359,7 @@ public class SerializerTests
     }
 
     [Fact]
-    public void Serialize_ScalarSection_ExcludeAllSections_FieldCollectionStillRenders()
+    public void Serialize_ScalarSection_IncludeNone_FieldCollectionStillRenders()
     {
         var view = new FieldCollectionBeforeSections
         {
@@ -1368,10 +1368,10 @@ public class SerializerTests
             Downloads = 500,
             Stars = 10
         };
-        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { ExcludeSections = ["Stats"] });
+        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { IncludeSections = [] });
         var mdf = context.Serialize(view);
 
-        // Non-section field collection should render even when all sections are excluded
+        // Non-section field collection should render even when no sections are included
         Assert.Contains("Version: 1.0", mdf);
         Assert.Contains("Type: Library", mdf);
         // Section should be excluded
@@ -1380,7 +1380,7 @@ public class SerializerTests
     }
 
     [Fact]
-    public void Serialize_ScalarSection_ExcludeScalarSection_OtherSectionsRender()
+    public void Serialize_ScalarSection_IncludeOnlyDependencies_ScalarSectionExcluded()
     {
         var view = new MixedSection
         {
@@ -1389,7 +1389,7 @@ public class SerializerTests
             Stars = 10,
             Dependencies = [new SimpleDep { Id = "Dep1", Version = "1.0" }]
         };
-        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { ExcludeSections = ["Stats"] });
+        var context = new ScalarSectionTestContext(new MarkoutWriterOptions { IncludeSections = ["Dependencies"] });
         var mdf = context.Serialize(view);
 
         // Scalar section should be excluded


### PR DESCRIPTION
## Summary

Four focused improvements to the Markout public API, shipped as individual commits.

### Commits

1. **Add DocumentSchema for schema query operations** — New `DocumentSchema` type for registering section/field/column metadata with discovery (`Discover`), case-insensitive resolution (`ResolveSection`), and projection validation (`ValidateProjection`). Enables tools to query available structure before rendering.

2. **Add DocumentLayout.Tree for tree-rooted serialization** — New layout option that starts rendering at a tree node rather than document root, for hierarchical views.

3. **Support glob patterns in field/column projection** — `MarkoutProjection` include/exclude lists now support `*` and `?` wildcards via `ProjectionMatcher`, enabling patterns like `IncludeFields = ["Name", "Version*"]`.

4. **Remove ExcludeSections and Projection.WithSections** — Consolidates section filtering to a single mechanism: `MarkoutWriterOptions.IncludeSections`. Removes `ExcludeSections` from writer options, removes `IncludeSections`/`WithSections`/`IsSectionIncluded` from `MarkoutProjection`, and eliminates the `_projectionSectionActive` field that silently disabled field/column filtering when projection had section includes set.

### API changes

**Added:**
- `DocumentSchema` (new type with `Add`, `AddSection`, `Discover`, `ResolveSection`, `ValidateProjection`)
- `DocumentLayout.Tree` enum value
- `ProjectionMatcher` (glob support in projection lists)

**Removed (breaking):**
- `MarkoutWriterOptions.ExcludeSections`
- `MarkoutProjection.IncludeSections`, `.WithSections()`, `.IsSectionIncluded()`

### Stats

- `src/`: 9 files, +326 −72
- `tests/`: 4 files, +12 −46
- `docs/`: 3 files, +4 −12
- `samples/`: 1 file, +1 −28
- All 446 tests pass