### PR TITLE
Add ToDocumentSchema conversion on MarkoutSchemaInfo

### DIFF
--- a/src/Markout/MarkoutSchemaInfo.cs
+++ b/src/Markout/MarkoutSchemaInfo.cs
@@ -145,6 +145,122 @@ public sealed class MarkoutSchemaInfo
         return rendering[start..end];
     }
 
+    /// <summary>
+    /// Converts the source-generated schema into a <see cref="DocumentSchema"/>
+    /// suitable for discovery, projection validation, and diagnostics.
+    /// </summary>
+    /// <remarks>
+    /// This is a lossy reduction: section headings, content types, and item names are
+    /// preserved, but dynamic content (field tables, code blocks) produces sections
+    /// with no queryable items.
+    /// </remarks>
+    public DocumentSchema ToDocumentSchema()
+    {
+        var sectionOrder = new List<string>();
+        var sectionData = new Dictionary<string, (string? ItemKind, List<string> Items)>(
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var prop in AsDocument)
+        {
+            var sectionName = ExtractSectionName(prop.Rendering);
+            if (sectionName == null) continue;
+
+            var contentType = ExtractContentType(prop.Rendering);
+            var (itemKind, items) = MapContentToItems(contentType, prop);
+
+            if (!sectionData.TryGetValue(sectionName, out var existing))
+            {
+                sectionData[sectionName] = (itemKind, items);
+                sectionOrder.Add(sectionName);
+            }
+            else
+            {
+                // Merge: union of items, upgrade kind if previously section-only
+                foreach (var item in items)
+                {
+                    if (!existing.Items.Contains(item, StringComparer.OrdinalIgnoreCase))
+                        existing.Items.Add(item);
+                }
+                if (existing.ItemKind == null && itemKind != null)
+                    sectionData[sectionName] = (itemKind, existing.Items);
+            }
+        }
+
+        var schema = new DocumentSchema();
+        foreach (var name in sectionOrder)
+        {
+            var (itemKind, items) = sectionData[name];
+            if (itemKind != null && items.Count > 0)
+                schema.Add(name, itemKind, items.ToArray());
+            else
+                schema.AddSection(name);
+        }
+        return schema;
+    }
+
+    private static string? ExtractContentType(string rendering)
+    {
+        // Extract the parenthetical suffix from: H2 Section "Name" (table)
+        int lastOpen = rendering.LastIndexOf('(');
+        int lastClose = rendering.LastIndexOf(')');
+        if (lastOpen < 0 || lastClose <= lastOpen) return null;
+        return rendering[(lastOpen + 1)..lastClose];
+    }
+
+    private static (string? ItemKind, List<string> Items) MapContentToItems(
+        string? contentType, MarkoutPropertySchema prop)
+    {
+        return contentType switch
+        {
+            "table" => ("column", CollectChildColumns(prop)),
+            "subsections" => ("column", CollectChildColumns(prop)),
+            "field" => ("field", [prop.DisplayName]),
+            "fields" => ("field", CollectChildFields(prop)),
+            "tree" => ("tree", CollectChildColumns(prop)),
+            // Content types with no queryable items
+            "field table" or "code block" or "bar chart"
+                or "labeled list" or "distribution" => (null, []),
+            // No parenthetical (e.g. bullet list in section) — no static items
+            _ => (null, []),
+        };
+    }
+
+    private static List<string> CollectChildColumns(MarkoutPropertySchema prop)
+    {
+        var names = new List<string>();
+        foreach (var child in prop.Children)
+        {
+            if (child.Rendering.StartsWith("Column", StringComparison.Ordinal)
+                && !names.Contains(child.DisplayName, StringComparer.OrdinalIgnoreCase))
+                names.Add(child.DisplayName);
+        }
+        return names;
+    }
+
+    private static List<string> CollectChildFields(MarkoutPropertySchema prop)
+    {
+        var names = new List<string>();
+        CollectChildFieldsRecursive(prop.Children, names);
+        return names;
+    }
+
+    private static void CollectChildFieldsRecursive(
+        IReadOnlyList<MarkoutPropertySchema> children, List<string> names)
+    {
+        foreach (var child in children)
+        {
+            if (child.Rendering.StartsWith("Field", StringComparison.Ordinal))
+            {
+                if (!names.Contains(child.DisplayName, StringComparer.OrdinalIgnoreCase))
+                    names.Add(child.DisplayName);
+            }
+            else if (child.Rendering == "Fields")
+            {
+                CollectChildFieldsRecursive(child.Children, names);
+            }
+        }
+    }
+
     private bool HasDifferences()
     {
         if (AsDocument.Count != AsTableItem.Count) return true;

--- a/tests/Markout.Tests/ProjectionTests.cs
+++ b/tests/Markout.Tests/ProjectionTests.cs
@@ -591,6 +591,208 @@ public class ProjectionTests
         Assert.Equal(["Name", "Version", "Target"], columns);
     }
 
+    // --- ToDocumentSchema tests ---
+
+    [Fact]
+    public void ToDocumentSchema_TableSections_ProducesColumns()
+    {
+        var schema = SectionTestContext.PackageWithSectionsSchema;
+        var doc = schema.ToDocumentSchema();
+
+        Assert.Equal(["Dependencies", "Assemblies"], doc.SectionNames);
+
+        var deps = doc.GetSection("Dependencies");
+        Assert.NotNull(deps);
+        Assert.Equal("column", deps.ItemKind);
+        Assert.Equal(["Id", "Version"], deps.Items.Select(i => i.Name).ToArray());
+
+        var asms = doc.GetSection("Assemblies");
+        Assert.NotNull(asms);
+        Assert.Equal("column", asms.ItemKind);
+        Assert.Equal(["Name", "Arch"], asms.Items.Select(i => i.Name).ToArray());
+    }
+
+    [Fact]
+    public void ToDocumentSchema_ScalarFieldSections_ProducesFields()
+    {
+        var schema = ScalarSectionTestContext.Default.GetSchemaInfo<MixedSection>()!;
+        var doc = schema.ToDocumentSchema();
+
+        Assert.Equal(["Stats", "Dependencies"], doc.SectionNames);
+
+        var stats = doc.GetSection("Stats");
+        Assert.NotNull(stats);
+        Assert.Equal("field", stats.ItemKind);
+        Assert.Contains("Downloads", stats.Items.Select(i => i.Name));
+        Assert.Contains("Stars", stats.Items.Select(i => i.Name));
+
+        var deps = doc.GetSection("Dependencies");
+        Assert.NotNull(deps);
+        Assert.Equal("column", deps.ItemKind);
+    }
+
+    [Fact]
+    public void ToDocumentSchema_MergesDuplicateSections()
+    {
+        // Two properties sharing "Items" section with different columns
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "MergeTest",
+            AsDocument = [
+                new() { Name = "ItemsA", DisplayName = "Items", Rendering = "H2 Section \"Items\" (table)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                    new() { Name = "Version", DisplayName = "Version", Rendering = "Column" },
+                ] },
+                new() { Name = "ItemsB", DisplayName = "Items", Rendering = "H2 Section \"Items\" (table)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                    new() { Name = "Arch", DisplayName = "Arch", Rendering = "Column" },
+                ] },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        Assert.Single(doc.SectionNames);
+        var items = doc.GetSection("Items")!;
+        Assert.Equal("column", items.ItemKind);
+        Assert.Equal(["Name", "Version", "Arch"], items.Items.Select(i => i.Name).ToArray());
+    }
+
+    [Fact]
+    public void ToDocumentSchema_FieldSection_SingleScalar()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "SingleField",
+            AsDocument = [
+                new() { Name = "Url", DisplayName = "URL", Rendering = "H2 Section \"Remote Source\" (field)" },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        var section = doc.GetSection("Remote Source")!;
+        Assert.Equal("field", section.ItemKind);
+        Assert.Equal(["URL"], section.Items.Select(i => i.Name).ToArray());
+    }
+
+    [Fact]
+    public void ToDocumentSchema_NestedFields_CollectsChildFields()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "Nested",
+            AsDocument = [
+                new() { Name = "Info", DisplayName = "Info", Rendering = "H2 Section \"Library Info\" (fields)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Field" },
+                    new() { Name = "Version", DisplayName = "Version", Rendering = "Field" },
+                    new() { Name = "IsSigned", DisplayName = "Signed", Rendering = "Field (yes/no)" },
+                ] },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        var section = doc.GetSection("Library Info")!;
+        Assert.Equal("field", section.ItemKind);
+        Assert.Equal(["Name", "Version", "Signed"], section.Items.Select(i => i.Name).ToArray());
+    }
+
+    [Fact]
+    public void ToDocumentSchema_TreeSection_CollectsColumns()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "TreeTest",
+            AsDocument = [
+                new() { Name = "Deps", DisplayName = "Deps", Rendering = "H2 Section \"Dependencies\" (tree)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                ] },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        var section = doc.GetSection("Dependencies")!;
+        Assert.Equal("tree", section.ItemKind);
+        Assert.Equal(["Name"], section.Items.Select(i => i.Name).ToArray());
+    }
+
+    [Fact]
+    public void ToDocumentSchema_CodeBlockSection_SectionOnly()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "CodeTest",
+            AsDocument = [
+                new() { Name = "IL", DisplayName = "IL", Rendering = "H2 Section \"IL\" (code block)" },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        Assert.Equal(["IL"], doc.SectionNames);
+        var section = doc.GetSection("IL")!;
+        Assert.Equal("section", section.ItemKind);
+        Assert.Empty(section.Items);
+    }
+
+    [Fact]
+    public void ToDocumentSchema_FieldTableSection_SectionOnly()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "FieldTableTest",
+            AsDocument = [
+                new() { Name = "Summary", DisplayName = "Summary", Rendering = "H2 Section \"Summary\" (field table)" },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        Assert.Equal(["Summary"], doc.SectionNames);
+        var section = doc.GetSection("Summary")!;
+        Assert.Equal("section", section.ItemKind);
+        Assert.Empty(section.Items);
+    }
+
+    [Fact]
+    public void ToDocumentSchema_SkipsNonSectionProperties()
+    {
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "MixedProps",
+            AsDocument = [
+                new() { Name = "Name", DisplayName = "Name", Rendering = "Field" },
+                new() { Name = "Version", DisplayName = "Version", Rendering = "Field" },
+                new() { Name = "Deps", DisplayName = "Deps", Rendering = "H2 Section \"Dependencies\" (table)", Children = [
+                    new() { Name = "Id", DisplayName = "Id", Rendering = "Column" },
+                ] },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        // Only the section should appear, not the scalar fields
+        Assert.Equal(["Dependencies"], doc.SectionNames);
+    }
+
+    [Fact]
+    public void ToDocumentSchema_MergesFieldAndCodeBlock()
+    {
+        // A section with both scalar fields and a code block property
+        var schema = new MarkoutSchemaInfo
+        {
+            TypeName = "MixedKinds",
+            AsDocument = [
+                new() { Name = "Sig", DisplayName = "Signature", Rendering = "H2 Section \"Constructors\" (code block)" },
+                new() { Name = "Table", DisplayName = "Table", Rendering = "H2 Section \"Constructors\" (table)", Children = [
+                    new() { Name = "Name", DisplayName = "Name", Rendering = "Column" },
+                ] },
+            ],
+        };
+        var doc = schema.ToDocumentSchema();
+
+        Assert.Single(doc.SectionNames);
+        var section = doc.GetSection("Constructors")!;
+        // Code block came first (no items), table merged in with items → upgraded
+        Assert.Equal("column", section.ItemKind);
+        Assert.Equal(["Name"], section.Items.Select(i => i.Name).ToArray());
+    }
+
     // --- Factory method tests ---
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds `ToDocumentSchema()` to `MarkoutSchemaInfo` for converting source-generated schema into `DocumentSchema`
- Maps tables/subsections to columns, fields to field items, merges duplicate section names
- Handles code block, field table, bar chart, labeled list, and distribution as section-only (no queryable items)
- Includes 10 tests covering all content type mappings, merging, and edge cases

## Test plan
- [x] All 456 Markout.Tests pass
- [ ] Verify integration with dotnet-inspect `DocumentSchema` auto-generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)