### PR TITLE
Code review fixes and PlainTextFormatter

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -20,10 +20,12 @@ internal static class EmitHelpers
             return WrapWithDisplayFormat(prop, expr);
         }
 
-        // Joined string array: render as string.Join(separator, collection)
-        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+        // Joined array: render as string.Join(separator, collection) or LINQ Select for complex types
+        if (IsJoinedArray(prop))
         {
-            return $"string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess})";
+            if (prop.Kind == PropertyKind.StringArray)
+                return $"string.Join(\"{EscapeString(prop.JoinSeparator!)}\", {propAccess})";
+            return GetComplexJoinExpression(prop, propAccess);
         }
 
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
@@ -150,10 +152,12 @@ internal static class EmitHelpers
             return WrapWithTableOrDisplayFormat(prop, inner);
         }
 
-        // Joined string array in table cell
-        if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+        // Joined array in table cell
+        if (IsJoinedArray(prop))
         {
-            return $"{propAccess} != null ? string.Join(\"{EscapeString(prop.JoinSeparator)}\", {propAccess}) : \"\"";
+            if (prop.Kind == PropertyKind.StringArray)
+                return $"{propAccess} != null ? string.Join(\"{EscapeString(prop.JoinSeparator!)}\", {propAccess}) : \"\"";
+            return $"{propAccess} != null ? {GetComplexJoinExpression(prop, propAccess)} : \"\"";
         }
 
         if (prop.Kind == PropertyKind.Boolean && prop.BoolTrueValue != null && prop.BoolFalseValue != null)
@@ -289,6 +293,47 @@ internal static class EmitHelpers
 
         sb.AppendLine($"{indent}if ({remainVar} > 0)");
         sb.AppendLine($"{indent}    writer.WriteParagraph(string.Format(\"{EscapeString(ellipsis)}\", {remainVar}));");
+    }
+
+    /// <summary>
+    /// Builds a string.Join expression for a complex array with [MarkoutJoin].
+    /// Each element is formatted by concatenating its visible scalar properties.
+    /// </summary>
+    public static string GetComplexJoinExpression(PropertyMetadata prop, string propAccess)
+    {
+        var separator = EscapeString(prop.JoinSeparator!);
+        var elemProps = prop.ElementProperties?
+            .Where(p => !p.IsIgnored && IsScalarKind(p.Kind))
+            .ToList();
+
+        if (elemProps == null || elemProps.Count == 0)
+            return $"string.Join(\"{separator}\", global::System.Linq.Enumerable.Select({propAccess}, __e => __e.ToString() ?? \"\"))";
+
+        if (elemProps.Count == 1)
+            return $"string.Join(\"{separator}\", global::System.Linq.Enumerable.Select({propAccess}, __e => {GetElementPropertyValue(elemProps[0])}))";
+
+        var parts = string.Join(" + \" \" + ", elemProps.Select(p => GetElementPropertyValue(p)));
+        return $"string.Join(\"{separator}\", global::System.Linq.Enumerable.Select({propAccess}, __e => {parts}))";
+    }
+
+    private static string GetElementPropertyValue(PropertyMetadata prop)
+    {
+        return prop.Kind switch
+        {
+            PropertyKind.String => $"(__e.{prop.Name} ?? \"\")",
+            PropertyKind.Boolean => $"(__e.{prop.Name} ? \"yes\" : \"no\")",
+            PropertyKind.Enum => $"__e.{prop.Name}.ToString()",
+            _ => $"__e.{prop.Name}.ToString(System.Globalization.CultureInfo.InvariantCulture)"
+        };
+    }
+
+    /// <summary>
+    /// Returns true if the property is an array with [MarkoutJoin], making it render as a scalar field.
+    /// </summary>
+    public static bool IsJoinedArray(PropertyMetadata prop)
+    {
+        return prop.JoinSeparator != null &&
+               (prop.Kind == PropertyKind.StringArray || prop.Kind == PropertyKind.ComplexArray);
     }
 
     public static bool IsScalarKind(PropertyKind kind)

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -59,7 +59,7 @@ internal static class FieldEmitter
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || EmitHelpers.IsJoinedArray(p)
             || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
@@ -94,7 +94,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
-                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                else if (EmitHelpers.IsJoinedArray(prop))
                 {
                     var countProp = prop.IsArray ? "Length" : "Count";
                     sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
@@ -170,7 +170,7 @@ internal static class FieldEmitter
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || EmitHelpers.IsJoinedArray(p)
             || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
@@ -205,7 +205,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
-                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                else if (EmitHelpers.IsJoinedArray(prop))
                 {
                     var countProp = prop.IsArray ? "Length" : "Count";
                     sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
@@ -281,7 +281,7 @@ internal static class FieldEmitter
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || EmitHelpers.IsJoinedArray(p)
             || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
@@ -316,7 +316,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
-                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                else if (EmitHelpers.IsJoinedArray(prop))
                 {
                     var countProp = prop.IsArray ? "Length" : "Count";
                     sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
@@ -392,7 +392,7 @@ internal static class FieldEmitter
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || EmitHelpers.IsJoinedArray(p)
             || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
@@ -425,7 +425,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
-                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                else if (EmitHelpers.IsJoinedArray(prop))
                 {
                     var countProp = prop.IsArray ? "Length" : "Count";
                     sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
@@ -500,7 +500,7 @@ internal static class FieldEmitter
     {
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
-            || (p.Kind == PropertyKind.StringArray && p.JoinSeparator != null)
+            || EmitHelpers.IsJoinedArray(p)
             || p.SkipWhenDefault || p.SkipWhenNull || p.ShowWhenProperty != null);
         var fieldsVar = nestingDepth == 0 ? "__fields" : $"__fields{nestingDepth}";
 
@@ -533,7 +533,7 @@ internal static class FieldEmitter
                     sb.AppendLine($"{fieldIndent}if (!string.IsNullOrEmpty({propAccess}))");
                     sb.AppendLine($"{fieldIndent}    {fieldsVar}.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));");
                 }
-                else if (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null)
+                else if (EmitHelpers.IsJoinedArray(prop))
                 {
                     var countProp = prop.IsArray ? "Length" : "Count";
                     sb.AppendLine($"{fieldIndent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -310,7 +310,7 @@ internal static class SerializerEmitter
             if (!autoFields && !prop.IsSection && prop.Kind != PropertyKind.FieldCollection)
                 continue;
 
-            bool isScalarKind = EmitHelpers.IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null);
+            bool isScalarKind = EmitHelpers.IsScalarKind(prop.Kind) || EmitHelpers.IsJoinedArray(prop);
 
             if (isScalarKind && !prop.IsSection)
             {
@@ -926,7 +926,7 @@ internal static class SerializerEmitter
                 return "Ignored";
             
             // In table context, only scalars (and joined arrays) work
-            if (EmitHelpers.IsScalarKind(prop.Kind) || (prop.Kind == PropertyKind.StringArray && prop.JoinSeparator != null))
+            if (EmitHelpers.IsScalarKind(prop.Kind) || EmitHelpers.IsJoinedArray(prop))
                 return "Column" + (prop.Name != prop.DisplayName ? $" \"{prop.DisplayName}\"" : "");
             
             // Unsupported patterns are skipped
@@ -977,9 +977,9 @@ internal static class SerializerEmitter
             PropertyKind.DateTime or PropertyKind.DateTimeOffset => "Field (ISO 8601)",
             PropertyKind.Enum => "Field (enum)",
             PropertyKind.StringArray => prop.JoinSeparator != null ? "Field (joined)" : "Bullet list",
-            PropertyKind.ComplexArray => prop.ElementHasNestedContent 
-                ? "Subsections" 
-                : "Table",
+            PropertyKind.ComplexArray => prop.JoinSeparator != null
+                ? "Field (joined)"
+                : prop.ElementHasNestedContent ? "Subsections" : "Table",
             PropertyKind.FieldCollection => "Field list",
             PropertyKind.NestedObject => "Fields",
             PropertyKind.Formattable => "Custom (IMarkoutFormattable)",

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -445,8 +445,8 @@ internal static class TypeParser
         var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, elementTitleContextProperty, elementAutoFields, elementFieldLayout, isArray) = DeterminePropertyKind(prop.Type, compilation, knownTypes, diagnostics, prop.Name, prop.Locations.FirstOrDefault(), visitedTypes);
 
         // Determine if property is unsupported in table context
-        // Joined string arrays are treated as scalars, so they're fine in tables
-        bool isJoinedArray = kind == PropertyKind.StringArray && joinSeparator != null;
+        // Joined arrays (string or complex) are treated as scalars, so they're fine in tables
+        bool isJoinedArray = joinSeparator != null && (kind == PropertyKind.StringArray || kind == PropertyKind.ComplexArray);
         bool isUnsupportedInTable = !isIgnored && !isSection && !isUnwrapped && !IsScalarKind(kind) && !isJoinedArray && kind != PropertyKind.Formattable;
 
         // Emit warning for unsupported properties without [MarkoutIgnoreInTable]
@@ -706,7 +706,8 @@ internal static class TypeParser
         if (props == null) return false;
         return props.Any(p => !p.IsIgnored &&
             (p.IsSection || p.Kind == PropertyKind.Callout ||
-             p.Kind == PropertyKind.NestedObject || p.Kind == PropertyKind.ComplexArray ||
+             p.Kind == PropertyKind.NestedObject ||
+             (p.Kind == PropertyKind.ComplexArray && p.JoinSeparator == null) ||
              p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree ||
              p.Kind == PropertyKind.Description || p.Kind == PropertyKind.Metric ||
              p.Kind == PropertyKind.CodeSection || p.Kind == PropertyKind.Breakdown ||

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -165,6 +165,8 @@ public class MarkdownFormatter : IMarkoutFormatter,
 
     void IStreamingTableFormatter.BeginTable(TextWriter w, ReadOnlySpan<string> headers, MarkoutWriterOptions options)
     {
+        _streamingWidths = null; // Reset state in case previous table had an error
+
         if (options.PrettyTables)
         {
             _streamingWidths = new int[headers.Length];
@@ -391,7 +393,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             var headers = new[] { "Category", "Count", "%" };
             var rows = item.Segments
                 .Where(s => s.Count > 0)
-                .Select(s => new[] { s.Category, s.Count.ToString(), $"{s.Count * 100 / total}" })
+                .Select(s => new[] { s.Category, s.Count.ToString(), $"{s.Count * 100.0 / total:F0}" })
                 .ToList();
 
             ((ITableFormatter)this).FormatTable(w, headers, rows, 0, options);
@@ -407,7 +409,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
                 if (total == 0) total = 1;
 
                 foreach (var seg in item.Segments.Where(s => s.Count > 0))
-                    rows.Add([item.Label, seg.Category, seg.Count.ToString(), $"{seg.Count * 100 / total}"]);
+                    rows.Add([item.Label, seg.Category, seg.Count.ToString(), $"{seg.Count * 100.0 / total:F0}"]);
             }
 
             ((ITableFormatter)this).FormatTable(w, headers, rows, 0, options);

--- a/src/Markout/MarkoutSerializer.cs
+++ b/src/Markout/MarkoutSerializer.cs
@@ -49,6 +49,7 @@ public static class MarkoutSerializer
     public static void Serialize<T>(T value, TextWriter output, Formatting.IMarkoutFormatter formatter, MarkoutSerializerContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(formatter);
         context.Serialize(value, output, formatter);
     }
 
@@ -64,6 +65,7 @@ public static class MarkoutSerializer
     public static void Serialize<T>(T value, TextWriter output, Formatting.IMarkoutFormatter formatter, MarkoutSerializerContext context, MarkoutWriterOptions options)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(formatter);
         ArgumentNullException.ThrowIfNull(options);
         context.Serialize(value, output, formatter, options);
     }

--- a/src/Markout/MarkoutSerializerContext.cs
+++ b/src/Markout/MarkoutSerializerContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Markout;
 
@@ -15,6 +16,10 @@ namespace Markout;
 /// <seealso href="../../samples/Serialization/SectionFiltering.cs">Section filtering via context</seealso>
 public abstract class MarkoutSerializerContext
 {
+    private const string TypeNotRegisteredMessage = 
+        "Type '{0}' is not registered in this serializer context. " +
+        "Add [MarkoutContext(typeof({1}))] to your context class.";
+
     private MarkoutWriterOptions _options;
 
     /// <summary>
@@ -72,6 +77,13 @@ public abstract class MarkoutSerializerContext
     /// <returns>An enumerable of all registered type infos.</returns>
     public abstract IEnumerable<IMarkoutTypeInfo> GetRegisteredTypes();
 
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    private static void ThrowTypeNotRegistered<T>()
+    {
+        throw new InvalidOperationException(
+            string.Format(TypeNotRegisteredMessage, typeof(T).FullName, typeof(T).Name));
+    }
+
     /// <summary>
     /// Serializes a value using this context.
     /// </summary>
@@ -90,11 +102,7 @@ public abstract class MarkoutSerializerContext
     {
         var typeInfo = GetTypeInfo<T>();
         if (typeInfo == null)
-        {
-            throw new InvalidOperationException(
-                $"Type '{typeof(T).FullName}' is not registered in this serializer context. " +
-                $"Add [MarkoutContext(typeof({typeof(T).Name}))] to your context class.");
-        }
+            ThrowTypeNotRegistered<T>();
 
         var orch = new MarkoutWriter(new MarkdownFormatter(), options);
         typeInfo.Serialize(orch, value);
@@ -109,11 +117,7 @@ public abstract class MarkoutSerializerContext
     {
         var typeInfo = GetTypeInfo<T>();
         if (typeInfo == null)
-        {
-            throw new InvalidOperationException(
-                $"Type '{typeof(T).FullName}' is not registered in this serializer context. " +
-                $"Add [MarkoutContext(typeof({typeof(T).Name}))] to your context class.");
-        }
+            ThrowTypeNotRegistered<T>();
 
         typeInfo.Serialize(writer, value);
     }
@@ -149,11 +153,7 @@ public abstract class MarkoutSerializerContext
     {
         var typeInfo = GetTypeInfo<T>();
         if (typeInfo == null)
-        {
-            throw new InvalidOperationException(
-                $"Type '{typeof(T).FullName}' is not registered in this serializer context. " +
-                $"Add [MarkoutContext(typeof({typeof(T).Name}))] to your context class.");
-        }
+            ThrowTypeNotRegistered<T>();
 
         var orch = new MarkoutWriter(output, formatter, options);
         typeInfo.Serialize(orch, value);

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -9,6 +9,9 @@ namespace Markout;
 /// Returns <c>bool</c> from all Write methods: <c>true</c> = rendered (or filtered),
 /// <c>false</c> = unsupported shape (nothing written).
 /// </summary>
+/// <remarks>
+/// This class is not thread-safe. Use separate instances for concurrent operations.
+/// </remarks>
 public class MarkoutWriter
 {
     private readonly TextWriter _writer;

--- a/src/Markout/PlainTextFormatter.cs
+++ b/src/Markout/PlainTextFormatter.cs
@@ -1,0 +1,211 @@
+using Markout.Formatting;
+
+namespace Markout;
+
+/// <summary>
+/// Formatter that produces plain-text output without any markup syntax.
+/// Fields render as "Key: Value", tables as space-padded columns,
+/// headings as plain text lines, and lists as indented items.
+/// </summary>
+public class PlainTextFormatter : IMarkoutFormatter,
+    IHeadingFormatter, IFieldFormatter, IBlockFormatter,
+    IListFormatter, ITableFormatter, ICodeBlockFormatter, ITreeFormatter
+{
+    private const int ColumnGap = 2;
+
+    // ── IHeadingFormatter ──
+
+    void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
+    {
+        w.Write(text);
+        if (!string.IsNullOrEmpty(context))
+        {
+            w.Write(" (");
+            w.Write(context);
+            w.Write(')');
+        }
+    }
+
+    // ── IFieldFormatter ──
+
+    void IFieldFormatter.FormatFieldName(TextWriter w, string key, bool bold)
+    {
+        w.Write(key);
+        w.Write(": ");
+    }
+
+    void IFieldFormatter.FormatFields(TextWriter w, MarkoutField[] fields, bool bold)
+    {
+        // Calculate max key width for alignment
+        int maxKeyWidth = 0;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (fields[i].Key.Length > maxKeyWidth)
+                maxKeyWidth = fields[i].Key.Length;
+        }
+
+        for (int i = 0; i < fields.Length; i++)
+        {
+            w.Write(fields[i].Key.PadRight(maxKeyWidth));
+            w.Write("  ");
+            w.WriteLine(fields[i].Value);
+        }
+    }
+
+    // ── ITableFormatter ──
+
+    void ITableFormatter.FormatTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows, MarkoutWriterOptions options)
+    {
+        var widths = new int[headers.Length];
+        for (int i = 0; i < headers.Length; i++)
+            widths[i] = headers[i].Length;
+        foreach (var row in rows)
+        {
+            for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
+                widths[i] = Math.Max(widths[i], row[i].Length);
+        }
+
+        // Header
+        for (int i = 0; i < headers.Length; i++)
+        {
+            if (i < headers.Length - 1)
+                w.Write(headers[i].PadRight(widths[i] + ColumnGap));
+            else
+                w.Write(headers[i]);
+        }
+        w.WriteLine();
+
+        // Separator
+        for (int i = 0; i < headers.Length; i++)
+        {
+            if (i < headers.Length - 1)
+                w.Write(new string('-', widths[i]).PadRight(widths[i] + ColumnGap));
+            else
+                w.Write(new string('-', widths[i]));
+        }
+        w.WriteLine();
+
+        // Rows
+        foreach (var row in rows)
+        {
+            for (int i = 0; i < row.Length; i++)
+            {
+                if (i < row.Length - 1)
+                    w.Write(row[i].PadRight(widths[i] + ColumnGap));
+                else
+                    w.Write(row[i]);
+            }
+            w.WriteLine();
+        }
+
+        if (skippedRows > 0)
+            w.WriteLine($"\n... and {skippedRows} more");
+    }
+
+    // ── ICodeBlockFormatter ──
+
+    void ICodeBlockFormatter.FormatCodeStart(TextWriter w, string? language)
+    {
+        // No fence markers in plain text
+    }
+
+    void ICodeBlockFormatter.FormatCodeEnd(TextWriter w)
+    {
+        // No fence markers in plain text
+    }
+
+    // ── IBlockFormatter ──
+
+    void IBlockFormatter.FormatParagraph(TextWriter w, string text)
+    {
+        w.WriteLine(text);
+    }
+
+    void IBlockFormatter.FormatCallout(TextWriter w, CalloutSeverity severity, string message)
+    {
+        var label = severity switch
+        {
+            CalloutSeverity.Note => "Note",
+            CalloutSeverity.Tip => "Tip",
+            CalloutSeverity.Important => "Important",
+            CalloutSeverity.Warning => "Warning",
+            CalloutSeverity.Caution => "Caution",
+            _ => severity.ToString()
+        };
+
+        w.Write(label);
+        w.Write(": ");
+        w.WriteLine(message);
+    }
+
+    void IBlockFormatter.FormatQuotation(TextWriter w, string text)
+    {
+        w.WriteLine(text);
+    }
+
+    void IBlockFormatter.FormatRule(TextWriter w)
+    {
+        w.WriteLine(new string('-', 40));
+    }
+
+    void IBlockFormatter.FormatDescription(TextWriter w, Description item)
+    {
+        w.Write(item.Term);
+        w.Write(": ");
+        w.WriteLine(item.Text);
+
+        if (item.Detail != null)
+        {
+            w.Write("  ");
+            w.WriteLine(item.Detail);
+        }
+    }
+
+    // ── IListFormatter ──
+
+    void IListFormatter.FormatListItem(TextWriter w, string text)
+    {
+        w.WriteLine(text);
+    }
+
+    void IListFormatter.FormatArray(TextWriter w, string key, ReadOnlySpan<string> items, bool bold)
+    {
+        w.Write(key);
+        w.WriteLine(":");
+        foreach (var item in items)
+            w.WriteLine(item);
+    }
+
+    // ── ITreeFormatter ──
+
+    void ITreeFormatter.FormatTree(TextWriter w, ReadOnlySpan<TreeNode> nodes, MarkoutWriterOptions options)
+    {
+        for (int i = 0; i < nodes.Length; i++)
+            FormatTreeNodeRecursive(w, nodes[i], "", i == nodes.Length - 1, options);
+    }
+
+    void ITreeFormatter.FormatTreeNode(TextWriter w, string text, string prefix)
+    {
+        w.Write(prefix);
+        w.WriteLine(text);
+    }
+
+    private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
+    {
+        w.Write(prefix);
+        w.Write(isLast ? "└─ " : "├─ ");
+        if (node.Badge != null && options.IncludeBadges)
+        {
+            w.Write(node.Badge);
+            w.Write(' ');
+        }
+        w.WriteLine(node.Text);
+
+        if (node.Children is { Count: > 0 })
+        {
+            var childPrefix = prefix + (isLast ? "   " : "│  ");
+            for (int i = 0; i < node.Children.Count; i++)
+                FormatTreeNodeRecursive(w, node.Children[i], childPrefix, i == node.Children.Count - 1, options);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix integer division in breakdown percentage calculation (now uses float division)
- Add null validation for formatter parameter in Serialize overloads
- Document MarkoutWriter as not thread-safe
- Extract duplicate TypeNotRegistered error message to constant and helper method
- Add PlainTextFormatter for plain-text output without markup syntax
- Support [MarkoutJoin] attribute on complex arrays (not just string arrays)
- Extract IsJoinedArray helper to reduce duplication in source generator