### PR TITLE
Add WriteLinkDefinitions and TableFormatterOptions support

### DIFF
--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Markout.Formatting;
+using MarkdownTable.Formatting;
 
 namespace Markout;
 
@@ -61,7 +62,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
     void ITableFormatter.FormatTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows, MarkoutWriterOptions options)
     {
         if (options.PrettyTables)
-            WritePrettyPipeTable(w, headers, rows, skippedRows);
+            WritePrettyPipeTable(w, headers, rows, skippedRows, options.TableOptions);
         else
             WriteCompactPipeTable(w, headers, rows, skippedRows);
     }
@@ -106,18 +107,28 @@ public class MarkdownFormatter : IMarkoutFormatter,
             w.WriteLine($"\n... and {skippedRows} more");
     }
 
-    private static void WritePrettyPipeTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows)
+    private static void WritePrettyPipeTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows, TableFormatterOptions? tableOptions = null)
     {
         // Calculate column widths
-        var widths = new int[headers.Length];
-        for (int i = 0; i < headers.Length; i++)
-            widths[i] = headers[i].Length;
-        foreach (var row in rows)
+        int[] widths;
+        if (tableOptions is not null)
         {
-            for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
+            // Statistical width calculation — prevents outlier rows from stretching the table
+            widths = ColumnWidthCalculator.Calculate(headers.ToArray(), (IReadOnlyList<string[]>)rows, tableOptions);
+        }
+        else
+        {
+            // Simple max-width calculation
+            widths = new int[headers.Length];
+            for (int i = 0; i < headers.Length; i++)
+                widths[i] = headers[i].Length;
+            foreach (var row in rows)
             {
-                var escaped = FormatHelper.EscapeTableCell(row[i]);
-                widths[i] = Math.Max(widths[i], escaped.Length);
+                for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
+                {
+                    var escaped = FormatHelper.EscapeTableCell(row[i]);
+                    widths[i] = Math.Max(widths[i], escaped.Length);
+                }
             }
         }
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,12 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MarkdownTable.Formatting\MarkdownTable.Formatting.csproj" />
+  </ItemGroup>
 
   <!-- Include source generator in this package -->
   <ItemGroup>

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -376,7 +376,7 @@ public class MarkoutWriter
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support lists.</returns>
     public bool WriteList(params ReadOnlySpan<string> items)
     {
-        if (_sectionExcluded)
+        if (items.Length == 0 || _sectionExcluded)
             return true;
 
         if (_formatter is not IListFormatter lf)
@@ -386,6 +386,7 @@ public class MarkoutWriter
         foreach (var item in items)
             lf.FormatListItem(_writer, item);
 
+        _needsBlankLine = true;
         _hasContent = true;
         return true;
     }
@@ -779,6 +780,26 @@ public class MarkoutWriter
         tf.FormatTree(_writer, nodes, _options);
         _hasContent = true;
         return true;
+    }
+
+    // ── Link definitions ──
+
+    /// <summary>
+    /// Writes a block of reference-style link definitions (e.g. <c>[0]: https://example.com</c>).
+    /// Ensures a blank line before the block and sets state so a blank line is inserted before subsequent content.
+    /// </summary>
+    public void WriteLinkDefinitions(params ReadOnlySpan<string> definitions)
+    {
+        if (definitions.Length == 0 || _sectionExcluded)
+            return;
+
+        EnsureBlankLineIfNeeded();
+
+        foreach (var def in definitions)
+            _writer.WriteLine(def);
+
+        _needsBlankLine = true;
+        _hasContent = true;
     }
 
     // ── Infrastructure ──

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -1,3 +1,5 @@
+using MarkdownTable.Formatting;
+
 namespace Markout;
 
 /// <summary>
@@ -14,6 +16,7 @@ public class MarkoutWriterOptions
     private HashSet<string>? _includeSections;
     private MarkoutProjection? _projection;
     private MarkoutShape _suppressedShapes;
+    private TableFormatterOptions? _tableOptions;
 
     /// <summary>
     /// Gets the default options instance. This instance is read-only.
@@ -136,6 +139,21 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _suppressedShapes = value;
+        }
+    }
+
+    /// <summary>
+    /// Statistical table formatting options. When set with <see cref="PrettyTables"/>,
+    /// column widths are calculated using percentile-based analysis instead of
+    /// simple max-width, preventing outlier rows from stretching the entire table.
+    /// </summary>
+    public TableFormatterOptions? TableOptions
+    {
+        get => _tableOptions;
+        set
+        {
+            ThrowIfReadOnly();
+            _tableOptions = value;
         }
     }
 

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -86,7 +86,9 @@ public class TableWriter
 
         _streamingHeaders = headers.ToArray();
 
-        if (_streamingFormatter != null)
+        // Force buffering when TableOptions is set — statistical width
+        // calculation requires all rows before rendering.
+        if (_streamingFormatter != null && _options.TableOptions == null)
         {
             _streamingDirect = true;
             _streamingFormatter.BeginTable(_writer, headers, _options);

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -651,6 +651,60 @@ public class MarkoutWriterTests
         Assert.Contains("Val", output);
     }
 
+    // ── WriteLinkDefinitions ──
+
+    [Fact]
+    public void WriteLinkDefinitions_RendersDefinitions()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteLinkDefinitions("[0]: https://example.com", "[1]: https://other.com");
+        Assert.Equal("[0]: https://example.com\n[1]: https://other.com", orch.ToString());
+    }
+
+    [Fact]
+    public void WriteLinkDefinitions_BlankLineAfterTable()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteTable(["Name"], [["Alice"]]);
+        orch.WriteLinkDefinitions("[0]: https://example.com");
+
+        var output = orch.ToString();
+        Assert.Contains("| Alice |\n\n[0]:", output);
+    }
+
+    [Fact]
+    public void WriteLinkDefinitions_BlankLineBeforeHeading()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteLinkDefinitions("[0]: https://example.com");
+        orch.WriteHeading(2, "Next");
+
+        var output = orch.ToString();
+        Assert.Contains("[0]: https://example.com\n\n## Next", output);
+    }
+
+    [Fact]
+    public void WriteLinkDefinitions_EmptySpan_NoOutput()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteParagraph("Text");
+        orch.WriteLinkDefinitions();
+        Assert.Equal("Text", orch.ToString());
+    }
+
+    [Fact]
+    public void WriteLinkDefinitions_BetweenTableAndHeading()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteTable(["Col"], [["Val"]]);
+        orch.WriteLinkDefinitions("[0]: https://example.com", "[1]: https://other.com");
+        orch.WriteHeading(2, "Section");
+
+        var output = orch.ToString();
+        // Blank line after table, contiguous definitions, blank line before heading
+        Assert.Contains("| Val |\n\n[0]: https://example.com\n[1]: https://other.com\n\n## Section", output);
+    }
+
     // ── Static factory ──
 
     [Fact]

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -1,5 +1,6 @@
 using Markout;
 using Markout.Formatting;
+using MarkdownTable.Formatting;
 
 namespace Markout.Tests;
 
@@ -703,6 +704,116 @@ public class MarkoutWriterTests
         var output = orch.ToString();
         // Blank line after table, contiguous definitions, blank line before heading
         Assert.Contains("| Val |\n\n[0]: https://example.com\n[1]: https://other.com\n\n## Section", output);
+    }
+
+    // ── TableOptions (statistical width calculation) ──
+
+    [Fact]
+    public void PrettyTable_WithTableOptions_CapsOutlierColumnWidth()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            PrettyTables = true,
+            TableOptions = new TableFormatterOptions()
+        };
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+
+        writer.WriteTableStart("OS", "Versions", "Arch");
+        writer.WriteTableRow("Alpine", "3.21, 3.20", "x64, Arm64");
+        writer.WriteTableRow("Ubuntu", "24.04", "x64, Arm64");
+        writer.WriteTableRow("Windows", "11 26H1, 11 25H2, 11 24H2 (IoT), 11 24H2 (E), 11 24H2, 11 23H2 (E), 10 21H2 (E), 10 21H2 (IoT), 10 1809 (E), 10 1607 (E)", "x64, Arm64");
+        writer.WriteTableRow("Debian", "12", "x64, Arm64");
+        writer.WriteTableEnd();
+
+        var output = writer.ToString();
+        var lines = output.Split('\n');
+
+        // Header separator should NOT be as wide as the Windows outlier row
+        var separatorLine = lines[1];
+        // Without statistical widths, the separator would be ~140+ chars (matching Windows row)
+        // With statistical widths, it should be much shorter
+        Assert.True(separatorLine.Length < 80, $"Separator line too wide ({separatorLine.Length} chars): {separatorLine}");
+
+        // The Windows row should overflow (wider than separator)
+        var windowsRow = lines.First(l => l.Contains("Windows"));
+        Assert.True(windowsRow.Length > separatorLine.Length, "Windows row should overflow the calculated width");
+    }
+
+    [Fact]
+    public void PrettyTable_WithoutTableOptions_UsesMaxWidth()
+    {
+        var options = new MarkoutWriterOptions { PrettyTables = true };
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+
+        writer.WriteTable(
+            ["OS", "Versions", "Arch"],
+            [["Alpine", "3.21, 3.20", "x64"],
+             ["Windows", "11 26H1, 11 25H2, 11 24H2 (IoT), 11 24H2 (E)", "x64"]]);
+
+        var output = writer.ToString();
+        var lines = output.Split('\n');
+
+        // All rows should be the same width (max-width padding)
+        var pipeLines = lines.Where(l => l.StartsWith('|')).ToList();
+        Assert.True(pipeLines.All(l => l.Length == pipeLines[0].Length),
+            "All rows should have equal width with simple max-width");
+    }
+
+    [Fact]
+    public void PrettyTable_Batch_WithTableOptions_CapsOutlierWidth()
+    {
+        var options = new MarkoutWriterOptions
+        {
+            PrettyTables = true,
+            TableOptions = new TableFormatterOptions()
+        };
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+
+        var headers = new[] { "Name", "Description" };
+        var rows = new List<string[]>
+        {
+            new[] { "Short", "Brief" },
+            new[] { "Also short", "Brief" },
+            new[] { "Outlier", "This is a very long description that should be treated as an outlier and not stretch the entire column width for all other rows in the table" }
+        };
+
+        writer.WriteTable(headers, rows);
+
+        var output = writer.ToString();
+        var lines = output.Split('\n');
+
+        var separatorLine = lines[1];
+        var outlierRow = lines.First(l => l.Contains("Outlier"));
+        Assert.True(outlierRow.Length > separatorLine.Length,
+            "Outlier row should overflow the statistical column width");
+    }
+
+    [Fact]
+    public void StreamingTable_WithTableOptions_BuffersForBatchRender()
+    {
+        // When TableOptions is set, streaming tables should buffer and render
+        // through the batch path (same result as WriteTable)
+        var options = new MarkoutWriterOptions
+        {
+            PrettyTables = true,
+            TableOptions = new TableFormatterOptions()
+        };
+
+        // Streaming path
+        var streamWriter = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        streamWriter.WriteTableStart("A", "B");
+        streamWriter.WriteTableRow("short", "x");
+        streamWriter.WriteTableRow("also short", "y");
+        streamWriter.WriteTableRow("outlier value that is much longer than the others", "z");
+        streamWriter.WriteTableEnd();
+
+        // Batch path
+        var batchWriter = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        batchWriter.WriteTable(
+            ["A", "B"],
+            [["short", "x"], ["also short", "y"], ["outlier value that is much longer than the others", "z"]]);
+
+        Assert.Equal(batchWriter.ToString(), streamWriter.ToString());
     }
 
     // ── Static factory ──


### PR DESCRIPTION
## Summary

Adds two features to MarkoutWriter:

### WriteLinkDefinitions
Adds `WriteLinkDefinitions(params string[] definitions)` to write markdown reference link definitions with proper blank-line separation, integrating with the MarkoutWriter content pipeline.

### TableFormatterOptions integration
Integrates `MarkdownTable.Formatting`'s statistical column width calculator (`ColumnWidthCalculator`) into the core table rendering pipeline. When `TableOptions` is set on `MarkoutWriterOptions`, `WritePrettyPipeTable` uses percentile-based width calculation instead of simple max-width, preventing outlier rows (e.g., Windows with 10+ version entries) from stretching the entire table.

**Key changes:**
- Add `MarkdownTable.Formatting` project reference to core Markout
- Add `TableOptions` property to `MarkoutWriterOptions`
- Modify `WritePrettyPipeTable` to use `ColumnWidthCalculator` when `TableOptions` is set
- Force buffering in streaming table API when statistical calculation is needed
- Fix `WriteList` to set `_needsBlankLine = true` after writing items

### Version
0.10.0 → 0.10.1

### Tests
- 5 tests for WriteLinkDefinitions
- 4 tests for TableFormatterOptions
- All 465 tests pass