### PR TITLE
Add statistical table formatting with AutoTune and trailing pipe clustering

### DIFF
--- a/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
+++ b/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
@@ -319,4 +319,45 @@ public static class ColumnWidthCalculator
         }
         return length;
     }
+
+    /// <summary>
+    /// Core P/T statistical target calculation on sorted values.
+    /// Same algorithm used for column widths — reusable for trailing pipe clustering.
+    /// </summary>
+    /// <param name="sortedValues">Values sorted ascending.</param>
+    /// <param name="minimum">Floor value (e.g., header width or previous cluster target).</param>
+    /// <param name="percentile">Percentile for baseline (0.0–1.0).</param>
+    /// <param name="tolerance">Multiplier on percentile value to capture nearby values.</param>
+    /// <param name="shadowThreshold">Below this, all values are kept as-is.</param>
+    /// <returns>Statistical target that covers the main mode of values.</returns>
+    public static int ComputeStatisticalTarget(
+        List<int> sortedValues, int minimum,
+        double percentile, double tolerance, int shadowThreshold)
+    {
+        if (sortedValues.Count == 0) return minimum;
+
+        int shadowValue = Math.Max(minimum, shadowThreshold);
+        int maxValue = sortedValues[^1];
+
+        if (maxValue <= shadowValue)
+            return maxValue;
+
+        int pIndex = Math.Min(
+            (int)(sortedValues.Count * percentile),
+            sortedValues.Count - 1);
+        int B = sortedValues[pIndex];
+        int toleranceLimit = (int)(B * tolerance);
+
+        int C = 0;
+        for (int i = sortedValues.Count - 1; i >= 0; i--)
+        {
+            if (sortedValues[i] <= toleranceLimit)
+            {
+                C = sortedValues[i];
+                break;
+            }
+        }
+
+        return Math.Max(minimum, Math.Max(B, C));
+    }
 }

--- a/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
+++ b/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
@@ -202,8 +202,82 @@ public static class ColumnWidthCalculator
             currentPercentile += percentileIncrement;
         }
 
+        // Modal expansion: detect bimodal columns and expand affordable ones
+        var expanded = TryModalExpansion(headers, rows, baseline);
+        if (expanded is not null)
+            return expanded;
+
         // Fallback: return baseline statistical widths
         return baseline;
+    }
+
+    /// <summary>
+    /// Detects bimodal column distributions and expands affordable second modes.
+    /// </summary>
+    /// <remarks>
+    /// After hill-climbing fails to find perfect alignment, this method analyzes
+    /// each column for bimodality by looking for gaps in the sorted cell lengths.
+    /// If a column has a clear second mode (≥2 values above a gap ≥3) and the
+    /// expansion cost is affordable (≤25 chars absolute, ≤3× current width),
+    /// the column is widened to accommodate both modes.
+    /// </remarks>
+    private static int[]? TryModalExpansion(string[] headers, IReadOnlyList<string[]> rows, int[] baseline)
+    {
+        const int minGapSize = 3;
+        const int minClusterSize = 2;
+        const int maxAbsoluteExpansion = 25;
+        const double maxRelativeFactor = 3.0;
+
+        int columnCount = headers.Length;
+        var expanded = new int[columnCount];
+        bool anyExpanded = false;
+
+        for (int col = 0; col < columnCount; col++)
+        {
+            expanded[col] = baseline[col];
+
+            // Collect raw cell lengths for this column
+            var lengths = new List<int>(1 + rows.Count) { headers[col].Length };
+            for (int r = 0; r < rows.Count; r++)
+                lengths.Add(col < rows[r].Length ? rows[r][col].Length : 0);
+
+            lengths.Sort();
+
+            // Find the largest gap where the lower value is at or below the baseline width
+            int bestGap = 0;
+            int bestGapIndex = -1;
+            for (int i = 1; i < lengths.Count; i++)
+            {
+                int gap = lengths[i] - lengths[i - 1];
+                if (gap > bestGap && lengths[i - 1] <= baseline[col])
+                {
+                    bestGap = gap;
+                    bestGapIndex = i;
+                }
+            }
+
+            if (bestGap < minGapSize || bestGapIndex < 0)
+                continue;
+
+            // Count values in the second mode (above the gap)
+            int mode2Count = lengths.Count - bestGapIndex;
+            if (mode2Count < minClusterSize)
+                continue;
+
+            int mode2Max = lengths[^1];
+            int expansion = mode2Max - baseline[col];
+            if (expansion <= 0)
+                continue;
+
+            // Affordability: absolute cap AND relative cap
+            if (expansion <= maxAbsoluteExpansion && mode2Max <= maxRelativeFactor * baseline[col])
+            {
+                expanded[col] = mode2Max;
+                anyExpanded = true;
+            }
+        }
+
+        return anyExpanded ? expanded : null;
     }
 
     /// <summary>

--- a/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
+++ b/src/MarkdownTable.Formatting/ColumnWidthCalculator.cs
@@ -164,6 +164,13 @@ public static class ColumnWidthCalculator
     /// Hill-climbing auto-tune: iteratively adjusts percentile and tolerance
     /// to achieve perfect trailing-edge alignment.
     /// </summary>
+    /// <remarks>
+    /// Computes a baseline with default statistical parameters, then hill-climbs
+    /// from there. Rejects candidates that expand the table width beyond
+    /// the outlier threshold relative to baseline — this prevents outlier rows
+    /// from inflating the entire table to full-width.
+    /// Falls back to baseline statistical widths when no perfect alignment is found.
+    /// </remarks>
     private static int[] CalculateAutoTuned(string[] headers, IReadOnlyList<string[]> rows,
         TableFormatterOptions options)
     {
@@ -171,7 +178,12 @@ public static class ColumnWidthCalculator
         const double toleranceIncrement = 0.2;
         const double percentileIncrement = 0.2;
         const int maxAttempts = 4;
-        const double outlierThreshold = 0.25;
+        const double outlierThreshold = 0.50;
+
+        // Compute baseline with default statistical parameters
+        var baseline = CalculateWithParameters(headers, rows,
+            options.Percentile, options.Tolerance, options.ShadowThreshold, options.MaxColumnWidth);
+        int baselineRowLength = CalculateRowLength(headers, baseline);
 
         double currentPercentile = options.Percentile;
 
@@ -183,38 +195,39 @@ public static class ColumnWidthCalculator
                 var widths = CalculateWithParameters(headers, rows,
                     currentPercentile, currentTolerance, options.ShadowThreshold, options.MaxColumnWidth);
 
-                if (HasPerfectAlignment(headers, rows, widths, outlierThreshold))
+                if (HasPerfectAlignment(headers, rows, widths, outlierThreshold, baselineRowLength))
                     return widths;
             }
 
             currentPercentile += percentileIncrement;
         }
 
-        // Fallback: last attempted parameters
-        double fallbackTolerance = options.Tolerance + ((toleranceBumpsPerPercentile - 1) * toleranceIncrement);
-        return CalculateWithParameters(headers, rows,
-            currentPercentile - percentileIncrement, fallbackTolerance,
-            options.ShadowThreshold, options.MaxColumnWidth);
+        // Fallback: return baseline statistical widths
+        return baseline;
     }
 
+    /// <summary>
+    /// Checks whether the target widths achieve perfect trailing-edge alignment
+    /// without impractical table expansion.
+    /// </summary>
+    /// <remarks>
+    /// Compares the candidate table width against the baseline statistical width.
+    /// If expanding beyond the outlier threshold, the alignment is rejected —
+    /// this prevents a single outlier row from inflating the entire table.
+    /// </remarks>
     private static bool HasPerfectAlignment(string[] headers, IReadOnlyList<string[]> rows,
-        int[] targetWidths, double outlierThreshold)
+        int[] targetWidths, double outlierThreshold, int baselineRowLength)
     {
         int headerRowLength = CalculateRowLength(headers, targetWidths);
+
+        // Reject if expansion from baseline exceeds threshold
+        if (headerRowLength > baselineRowLength * (1.0 + outlierThreshold))
+            return false;
 
         for (int r = 0; r < rows.Count; r++)
         {
             int rowLength = CalculateRowLength(rows[r], targetWidths);
             if (rowLength != headerRowLength)
-                return false;
-        }
-
-        // Check for impractical outliers
-        double outlierLimit = headerRowLength * (1.0 + outlierThreshold);
-        for (int r = 0; r < rows.Count; r++)
-        {
-            int naturalLength = CalculateNaturalRowLength(rows[r]);
-            if (naturalLength >= outlierLimit)
                 return false;
         }
 
@@ -229,16 +242,6 @@ public static class ColumnWidthCalculator
             int contentWidth = col < row.Length ? row[col].Length : 0;
             int cellWidth = Math.Max(contentWidth, targetWidths[col]) + CellPadding;
             length += cellWidth + 1; // +1 for trailing pipe
-        }
-        return length;
-    }
-
-    private static int CalculateNaturalRowLength(string[] row)
-    {
-        int length = 1; // leading pipe
-        for (int col = 0; col < row.Length; col++)
-        {
-            length += row[col].Length + CellPadding + 1; // content + padding + pipe
         }
         return length;
     }

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>MarkdownTable.Formatting</RootNamespace>
     <Description>Statistical column-width optimization for markdown pipe tables</Description>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>MarkdownTable.Formatting</RootNamespace>
     <Description>Statistical column-width optimization for markdown pipe tables</Description>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -156,10 +156,17 @@ public class MarkdownFormatter : IMarkoutFormatter,
         // Compute default end positions for accumulated position tracking
         var defaultEnd = ComputeDefaultEndPositions(widths);
 
+        // Second pass: treat overflow rows as a separate table, cluster their
+        // trailing pipe positions using the same P/T statistical algorithm
+        var trailingExtra = tableOptions is not null
+            ? ComputeTrailingClusters(headers.Length, rows, defaultEnd)
+            : null;
+
         // Data rows — accumulated position tracking ensures overflow in one cell
         // reduces padding in subsequent cells, matching the original algorithm
-        foreach (var row in rows)
+        for (int r = 0; r < rows.Count; r++)
         {
+            var row = rows[r];
             w.Write('|');
             var rowEnd = new int[headers.Length];
 
@@ -171,6 +178,10 @@ public class MarkdownFormatter : IMarkoutFormatter,
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = defaultEnd[i] - rowStart - CellPadding;
                 int padWidth = Math.Max(value.Length, space);
+
+                // Last column: apply trailing cluster alignment
+                if (trailingExtra is not null && i == headers.Length - 1)
+                    padWidth += trailingExtra[r];
 
                 w.Write(value.PadRight(padWidth));
                 w.Write(" |");
@@ -195,6 +206,80 @@ public class MarkdownFormatter : IMarkoutFormatter,
             defaultEnd[i] = start + widths[i] + CellPadding;
         }
         return defaultEnd;
+    }
+
+    /// <summary>
+    /// Treats overflow rows as a "second table" and recursively applies the same
+    /// P/T statistical algorithm to cluster their trailing pipe positions.
+    /// Each recursion peels off one mode — the remaining outliers become the next tier.
+    /// </summary>
+    private static int[] ComputeTrailingClusters(
+        int colCount, IList<string[]> rows, int[] defaultEnd)
+    {
+        const double Percentile = 0.5;
+        const double Tolerance = 1.05;
+        const int ShadowThreshold = 12;
+
+        int headerEnd = defaultEnd[^1];
+        var extra = new int[rows.Count];
+
+        // Pre-compute each row's natural trailing position
+        var naturalEnd = new int[rows.Count];
+        for (int r = 0; r < rows.Count; r++)
+        {
+            var row = rows[r];
+            var rowEnd = new int[colCount];
+            for (int i = 0; i < colCount; i++)
+            {
+                var value = i < row.Length ? FormatHelper.EscapeTableCell(row[i]) : "";
+                int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
+                int space = defaultEnd[i] - rowStart - CellPadding;
+                int padWidth = Math.Max(value.Length, space);
+                rowEnd[i] = rowStart + padWidth + CellPadding;
+            }
+            naturalEnd[r] = rowEnd[^1];
+        }
+
+        // Collect overflow rows — this is the "second table"
+        var overflow = new List<(int position, int index)>();
+        for (int r = 0; r < rows.Count; r++)
+        {
+            if (naturalEnd[r] > headerEnd)
+                overflow.Add((naturalEnd[r], r));
+        }
+
+        if (overflow.Count >= 2)
+            ClusterRecursive(overflow, extra, headerEnd, Percentile, Tolerance, ShadowThreshold);
+
+        return extra;
+    }
+
+    /// <summary>
+    /// Recursively clusters overflow positions using the same P/T formula
+    /// as column width calculation. Each call finds one cluster target;
+    /// positions above the target form input for the next recursion.
+    /// </summary>
+    private static void ClusterRecursive(
+        List<(int position, int index)> items, int[] extra, int floor,
+        double percentile, double tolerance, int shadowThreshold)
+    {
+        if (items.Count < 2) return;
+
+        var sortedPositions = items.OrderBy(x => x.position).Select(x => x.position).ToList();
+        int target = ColumnWidthCalculator.ComputeStatisticalTarget(
+            sortedPositions, floor, percentile, tolerance, shadowThreshold);
+
+        var remaining = new List<(int position, int index)>();
+        foreach (var (pos, idx) in items)
+        {
+            if (pos <= target)
+                extra[idx] = target - pos;
+            else
+                remaining.Add((pos, idx));
+        }
+
+        if (remaining.Count >= 2)
+            ClusterRecursive(remaining, extra, target, percentile, tolerance, shadowThreshold);
     }
 
     // ── IStreamingTableFormatter ──

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -12,6 +12,7 @@ namespace Markout;
 public class MarkdownFormatter : IMarkoutFormatter,
     IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter
 {
+    private const int CellPadding = 2; // leading space + trailing space
     private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
 
     // ── IHeadingFormatter ──
@@ -152,29 +153,29 @@ public class MarkdownFormatter : IMarkoutFormatter,
         }
         w.WriteLine();
 
-        // Data rows
+        // Compute default end positions for accumulated position tracking
+        var defaultEnd = ComputeDefaultEndPositions(widths);
+
+        // Data rows — accumulated position tracking ensures overflow in one cell
+        // reduces padding in subsequent cells, matching the original algorithm
         foreach (var row in rows)
         {
             w.Write('|');
-            bool overflowed = false;
+            var rowEnd = new int[headers.Length];
+
             for (int i = 0; i < headers.Length; i++)
             {
                 w.Write(' ');
                 var value = i < row.Length ? FormatHelper.EscapeTableCell(row[i]) : "";
 
-                if (!overflowed)
-                {
-                    w.Write(value.PadRight(widths[i]));
-                    if (value.Length > widths[i])
-                        overflowed = true;
-                }
-                else
-                {
-                    // After overflow, padding serves no alignment purpose
-                    w.Write(value);
-                }
+                int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
+                int space = defaultEnd[i] - rowStart - CellPadding;
+                int padWidth = Math.Max(value.Length, space);
 
+                w.Write(value.PadRight(padWidth));
                 w.Write(" |");
+
+                rowEnd[i] = rowStart + padWidth + CellPadding;
             }
             w.WriteLine();
         }
@@ -183,19 +184,35 @@ public class MarkdownFormatter : IMarkoutFormatter,
             w.WriteLine($"\n... and {skippedRows} more");
     }
 
+    // ── Shared helpers ──
+
+    private static int[] ComputeDefaultEndPositions(int[] widths)
+    {
+        var defaultEnd = new int[widths.Length];
+        for (int i = 0; i < widths.Length; i++)
+        {
+            int start = i == 0 ? 0 : defaultEnd[i - 1] + 1;
+            defaultEnd[i] = start + widths[i] + CellPadding;
+        }
+        return defaultEnd;
+    }
+
     // ── IStreamingTableFormatter ──
 
     private int[]? _streamingWidths;
+    private int[]? _streamingDefaultEnd;
 
     void IStreamingTableFormatter.BeginTable(TextWriter w, ReadOnlySpan<string> headers, MarkoutWriterOptions options)
     {
         _streamingWidths = null; // Reset state in case previous table had an error
+        _streamingDefaultEnd = null;
 
         if (options.PrettyTables)
         {
             _streamingWidths = new int[headers.Length];
             for (int i = 0; i < headers.Length; i++)
                 _streamingWidths[i] = headers[i].Length;
+            _streamingDefaultEnd = ComputeDefaultEndPositions(_streamingWidths);
 
             w.Write('|');
             for (int i = 0; i < headers.Length; i++)
@@ -245,24 +262,20 @@ public class MarkdownFormatter : IMarkoutFormatter,
         w.Write('|');
         if (_streamingWidths != null)
         {
-            bool overflowed = false;
+            var rowEnd = new int[_streamingWidths.Length];
             for (int i = 0; i < _streamingWidths.Length; i++)
             {
                 w.Write(' ');
                 var value = i < values.Length ? FormatHelper.EscapeTableCell(values[i]) : "";
 
-                if (!overflowed)
-                {
-                    w.Write(value.PadRight(_streamingWidths[i]));
-                    if (value.Length > _streamingWidths[i])
-                        overflowed = true;
-                }
-                else
-                {
-                    w.Write(value);
-                }
+                int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
+                int space = _streamingDefaultEnd![i] - rowStart - CellPadding;
+                int padWidth = Math.Max(value.Length, space);
 
+                w.Write(value.PadRight(padWidth));
                 w.Write(" |");
+
+                rowEnd[i] = rowStart + padWidth + CellPadding;
             }
         }
         else
@@ -280,6 +293,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
     void IStreamingTableFormatter.EndTable(TextWriter w, int skippedRows)
     {
         _streamingWidths = null;
+        _streamingDefaultEnd = null;
         if (skippedRows > 0)
             w.WriteLine($"\n... and {skippedRows} more");
     }

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -156,11 +156,24 @@ public class MarkdownFormatter : IMarkoutFormatter,
         foreach (var row in rows)
         {
             w.Write('|');
+            bool overflowed = false;
             for (int i = 0; i < headers.Length; i++)
             {
                 w.Write(' ');
                 var value = i < row.Length ? FormatHelper.EscapeTableCell(row[i]) : "";
-                w.Write(value.PadRight(widths[i]));
+
+                if (!overflowed)
+                {
+                    w.Write(value.PadRight(widths[i]));
+                    if (value.Length > widths[i])
+                        overflowed = true;
+                }
+                else
+                {
+                    // After overflow, padding serves no alignment purpose
+                    w.Write(value);
+                }
+
                 w.Write(" |");
             }
             w.WriteLine();
@@ -232,11 +245,23 @@ public class MarkdownFormatter : IMarkoutFormatter,
         w.Write('|');
         if (_streamingWidths != null)
         {
+            bool overflowed = false;
             for (int i = 0; i < _streamingWidths.Length; i++)
             {
                 w.Write(' ');
                 var value = i < values.Length ? FormatHelper.EscapeTableCell(values[i]) : "";
-                w.Write(value.PadRight(_streamingWidths[i]));
+
+                if (!overflowed)
+                {
+                    w.Write(value.PadRight(_streamingWidths[i]));
+                    if (value.Length > _streamingWidths[i])
+                        overflowed = true;
+                }
+                else
+                {
+                    w.Write(value);
+                }
+
                 w.Write(" |");
             }
         }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.10.1</Version>
+    <Version>0.10.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.10.2</Version>
+    <Version>0.10.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.10.3</Version>
+    <Version>10.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -869,6 +869,58 @@ public class MarkoutWriterTests
         Assert.Contains("| Link          |", lines[0]);
     }
 
+    [Fact]
+    public void PrettyTable_AutoTune_ClustersTrailingPipes()
+    {
+        // Overflow rows should have trailing pipes clustered into tiers
+        // rather than each row having a unique trailing position
+        var options = new MarkoutWriterOptions
+        {
+            PrettyTables = true,
+            TableOptions = new TableFormatterOptions() { AutoTune = true }
+        };
+
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        writer.WriteTable(
+            ["OS", "Version", "End of Life"],
+            [
+                // Short rows — align with header
+                ["tvOS", "18", "2025-09-15"],
+                ["tvOS", "17", "2024-09-16"],
+                ["tvOS", "16", "2023-09-18"],
+                ["Fedora", "41", "2025-12-15"],
+                ["Fedora", "40", "2025-05-13"],
+                ["iOS", "17", "2024-11-19"],
+                ["macOS", "13", "2025-09-15"],
+                ["Ubuntu", "24.10", "2025-07-10"],
+                ["openSUSE Leap", "15.5", "2024-12-31"],
+                ["SUSE Linux Enterprise", "15.6", "2025-12-31"],
+                // Overflow rows at various natural lengths — should cluster
+                ["Android", "12.1", "[2025-03-03](https://developer.android.com/about/versions/12/12L)"],
+                ["Windows Server", "2012", "[2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012)"],
+                ["Windows Server Core", "2012", "[2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012)"],
+                ["Windows", "11 23H2 (W)", "[2025-11-11](https://learn.microsoft.com/windows/release-health/windows11-release-information)"],
+                ["Windows", "11 22H2 (E)", "[2025-10-14](https://learn.microsoft.com/windows/release-health/windows11-release-information)"],
+                ["iOS", "16", "[2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-16-release-notes)"],
+                ["iPadOS", "16", "[2025-03-31](https://developer.apple.com/documentation/ios-ipados-release-notes/ipados-16-release-notes)"],
+            ]);
+
+        var result = writer.ToString();
+        var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Count distinct line lengths — should be few tiers, not many unique values
+        var lengths = lines.Select(l => l.Length).Distinct().OrderBy(x => x).ToList();
+
+        // Without clustering we'd have 6+ unique lengths (55, ~88, ~108, ~122, ~136, ~146)
+        // With clustering we expect ≤ 4 (header-aligned + 1-2 overflow tiers + separator)
+        Assert.True(lengths.Count <= 4,
+            $"Expected ≤ 4 distinct line lengths but got {lengths.Count}: [{string.Join(", ", lengths)}]");
+
+        // All overflow rows should end with " |" (properly closed)
+        foreach (var line in lines)
+            Assert.EndsWith(" |", line);
+    }
+
     // ── Static factory ──
 
     [Fact]

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -816,6 +816,59 @@ public class MarkoutWriterTests
         Assert.Equal(batchWriter.ToString(), streamWriter.ToString());
     }
 
+    [Fact]
+    public void PrettyTable_AutoTune_ExpandsAffordableBimodalColumns()
+    {
+        // Simulates the Out of Support table pattern:
+        // OS column has a clear second mode (long names) that's affordable to expand
+        // "Link" column has a second mode (long URLs) that's too expensive to expand
+        var options = new MarkoutWriterOptions
+        {
+            PrettyTables = true,
+            TableOptions = new TableFormatterOptions() { AutoTune = true }
+        };
+
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        writer.WriteTable(
+            ["OS", "Ver", "Link"],
+            [
+                ["Alpine", "3.19", "2025-01-01"],
+                ["Alpine", "3.18", "2024-05-01"],
+                ["Fedora", "42", "2025-12-15"],
+                ["Fedora", "41", "2025-05-13"],
+                ["iOS", "18", "2025-09-15"],
+                ["iOS", "17", "2024-11-19"],
+                ["macOS", "15", "2025-09-15"],
+                ["tvOS", "18", "2025-09-15"],
+                ["tvOS", "17", "2024-09-16"],
+                ["tvOS", "16", "2023-09-18"],
+                ["Ubuntu", "24.04", "2029-05-31"],
+                ["Ubuntu", "22.04", "2027-04-01"],
+                // Second mode: long OS names (affordable expansion)
+                ["openSUSE Leap", "15.5", "2024-12-31"],
+                ["SUSE Linux Enterprise", "15.6", "2025-12-31"],
+                // Second mode: long links (too expensive to expand)
+                ["Windows", "10 22H2", "[2025-10-14](https://learn.microsoft.com/windows/release-health/release-information)"],
+                ["Windows Server", "2012", "[2023-10-10](https://learn.microsoft.com/lifecycle/products/windows-server-2012)"],
+            ]);
+
+        var result = writer.ToString();
+        var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Header should show expanded OS column (fits "SUSE Linux Enterprise" = 21 chars)
+        Assert.StartsWith("| OS                    |", lines[0]);
+
+        // Short OS names should be padded to the expanded width
+        Assert.StartsWith("| Alpine                |", lines[2]);
+
+        // Long OS names should fit without overflow
+        Assert.StartsWith("| SUSE Linux Enterprise |", lines[15]);
+
+        // Link column should NOT expand (too expensive) — long links overflow
+        // The "Link" header column should stay narrow (statistical width)
+        Assert.Contains("| Link          |", lines[0]);
+    }
+
     // ── Static factory ──
 
     [Fact]


### PR DESCRIPTION
## Summary

Builds on the WriteLinkDefinitions and TableFormatterOptions foundation from PR #92 to add statistical table width optimization with AutoTune, accumulated position tracking, multi-modal column expansion, and trailing pipe clustering.

### AutoTune hill-climbing

When `AutoTune = true`, `ColumnWidthCalculator` tries P/T parameter combinations seeking perfect row alignment. Falls back gracefully through multi-modal expansion to baseline statistical widths.

### Accumulated position tracking

Replaces the ad-hoc overflow boolean with proper accumulated position tracking from the original StatisticalRenderer algorithm. When a cell overflows, subsequent cells get reduced padding — matching the reference implementation.

### Multi-modal column expansion (TryModalExpansion)

Detects bimodal columns (e.g., "tvOS" vs "SUSE Linux Enterprise") and expands affordable ones. Criteria: gap ≥ 3, mode2Count ≥ 2, expansion ≤ 25 chars, mode2Max ≤ 3× baseline.

### Trailing pipe clustering

Treats overflow rows as a "second table." Their trailing pipe positions are recursively clustered using `ComputeStatisticalTarget` (P=0.5, T=1.05), aligning trailing pipes into tiers instead of each row having a unique length.

Example — 9.0 Out of Support table:
- Before: 8 unique overflow positions (107, 122, 126, 135, 136, 143, 146)
- After: 2 tiers (136, 146)

### Key changes

| File | Change |
|---|---|
| `ColumnWidthCalculator.cs` | AutoTune hill-climbing, `TryModalExpansion`, `ComputeStatisticalTarget` (public) |
| `MarkdownFormatter.cs` | Accumulated position tracking, `ComputeTrailingClusters`, `ClusterRecursive` |
| `MarkdownTable.Formatting.csproj` | 0.3.1 → 0.3.3 |
| `Markout.csproj` | 10.0.1 → 10.0.2 |

### Tests

All 526 tests pass. New tests: modal expansion (1), trailing clustering (1).