### PR TITLE
Fix version: 10.0.2 → 0.10.2

### DIFF
--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>10.0.2</Version>
+    <Version>0.10.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Version was incorrectly set to 10.0.2. Should be 0.10.2 per the existing 0.x.y scheme.