### PR TITLE
Add FormatSize, FormatDownloads, Truncate to FormatHelper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event.inputs.confirm == 'publish'
-    environment: nuget-publish
+    environment: nuget
     steps:
       - name: Download packages from CI run
         uses: actions/download-artifact@v8

--- a/src/Markout/Formatting/FormatHelper.cs
+++ b/src/Markout/Formatting/FormatHelper.cs
@@ -28,4 +28,42 @@ public static class FormatHelper
         }
         return value;
     }
+
+    /// <summary>
+    /// Formats a byte count as a human-readable size (B, KB, MB, GB).
+    /// Uses binary (1024) divisors.
+    /// </summary>
+    public static string FormatSize(long bytes) => bytes switch
+    {
+        >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+        >= 1_048_576 => $"{bytes / 1_048_576.0:F1} MB",
+        >= 1_024 => $"{bytes / 1_024.0:F1} KB",
+        _ => $"{bytes} B"
+    };
+
+    /// <summary>
+    /// Formats a download/count value with K/M/B suffixes.
+    /// Uses decimal (1000) divisors.
+    /// </summary>
+    public static string FormatDownloads(long count) => count switch
+    {
+        >= 1_000_000_000 => $"{count / 1_000_000_000.0:F1}B",
+        >= 1_000_000 => $"{count / 1_000_000.0:F1}M",
+        >= 1_000 => $"{count / 1_000.0:F1}K",
+        _ => count.ToString()
+    };
+
+    /// <summary>
+    /// Truncates a string to a maximum length, appending "..." if truncated.
+    /// Collapses newlines to spaces before truncating.
+    /// </summary>
+    public static string Truncate(string? text, int maxLength)
+    {
+        if (text is null) return "";
+
+        // Collapse newlines to spaces
+        string clean = text.Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
+
+        return clean.Length <= maxLength ? clean : clean[..(maxLength - 3)] + "...";
+    }
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.10.2</Version>
+    <Version>0.11.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Markout.Tests/FormatHelperTests.cs
+++ b/tests/Markout.Tests/FormatHelperTests.cs
@@ -1,0 +1,64 @@
+using Markout.Formatting;
+using Xunit;
+
+namespace Markout.Tests;
+
+public class FormatHelperTests
+{
+    [Theory]
+    [InlineData(0, "0 B")]
+    [InlineData(512, "512 B")]
+    [InlineData(1_024, "1.0 KB")]
+    [InlineData(1_536, "1.5 KB")]
+    [InlineData(1_048_576, "1.0 MB")]
+    [InlineData(10_485_760, "10.0 MB")]
+    [InlineData(1_073_741_824, "1.0 GB")]
+    public void FormatSize_FormatsCorrectly(long bytes, string expected)
+    {
+        Assert.Equal(expected, FormatHelper.FormatSize(bytes));
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(999, "999")]
+    [InlineData(1_000, "1.0K")]
+    [InlineData(1_500, "1.5K")]
+    [InlineData(1_000_000, "1.0M")]
+    [InlineData(2_500_000, "2.5M")]
+    [InlineData(1_000_000_000, "1.0B")]
+    public void FormatDownloads_FormatsCorrectly(long count, string expected)
+    {
+        Assert.Equal(expected, FormatHelper.FormatDownloads(count));
+    }
+
+    [Fact]
+    public void Truncate_ShortString_ReturnsUnchanged()
+    {
+        Assert.Equal("hello", FormatHelper.Truncate("hello", 10));
+    }
+
+    [Fact]
+    public void Truncate_ExactLength_ReturnsUnchanged()
+    {
+        Assert.Equal("hello", FormatHelper.Truncate("hello", 5));
+    }
+
+    [Fact]
+    public void Truncate_LongString_TruncatesWithEllipsis()
+    {
+        Assert.Equal("hell...", FormatHelper.Truncate("hello world", 7));
+    }
+
+    [Fact]
+    public void Truncate_Null_ReturnsEmpty()
+    {
+        Assert.Equal("", FormatHelper.Truncate(null, 10));
+    }
+
+    [Fact]
+    public void Truncate_CollapsesNewlines()
+    {
+        Assert.Equal("line1 line2", FormatHelper.Truncate("line1\nline2", 20));
+        Assert.Equal("line1 line2", FormatHelper.Truncate("line1\r\nline2", 20));
+    }
+}


### PR DESCRIPTION
Shared display formatting utilities for size/count values and text truncation.

## Added to `FormatHelper`

- **`FormatSize(long bytes)`** — formats bytes as human-readable (B, KB, MB, GB) using binary (1024) divisors
- **`FormatDownloads(long count)`** — formats counts with K/M/B suffixes using decimal (1000) divisors
- **`Truncate(string? text, int maxLength)`** — truncates with `...`, collapses newlines to spaces

These are currently duplicated across dotnet-install and dotnet-inspect (~5 instances). Moving them here eliminates duplication since both tools already depend on Markout.

Also bumps version to 0.11.0 and updates release.yml environment to `nuget`.