### PR TITLE
Fix broken samples: TreeNode API and naming conflict

### DIFF
--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -243,9 +243,9 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
                         .Where(s => s.CanadianActors.Contains(actor.Name))
                         .ToList();
                     if (actorShows.Count == 0) return null;
-                    return new TreeNode(actor.Name,
+                    return new TreeNode(actor.Name, null,
                         actorShows.GroupBy(s => s.Location).OrderBy(g => g.Key)
-                            .Select(g => new TreeNode(g.Key, g.Select(s => $"{s.Title} ({s.Years})"))));
+                            .Select(g => new TreeNode(g.Key, null, g.Select(s => new TreeNode($"{s.Title} ({s.Years})")).ToArray())).ToArray());
                 })
                 .Where(n => n is not null)
                 .ToList()!
@@ -329,9 +329,9 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
             FilmographyTree = topActors.Select(actor =>
             {
                 var actorShows = shows.Where(s => s.CanadianActors.Contains(actor.Name)).ToList();
-                return new TreeNode(actor.Name,
+                return new TreeNode(actor.Name, null,
                     actorShows.GroupBy(s => s.Location).Select(g =>
-                        new TreeNode(g.Key, g.Select(s => s.Title))));
+                        new TreeNode(g.Key, null, g.Select(s => new TreeNode(s.Title)).ToArray())).ToArray());
             }).ToList(),
             Quote = "The world needs more Canada.\n— Bono, 2003"
         };

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -13,7 +13,7 @@ var index = JsonSerializer.Deserialize(json, ReleasesJsonContext.Default.Release
 var releases = index.Embedded?.Releases ?? [];
 var unsupported = releases.Where(r => !r.Supported).ToList();
 
-var view = new Releases
+var view = new ReleasesView
 {
     Title = index.Title ?? ".NET Releases",
     LatestMajor = index.LatestMajor,
@@ -40,7 +40,7 @@ MarkoutSerializer.Serialize(view, Console.Out, ReleasesContext.Default);
 // --- View Models ---
 
 [MarkoutSerializable(TitleProperty = nameof(Title))]
-public class Releases
+public class ReleasesView
 {
     public string Title { get; set; } = "";
 
@@ -73,7 +73,7 @@ public class ReleaseRow
     public bool Supported { get; set; }
 }
 
-[MarkoutContext(typeof(Releases))]
+[MarkoutContext(typeof(ReleasesView))]
 [MarkoutContext(typeof(ReleaseRow))]
 public partial class ReleasesContext : MarkoutSerializerContext { }
 

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -83,7 +83,7 @@ foreach (var (version, vi) in versionData.OrderByDescending(v => decimal.TryPars
     if (cves.Count == 0)
         cves.Add(new TreeNode("None"));
 
-    tree.Add(new TreeNode($"{version} (last updated: {date})", cves));
+    tree.Add(new TreeNode($"{version} (last updated: {date})", null, [..cves]));
 }
 
 // Count severity distribution


### PR DESCRIPTION
## Summary

Three samples had build errors due to API drift:

### CanadianContent & LatestCves — `TreeNode` constructor mismatch
The `TreeNode` constructor changed to `(string text, string? badge, params ReadOnlySpan<TreeNode> children)`, but these samples were still passing `IEnumerable<string>` as the second argument (interpreted as `badge`). Fixed by:
- Adding explicit `null` badge parameter
- Wrapping string children as `new TreeNode(...)` objects
- Calling `.ToArray()` for `ReadOnlySpan` compatibility

### DotNetReleases — CS0542 naming conflict
The `Releases` class had a property also named `Releases`, which C# disallows. Renamed the class to `ReleasesView`.

### Validation
- All 3 fixed samples build successfully
- All other samples build successfully
- All 486 unit tests pass