### PR TITLE
Add MermaidFormatter for diagram output

### DIFF
--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MermaidFormatter.cs
+++ b/src/Markout/MermaidFormatter.cs
@@ -1,0 +1,100 @@
+using Markout.Formatting;
+
+namespace Markout;
+
+/// <summary>
+/// A formatter that outputs Mermaid diagram syntax.
+/// Supports headings (as comments) and trees (as <c>graph TD</c> flowcharts).
+/// Use standalone with <c>--mermaid</c> for raw mermaid output, or pair with
+/// <c>MarkdownFormatter</c> via code blocks for embedded mermaid in markdown.
+/// </summary>
+public class MermaidFormatter : IMarkoutFormatter,
+    IHeadingFormatter, ITreeFormatter
+{
+    private int _nextNodeId;
+
+    // ── IHeadingFormatter ──
+
+    void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
+    {
+        w.Write("%% ");
+        w.Write(text);
+        if (!string.IsNullOrEmpty(context))
+        {
+            w.Write(" (");
+            w.Write(context);
+            w.Write(')');
+        }
+    }
+
+    // ── ITreeFormatter ──
+
+    void ITreeFormatter.FormatTree(TextWriter w, ReadOnlySpan<TreeNode> nodes, MarkoutWriterOptions options)
+    {
+        _nextNodeId = 0;
+        w.WriteLine("graph TD");
+
+        for (int i = 0; i < nodes.Length; i++)
+            FormatSubgraph(w, nodes[i], parentId: null, options);
+    }
+
+    void ITreeFormatter.FormatTreeNode(TextWriter w, string text, string prefix)
+    {
+        // Standalone tree nodes are rendered as a single-node graph.
+        w.Write("graph TD");
+        w.WriteLine();
+        var id = "n0";
+        w.Write("    ");
+        w.Write(id);
+        w.Write("[\"");
+        w.Write(EscapeLabel(text));
+        w.Write("\"]");
+        w.WriteLine();
+    }
+
+    private void FormatSubgraph(TextWriter w, TreeNode node, string? parentId, MarkoutWriterOptions options)
+    {
+        var id = $"n{_nextNodeId++}";
+        var label = BuildLabel(node, options);
+
+        w.Write("    ");
+        w.Write(id);
+        w.Write("[\"");
+        w.Write(EscapeLabel(label));
+        w.Write("\"]");
+        w.WriteLine();
+
+        if (parentId != null)
+        {
+            w.Write("    ");
+            w.Write(parentId);
+            w.Write(" --> ");
+            w.Write(id);
+            w.WriteLine();
+        }
+
+        if (node.Children is { Count: > 0 })
+        {
+            foreach (var child in node.Children)
+                FormatSubgraph(w, child, id, options);
+        }
+    }
+
+    private static string BuildLabel(TreeNode node, MarkoutWriterOptions options)
+    {
+        if (node.Badge != null && options.IncludeBadges)
+            return $"{node.Badge} {node.Text}";
+        return node.Text;
+    }
+
+    /// <summary>
+    /// Escapes text for use in a Mermaid node label (double-quoted form).
+    /// </summary>
+    public static string EscapeLabel(string text)
+    {
+        // Mermaid uses double-quoted labels; escape quotes and special chars.
+        return text
+            .Replace("\\", "\\\\")
+            .Replace("\"", "#quot;");
+    }
+}

--- a/tests/Markout.Tests/MermaidFormatterTests.cs
+++ b/tests/Markout.Tests/MermaidFormatterTests.cs
@@ -1,0 +1,215 @@
+using Markout;
+using Markout.Formatting;
+
+namespace Markout.Tests;
+
+[Collection("ConsoleError")]
+public class MermaidFormatterTests
+{
+    [Fact]
+    public void MermaidFormatter_ImplementsExpectedInterfaces()
+    {
+        var formatter = new MermaidFormatter();
+        Assert.IsAssignableFrom<IMarkoutFormatter>(formatter);
+        Assert.IsAssignableFrom<IHeadingFormatter>(formatter);
+        Assert.IsAssignableFrom<ITreeFormatter>(formatter);
+    }
+
+    [Fact]
+    public void MermaidFormatter_DoesNotImplementUnsupportedInterfaces()
+    {
+        var formatter = new MermaidFormatter();
+        Assert.IsNotAssignableFrom<ITableFormatter>(formatter);
+        Assert.IsNotAssignableFrom<IFieldFormatter>(formatter);
+        Assert.IsNotAssignableFrom<IListFormatter>(formatter);
+        Assert.IsNotAssignableFrom<ICodeBlockFormatter>(formatter);
+        Assert.IsNotAssignableFrom<IBlockFormatter>(formatter);
+        Assert.IsNotAssignableFrom<IMetricsFormatter>(formatter);
+    }
+
+    [Fact]
+    public void WriteHeading_RendersAsMermaidComment()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteHeading(1, "My Diagram");
+        Assert.Contains("%% My Diagram", orch.ToString());
+    }
+
+    [Fact]
+    public void WriteHeading_WithContext_RendersContextInParens()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteHeading(1, "Dependencies", "v1.0");
+        var output = orch.ToString();
+        Assert.Contains("%% Dependencies (v1.0)", output);
+    }
+
+    [Fact]
+    public void WriteTree_RendersGraphTD()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("Root", null,
+                new TreeNode("Child A"),
+                new TreeNode("Child B")));
+        var output = orch.ToString();
+        Assert.Contains("graph TD", output);
+    }
+
+    [Fact]
+    public void WriteTree_RendersNodeLabels()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("Root", null,
+                new TreeNode("Child A"),
+                new TreeNode("Child B")));
+        var output = orch.ToString();
+        Assert.Contains("\"Root\"", output);
+        Assert.Contains("\"Child A\"", output);
+        Assert.Contains("\"Child B\"", output);
+    }
+
+    [Fact]
+    public void WriteTree_RendersEdges()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("Root", null,
+                new TreeNode("Child A"),
+                new TreeNode("Child B")));
+        var output = orch.ToString();
+        // Root is n0, children are n1 and n2
+        Assert.Contains("n0 --> n1", output);
+        Assert.Contains("n0 --> n2", output);
+    }
+
+    [Fact]
+    public void WriteTree_DeepHierarchy_RendersAllLevels()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("A", null,
+                new TreeNode("B", null,
+                    new TreeNode("C"))));
+        var output = orch.ToString();
+        Assert.Contains("\"A\"", output);
+        Assert.Contains("\"B\"", output);
+        Assert.Contains("\"C\"", output);
+        // A->B, B->C
+        Assert.Contains("n0 --> n1", output);
+        Assert.Contains("n1 --> n2", output);
+    }
+
+    [Fact]
+    public void WriteTree_MultipleRoots_RendersAll()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("Root1"),
+            new TreeNode("Root2"));
+        var output = orch.ToString();
+        Assert.Contains("\"Root1\"", output);
+        Assert.Contains("\"Root2\"", output);
+        // Root nodes have no parent edges
+        Assert.DoesNotContain("-->", output);
+    }
+
+    [Fact]
+    public void WriteTree_WithBadges_IncludesBadgeInLabel()
+    {
+        var options = new MarkoutWriterOptions { IncludeBadges = true };
+        var orch = MarkoutWriter.Create(new MermaidFormatter(), options);
+        orch.WriteTree(new TreeNode("Libraries", "📁"));
+        var output = orch.ToString();
+        Assert.Contains("📁 Libraries", output);
+    }
+
+    [Fact]
+    public void WriteTree_BadgesDisabled_ExcludesBadge()
+    {
+        var options = new MarkoutWriterOptions { IncludeBadges = false };
+        var orch = MarkoutWriter.Create(new MermaidFormatter(), options);
+        orch.WriteTree(new TreeNode("Libraries", "📁"));
+        var output = orch.ToString();
+        Assert.DoesNotContain("📁", output);
+        Assert.Contains("\"Libraries\"", output);
+    }
+
+    [Fact]
+    public void WriteTable_ReturnsFalse()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        var result = orch.WriteTable(["Col1"], [["val1"]]);
+        Assert.False(result);
+        Assert.Equal("", orch.ToString());
+    }
+
+    [Fact]
+    public void WriteFields_ReturnsFalse()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        var result = orch.WriteFields(new MarkoutField("Key", "Value"));
+        Assert.False(result);
+        Assert.Equal("", orch.ToString());
+    }
+
+    [Fact]
+    public void WriteList_ReturnsFalse()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        var result = orch.WriteList("one", "two");
+        Assert.False(result);
+        Assert.Equal("", orch.ToString());
+    }
+
+    [Fact]
+    public void EscapeLabel_EscapesDoubleQuotes()
+    {
+        var result = MermaidFormatter.EscapeLabel("hello \"world\"");
+        Assert.Equal("hello #quot;world#quot;", result);
+    }
+
+    [Fact]
+    public void EscapeLabel_EscapesBackslashes()
+    {
+        var result = MermaidFormatter.EscapeLabel("path\\to\\file");
+        Assert.Equal("path\\\\to\\\\file", result);
+    }
+
+    [Fact]
+    public void EscapeLabel_PlainTextPassesThrough()
+    {
+        var result = MermaidFormatter.EscapeLabel("System.Object");
+        Assert.Equal("System.Object", result);
+    }
+
+    [Fact]
+    public void WriteTree_UniqueNodeIds_AcrossSubtrees()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("A", null,
+                new TreeNode("A1"),
+                new TreeNode("A2")),
+            new TreeNode("B", null,
+                new TreeNode("B1")));
+        var output = orch.ToString();
+        // 5 nodes total: n0 (A), n1 (A1), n2 (A2), n3 (B), n4 (B1)
+        Assert.Contains("n0[", output);
+        Assert.Contains("n1[", output);
+        Assert.Contains("n2[", output);
+        Assert.Contains("n3[", output);
+        Assert.Contains("n4[", output);
+    }
+
+    [Fact]
+    public void WriteTreeNode_RendersSingleNodeGraph()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTreeNode("Standalone Node");
+        var output = orch.ToString();
+        Assert.Contains("graph TD", output);
+        Assert.Contains("\"Standalone Node\"", output);
+    }
+}


### PR DESCRIPTION
## Summary

Add `MermaidFormatter` — a new formatter that emits Mermaid diagram syntax, enabling CLI tools to produce flowcharts and dependency graphs.

### MermaidFormatter

Implements `IMarkoutFormatter`, `IHeadingFormatter`, and `ITreeFormatter` (selective capability, like `DiagramFormatter`):

- **Headings** → `%% comment` syntax
- **Trees** → `graph TD` with `n0["label"]` nodes and `parent --> child` edges
- **`EscapeLabel()`** — public static helper for consumers building mermaid output directly
- Uses internal node ID counter for unique IDs across subtrees

### Design

Two consumption modes (implemented by the consumer, not Markout):
- **Standalone** — use `MermaidFormatter` directly for raw mermaid output (pipeable to `mmdc`)
- **Embedded** — use `MarkdownFormatter` with `WriteCodeStart("mermaid")` fenced blocks

### Tests

19 xunit tests covering headings, flat trees, nested trees, special characters, empty nodes, and multi-root trees.

### Version

Bumps Markout from 0.11.0 → 0.12.0.