### PR TITLE
Add column projection resolution API

### DIFF
--- a/src/Markout/ColumnProjectionResolution.cs
+++ b/src/Markout/ColumnProjectionResolution.cs
@@ -1,0 +1,68 @@
+namespace Markout;
+
+/// <summary>
+/// Result of resolving requested columns against a concrete table shape.
+/// </summary>
+public sealed class ColumnProjectionResolution
+{
+    private static readonly int[] EmptyMap = [];
+    private static readonly string[] EmptyNames = [];
+
+    private ColumnProjectionResolution(
+        ColumnProjectionResolutionKind kind,
+        int[] columnMap,
+        string[] requestedColumns,
+        string[] unmatchedColumns)
+    {
+        Kind = kind;
+        ColumnMap = columnMap;
+        RequestedColumns = requestedColumns;
+        UnmatchedColumns = unmatchedColumns;
+    }
+
+    /// <summary>
+    /// The resolution outcome.
+    /// </summary>
+    public ColumnProjectionResolutionKind Kind { get; }
+
+    /// <summary>
+    /// Maps projected column position to original column position when <see cref="Kind"/>
+    /// is <see cref="ColumnProjectionResolutionKind.Matched"/>. Empty otherwise.
+    /// </summary>
+    public IReadOnlyList<int> ColumnMap { get; }
+
+    /// <summary>
+    /// The requested columns that were evaluated. Empty when no include projection was configured.
+    /// </summary>
+    public IReadOnlyList<string> RequestedColumns { get; }
+
+    /// <summary>
+    /// Requested columns that did not match the table shape.
+    /// </summary>
+    public IReadOnlyList<string> UnmatchedColumns { get; }
+
+    /// <summary>
+    /// A result representing an unconfigured projection.
+    /// </summary>
+    public static ColumnProjectionResolution NoProjection()
+        => new(ColumnProjectionResolutionKind.NoProjection, EmptyMap, EmptyNames, EmptyNames);
+
+    /// <summary>
+    /// A result representing a projection with at least one matched column.
+    /// </summary>
+    public static ColumnProjectionResolution Matched(
+        IReadOnlyList<int> columnMap,
+        IReadOnlyList<string>? requestedColumns = null,
+        IReadOnlyList<string>? unmatchedColumns = null)
+        => new(
+            ColumnProjectionResolutionKind.Matched,
+            [.. columnMap],
+            requestedColumns is null ? EmptyNames : [.. requestedColumns],
+            unmatchedColumns is null ? EmptyNames : [.. unmatchedColumns]);
+
+    /// <summary>
+    /// A result representing a projection where no requested columns matched.
+    /// </summary>
+    public static ColumnProjectionResolution NoMatches(IReadOnlyList<string> requestedColumns)
+        => new(ColumnProjectionResolutionKind.NoMatches, EmptyMap, [.. requestedColumns], [.. requestedColumns]);
+}

--- a/src/Markout/ColumnProjectionResolutionKind.cs
+++ b/src/Markout/ColumnProjectionResolutionKind.cs
@@ -1,0 +1,22 @@
+namespace Markout;
+
+/// <summary>
+/// Describes the result of resolving a column projection against a table shape.
+/// </summary>
+public enum ColumnProjectionResolutionKind
+{
+    /// <summary>
+    /// No column projection was configured.
+    /// </summary>
+    NoProjection,
+
+    /// <summary>
+    /// At least one requested column matched the table shape.
+    /// </summary>
+    Matched,
+
+    /// <summary>
+    /// A column projection was configured, but none of the requested columns matched.
+    /// </summary>
+    NoMatches
+}

--- a/src/Markout/DocumentSchema.cs
+++ b/src/Markout/DocumentSchema.cs
@@ -3,7 +3,27 @@ namespace Markout;
 /// <summary>
 /// A name-kind pair representing a discoverable schema element.
 /// </summary>
-public readonly record struct SchemaItem(string Name, string Kind);
+public readonly record struct SchemaItem(string Name, string Kind)
+{
+    /// <summary>
+    /// Creates a schema item with a stable source name.
+    /// </summary>
+    public SchemaItem(string name, string kind, string stableName)
+        : this(name, kind)
+    {
+        StableName = stableName;
+    }
+
+    /// <summary>
+    /// Stable source name for the item, usually the source property/member name.
+    /// </summary>
+    public string StableName { get; init; } = Name;
+
+    /// <summary>
+    /// Canonical machine-facing key for the item.
+    /// </summary>
+    public string Key => Formatting.FormatHelper.ToSnakeCase(StableName);
+}
 
 /// <summary>
 /// Describes a section's schema: its items and their kind.
@@ -11,13 +31,19 @@ public readonly record struct SchemaItem(string Name, string Kind);
 public sealed class SectionSchema
 {
     public SectionSchema(string name, string itemKind, string[] itemNames)
+        : this(name, itemKind, itemNames.Select(n => new SchemaItem(n, itemKind)).ToArray())
+    {
+    }
+
+    public SectionSchema(string name, string itemKind, SchemaItem[] items)
     {
         Name = name;
         ItemKind = itemKind;
-        Items = itemNames.Select(n => new SchemaItem(n, itemKind)).ToArray();
+        Items = items.Select(i => i with { Kind = itemKind }).ToArray();
     }
 
     public string Name { get; }
+    public string Key => Formatting.FormatHelper.ToSnakeCase(Name);
     public string ItemKind { get; }
     public SchemaItem[] Items { get; }
 }
@@ -49,12 +75,24 @@ public sealed class DocumentSchema
     }
 
     /// <summary>
+    /// Registers a section with typed items and stable item names.
+    /// </summary>
+    public DocumentSchema Add(string sectionName, string itemKind, params SchemaItem[] items)
+    {
+        var schema = new SectionSchema(sectionName, itemKind, items);
+        _sections[sectionName] = schema;
+        if (!_sectionOrder.Contains(sectionName, StringComparer.OrdinalIgnoreCase))
+            _sectionOrder.Add(sectionName);
+        return this;
+    }
+
+    /// <summary>
     /// Registers a section with no explicit items (e.g., a headless summary section).
     /// </summary>
     public DocumentSchema AddSection(string sectionName)
     {
         if (!_sections.ContainsKey(sectionName))
-            _sections[sectionName] = new SectionSchema(sectionName, "section", []);
+            _sections[sectionName] = new SectionSchema(sectionName, "section", Array.Empty<SchemaItem>());
         if (!_sectionOrder.Contains(sectionName, StringComparer.OrdinalIgnoreCase))
             _sectionOrder.Add(sectionName);
         return this;
@@ -113,37 +151,32 @@ public sealed class DocumentSchema
         if (section == null)
             return new ProjectionValidation([], requestedNames, new Dictionary<string, string[]>());
 
-        var knownNames = new HashSet<string>(
-            section.Items.Select(i => i.Name), StringComparer.OrdinalIgnoreCase);
+        var headers = section.Items.Select(i => i.Name).ToArray();
+        var headerNames = section.Items.Select(i => i.StableName).ToArray();
+        var projection = MarkoutProjection.WithColumns(requestedNames);
+        projection.TryResolveColumns(headers, headerNames, out var resolution);
 
-        var resolved = new List<string>();
-        var unresolved = new List<string>();
+        var unresolved = resolution.UnmatchedColumns.ToArray();
+        var resolved = requestedNames
+            .Where(n => !unresolved.Contains(n, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
         var suggestions = new Dictionary<string, string[]>();
 
-        foreach (var name in requestedNames)
+        foreach (var name in unresolved)
         {
-            if (knownNames.Contains(name))
-            {
-                resolved.Add(name);
-            }
-            else if (name.Contains('*') || name.Contains('?'))
-            {
-                // Glob patterns are resolved at render time by Markout
-                resolved.Add(name);
-            }
-            else
-            {
-                unresolved.Add(name);
-                var prefixMatches = section.Items
-                    .Where(i => i.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase))
-                    .Select(i => i.Name)
-                    .ToArray();
-                if (prefixMatches.Length > 0)
-                    suggestions[name] = prefixMatches;
-            }
+            var prefixMatches = section.Items
+                .Where(i =>
+                    i.Name.StartsWith(name, StringComparison.OrdinalIgnoreCase)
+                    || i.StableName.StartsWith(name, StringComparison.OrdinalIgnoreCase)
+                    || i.Key.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                .Select(i => i.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (prefixMatches.Length > 0)
+                suggestions[name] = prefixMatches;
         }
 
-        return new ProjectionValidation([.. resolved], [.. unresolved], suggestions);
+        return new ProjectionValidation(resolved, unresolved, suggestions);
     }
 
     // ── Post-render diagnostics ──

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.0</Version>
+    <Version>0.13.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutProjection.cs
+++ b/src/Markout/MarkoutProjection.cs
@@ -166,40 +166,44 @@ public class MarkoutProjection
     }
 
     /// <summary>
-    /// Computes a column index map for projecting table columns.
-    /// Returns null if no column projection is needed.
-    /// Each entry maps projected position → original position.
+    /// Resolves the column projection against display headers.
     /// </summary>
-    internal int[]? ComputeColumnMap(ReadOnlySpan<string> headers)
-        => ComputeColumnMap(headers, default);
+    public ColumnProjectionResolution ResolveColumns(ReadOnlySpan<string> headers)
+        => ResolveColumns(headers, default);
 
     /// <summary>
-    /// Computes a column index map for projecting table columns.
+    /// Resolves the column projection against display headers and stable header names.
     /// Matches display headers, stable header names, and snake_case stable names.
     /// </summary>
-    internal int[]? ComputeColumnMap(ReadOnlySpan<string> headers, ReadOnlySpan<string> headerNames)
+    public ColumnProjectionResolution ResolveColumns(ReadOnlySpan<string> headers, ReadOnlySpan<string> headerNames)
     {
         if (_includeColumns != null)
         {
             // Include: output columns in the order specified by IncludeColumns
             var map = new List<int>(_includeColumns.Count);
+            var unmatched = new List<string>();
             foreach (var col in _includeColumns)
             {
+                bool matched = false;
                 bool isGlob = col.Contains('*') || col.Contains('?');
                 for (int i = 0; i < headers.Length; i++)
                 {
                     if (MatchesColumn(col, headers, headerNames, i))
                     {
+                        matched = true;
                         map.Add(i);
                         if (!isGlob) break;
                     }
                 }
-            }
-            if (map.Count == 0)
-                throw new InvalidOperationException(
-                    $"No columns matched projection: {string.Join(", ", _includeColumns)}");
 
-            return map.ToArray();
+                if (!matched)
+                    unmatched.Add(col);
+            }
+
+            if (map.Count == 0)
+                return ColumnProjectionResolution.NoMatches(_includeColumns);
+
+            return ColumnProjectionResolution.Matched(map, _includeColumns, unmatched);
         }
 
         if (_excludeColumns != null)
@@ -220,10 +224,51 @@ public class MarkoutProjection
                 if (!excluded)
                     map.Add(i);
             }
-            return map.Count < headers.Length ? map.ToArray() : null;
+            return map.Count < headers.Length
+                ? ColumnProjectionResolution.Matched(map)
+                : ColumnProjectionResolution.NoProjection();
         }
 
-        return null;
+        return ColumnProjectionResolution.NoProjection();
+    }
+
+    /// <summary>
+    /// Attempts to resolve the column projection against display headers.
+    /// </summary>
+    public bool TryResolveColumns(ReadOnlySpan<string> headers, out ColumnProjectionResolution resolution)
+        => TryResolveColumns(headers, default, out resolution);
+
+    /// <summary>
+    /// Attempts to resolve the column projection against display headers and stable header names.
+    /// </summary>
+    public bool TryResolveColumns(ReadOnlySpan<string> headers, ReadOnlySpan<string> headerNames, out ColumnProjectionResolution resolution)
+    {
+        resolution = ResolveColumns(headers, headerNames);
+        return resolution.Kind != ColumnProjectionResolutionKind.NoMatches;
+    }
+
+    /// <summary>
+    /// Computes a column index map for projecting table columns.
+    /// Returns null if no column projection is needed.
+    /// Each entry maps projected position → original position.
+    /// </summary>
+    internal int[]? ComputeColumnMap(ReadOnlySpan<string> headers)
+        => ComputeColumnMap(headers, default);
+
+    /// <summary>
+    /// Computes a column index map for projecting table columns.
+    /// Matches display headers, stable header names, and snake_case stable names.
+    /// </summary>
+    internal int[]? ComputeColumnMap(ReadOnlySpan<string> headers, ReadOnlySpan<string> headerNames)
+    {
+        var resolution = ResolveColumns(headers, headerNames);
+        return resolution.Kind switch
+        {
+            ColumnProjectionResolutionKind.NoProjection => null,
+            ColumnProjectionResolutionKind.Matched => [.. resolution.ColumnMap],
+            _ => throw new InvalidOperationException(
+                $"No columns matched projection: {string.Join(", ", resolution.RequestedColumns)}")
+        };
     }
 
     private bool MatchesColumn(string pattern, ReadOnlySpan<string> headers, ReadOnlySpan<string> headerNames, int index)

--- a/src/Markout/MarkoutSchemaInfo.cs
+++ b/src/Markout/MarkoutSchemaInfo.cs
@@ -157,7 +157,7 @@ public sealed class MarkoutSchemaInfo
     public DocumentSchema ToDocumentSchema()
     {
         var sectionOrder = new List<string>();
-        var sectionData = new Dictionary<string, (string? ItemKind, List<string> Items)>(
+        var sectionData = new Dictionary<string, (string? ItemKind, List<SchemaItem> Items)>(
             StringComparer.OrdinalIgnoreCase);
 
         foreach (var prop in AsDocument)
@@ -178,7 +178,9 @@ public sealed class MarkoutSchemaInfo
                 // Merge: union of items, upgrade kind if previously section-only
                 foreach (var item in items)
                 {
-                    if (!existing.Items.Contains(item, StringComparer.OrdinalIgnoreCase))
+                    if (!existing.Items.Any(i =>
+                            string.Equals(i.Name, item.Name, StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(i.StableName, item.StableName, StringComparison.OrdinalIgnoreCase)))
                         existing.Items.Add(item);
                 }
                 if (existing.ItemKind == null && itemKind != null)
@@ -191,7 +193,7 @@ public sealed class MarkoutSchemaInfo
         {
             var (itemKind, items) = sectionData[name];
             if (itemKind != null && items.Count > 0)
-                schema.Add(name, itemKind, items.ToArray());
+                schema.Add(name, itemKind, [.. items]);
             else
                 schema.AddSection(name);
         }
@@ -207,14 +209,14 @@ public sealed class MarkoutSchemaInfo
         return rendering[(lastOpen + 1)..lastClose];
     }
 
-    private static (string? ItemKind, List<string> Items) MapContentToItems(
+    private static (string? ItemKind, List<SchemaItem> Items) MapContentToItems(
         string? contentType, MarkoutPropertySchema prop)
     {
         return contentType switch
         {
             "table" => ("column", CollectChildColumns(prop)),
             "subsections" => ("column", CollectChildColumns(prop)),
-            "field" => ("field", [prop.DisplayName]),
+            "field" => ("field", [new SchemaItem(prop.DisplayName, "field", prop.Name)]),
             "fields" => ("field", CollectChildFields(prop)),
             "tree" => ("tree", CollectChildColumns(prop)),
             // Content types with no queryable items
@@ -225,38 +227,46 @@ public sealed class MarkoutSchemaInfo
         };
     }
 
-    private static List<string> CollectChildColumns(MarkoutPropertySchema prop)
+    private static List<SchemaItem> CollectChildColumns(MarkoutPropertySchema prop)
     {
-        var names = new List<string>();
+        var items = new List<SchemaItem>();
         foreach (var child in prop.Children)
         {
             if (child.Rendering.StartsWith("Column", StringComparison.Ordinal)
-                && !names.Contains(child.DisplayName, StringComparer.OrdinalIgnoreCase))
-                names.Add(child.DisplayName);
+                && !items.Any(i =>
+                    string.Equals(i.Name, child.DisplayName, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(i.StableName, child.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                items.Add(new SchemaItem(child.DisplayName, "column", child.Name));
+            }
         }
-        return names;
+        return items;
     }
 
-    private static List<string> CollectChildFields(MarkoutPropertySchema prop)
+    private static List<SchemaItem> CollectChildFields(MarkoutPropertySchema prop)
     {
-        var names = new List<string>();
-        CollectChildFieldsRecursive(prop.Children, names);
-        return names;
+        var items = new List<SchemaItem>();
+        CollectChildFieldsRecursive(prop.Children, items);
+        return items;
     }
 
     private static void CollectChildFieldsRecursive(
-        IReadOnlyList<MarkoutPropertySchema> children, List<string> names)
+        IReadOnlyList<MarkoutPropertySchema> children, List<SchemaItem> items)
     {
         foreach (var child in children)
         {
             if (child.Rendering.StartsWith("Field", StringComparison.Ordinal))
             {
-                if (!names.Contains(child.DisplayName, StringComparer.OrdinalIgnoreCase))
-                    names.Add(child.DisplayName);
+                if (!items.Any(i =>
+                    string.Equals(i.Name, child.DisplayName, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(i.StableName, child.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    items.Add(new SchemaItem(child.DisplayName, "field", child.Name));
+                }
             }
             else if (child.Rendering == "Fields")
             {
-                CollectChildFieldsRecursive(child.Children, names);
+                CollectChildFieldsRecursive(child.Children, items);
             }
         }
     }

--- a/src/Markout/MarkoutTableHeader.cs
+++ b/src/Markout/MarkoutTableHeader.cs
@@ -6,4 +6,10 @@ namespace Markout;
 /// <param name="Name">Stable source name for the column, usually the property name.</param>
 /// <param name="DisplayName">Human-facing display name for the column.</param>
 /// <param name="Index">Zero-based column index after projection.</param>
-public readonly record struct MarkoutTableHeader(string Name, string DisplayName, int Index);
+public readonly record struct MarkoutTableHeader(string Name, string DisplayName, int Index)
+{
+    /// <summary>
+    /// Canonical machine-facing key for the column.
+    /// </summary>
+    public string Key => Formatting.FormatHelper.ToSnakeCase(Name);
+}

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -139,8 +139,8 @@ public class TableWriter
         return _options.TableHeaderStyle switch
         {
             MarkoutTableHeaderStyle.DisplayName => header.DisplayName,
-            MarkoutTableHeaderStyle.StableName => FormatHelper.ToSnakeCase(header.Name),
-            _ when _options.TableMode == MarkoutTableMode.Tsv => FormatHelper.ToSnakeCase(header.Name),
+            MarkoutTableHeaderStyle.StableName => header.Key,
+            _ when _options.TableMode == MarkoutTableMode.Tsv => header.Key,
             _ => header.DisplayName
         };
     }

--- a/tests/Markout.Tests/ProjectionTests.cs
+++ b/tests/Markout.Tests/ProjectionTests.cs
@@ -114,6 +114,47 @@ public class ProjectionTests
         Assert.Contains("No columns matched projection: NonExistent", ex.Message);
     }
 
+    [Fact]
+    public void TryResolveColumns_AllUnmatched_ReturnsNoMatches()
+    {
+        var projection = MarkoutProjection.WithColumns("NonExistent");
+
+        var success = projection.TryResolveColumns(["Name", "Return Type"], ["Name", "ReturnType"], out var resolution);
+
+        Assert.False(success);
+        Assert.Equal(ColumnProjectionResolutionKind.NoMatches, resolution.Kind);
+        Assert.Empty(resolution.ColumnMap);
+        Assert.Equal(["NonExistent"], resolution.UnmatchedColumns);
+    }
+
+    [Fact]
+    public void TryResolveColumns_MixedUnmatched_ReturnsMatchedWithUnmatchedColumns()
+    {
+        var projection = MarkoutProjection.WithColumns("return_type", "NonExistent");
+
+        var success = projection.TryResolveColumns(["Name", "Return Type"], ["Name", "ReturnType"], out var resolution);
+
+        Assert.True(success);
+        Assert.Equal(ColumnProjectionResolutionKind.Matched, resolution.Kind);
+        Assert.Equal([1], resolution.ColumnMap);
+        Assert.Equal(["NonExistent"], resolution.UnmatchedColumns);
+    }
+
+    [Fact]
+    public void DocumentSchema_ValidateProjection_AcceptsStableAndSnakeCaseNames()
+    {
+        var schema = new DocumentSchema()
+            .Add("Methods", "column",
+                new SchemaItem("Name", "column", "Name"),
+                new SchemaItem("Return Type", "column", "ReturnType"));
+
+        var validation = schema.ValidateProjection("Methods", ["return_type", "ReturnType"]);
+
+        Assert.True(validation.IsValid);
+        Assert.Equal(["return_type", "ReturnType"], validation.Resolved);
+        Assert.Empty(validation.Unresolved);
+    }
+
     // --- Column projection: ExcludeColumns ---
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add explicit column projection resolution result types and TryResolveColumns APIs
- Add canonical keys for table headers, schema items, and sections
- Route DocumentSchema projection validation through the same resolver as rendering
- Bump Markout package version to 0.13.1

## Validation

- dotnet test Markout.sln
- dotnet pack src/Markout/Markout.csproj -o /tmp/markout-pack-check