### PR TITLE
Add JSONL table output

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ dotnet run samples/GitHubRepo/GitHubRepo.cs                                     
 dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format markdown # Markdown
 dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format table    # Compact table
 dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format tsv      # Stable TSV rows
+dotnet run samples/GitHubRepo/GitHubRepo.cs -- dotnet/runtime --format jsonl    # Stable JSONL rows
 ```
 
 **Markdown output** for `dotnet/runtime`:
@@ -258,6 +259,14 @@ v9.0.13  v9.0.13      2026-02-10
 v10.0.3  .NET 10.0.3  2026-02-10
 ```
 
+**JSONL output** — same table projection, `--format jsonl`:
+
+```jsonl
+{"tag":"v8.0.24","name":".NET 8.0.24","published":"2026-02-10"}
+{"tag":"v9.0.13","name":"v9.0.13","published":"2026-02-10"}
+{"tag":"v10.0.3","name":".NET 10.0.3","published":"2026-02-10"}
+```
+
 The pattern is always the same: deserialize your API data, project to a model, serialize. Markout handles the rest.
 
 ## Shape Library
@@ -300,7 +309,7 @@ Markout ships five formatters. The serializer writes through `MarkoutWriter` (th
 | **MarkdownFormatter** | GitHub-Flavored Markdown | Documentation, LLM tool output, rendered reports |
 | **PlainTextFormatter** | Plain text without markup | Minimal output, no syntax characters |
 | **UnicodeFormatter** | Box-drawing characters | Rich tables with borders, no color |
-| **TableFormatter** | Tables, lists, fields | Compact summaries, pretty tables, TSV rows |
+| **TableFormatter** | Tables, lists, fields | Compact summaries, pretty tables, TSV/JSONL rows |
 | **DiagramFormatter** | Trees and structural diagrams | Dependency graphs, file trees |
 
 Optional packages:
@@ -316,6 +325,7 @@ Formatters declare which shapes they support by implementing capability interfac
 
 - Markdown table cell values normalize pipe characters to `&#124;`; they do not emit escaped pipes (`\|`).
 - `TableFormatter` with `MarkoutTableMode.Tsv` uses stable snake_case headers by default and never emits embedded tabs or newlines in table cells.
+- `TableFormatter` with `MarkoutTableMode.Jsonl` uses stable snake_case property names by default and emits one JSON object per table row.
 - `TableFormatter` with `MarkoutTableMode.Pretty` renders the same projection as TSV, with each column starting at a uniform position across rows.
 
 ## Templates
@@ -438,7 +448,7 @@ The package includes the source generator — no additional packages needed.
 
 - **[HelloMarkout](samples/HelloMarkout)** — Simplest possible example: a class, a context, one line of serialization
 - **[RecordDemo](samples/RecordDemo)** — Records as data models
-- **[GitHubRepo](samples/GitHubRepo)** — GitHub API → fields, breakdowns, metrics, and tables with Spectre, Markdown, table, and TSV output
+- **[GitHubRepo](samples/GitHubRepo)** — GitHub API → fields, breakdowns, metrics, and tables with Spectre, Markdown, table, TSV, and JSONL output
 - **[GitHubActivity](samples/GitHubActivity)** — User profile and recent events from the GitHub API
 - **[CanadianContent](samples/CanadianContent)** — Canadian actors and shows with tables, trees, metrics, and multiple renderers
 - **[LatestCves](samples/LatestCves)** — .NET security advisories with trees and severity breakdowns

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -16,7 +16,7 @@ Markout is a source-generated .NET library that serializes objects to clean, rea
 - [Links](#links)
 - [Custom Value Formatters](#custom-value-formatters)
 - [Writer Options](#writer-options)
-- [Table and TSV Output](#table-and-tsv-output)
+- [Table, TSV, and JSONL Output](#table-tsv-and-jsonl-output)
 - [Low-Level Writer API](#low-level-writer-api)
 - [Attribute Reference](#attribute-reference)
 
@@ -867,12 +867,13 @@ var context = new SampleContext(new MarkoutWriterOptions
 string markdown = MarkoutSerializer.Serialize(product, context);
 ```
 
-## Table and TSV Output
+## Table, TSV, and JSONL Output
 
-`TableFormatter` renders the same table projection in two compact forms:
+`TableFormatter` renders the same table projection in compact, line-oriented forms:
 
 - `MarkoutTableMode.Pretty` (default) uses display labels and aligns columns with spaces.
 - `MarkoutTableMode.Tsv` emits normalized tab-separated rows with stable snake_case headers derived from source property names.
+- `MarkoutTableMode.Jsonl` emits one JSON object per table row with stable snake_case property names derived from source property names.
 
 ```csharp
 // Pretty compact table
@@ -881,9 +882,13 @@ MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), context);
 // TSV with stable headers
 var options = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv };
 MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), context, options);
+
+// JSONL with stable property names
+var jsonlOptions = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl };
+MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), context, jsonlOptions);
 ```
 
-Header style is configurable. `Auto` uses display names for pretty tables and stable names for TSV.
+Header style is configurable. `Auto` uses display names for pretty tables and stable names for TSV and JSONL.
 
 ```csharp
 var options = new MarkoutWriterOptions

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -12,7 +12,7 @@ using Spectre.Console;
 using TreeNode = Markout.TreeNode;
 
 var formatOption = new Option<string>("--format", "-f") { DefaultValueFactory = _ => "markdown", Description = "Output format" };
-formatOption.AcceptOnlyFromAmong("markdown", "ansi", "spectre", "plain", "table", "tsv", "diagram");
+formatOption.AcceptOnlyFromAmong("markdown", "ansi", "spectre", "plain", "table", "tsv", "jsonl", "diagram");
 
 var maxItemsOption = new Option<int?>("-n") { Description = "Limit table rows" };
 var prettyOption = new Option<bool>("--pretty") { Description = "Pad table columns for aligned output" };
@@ -58,7 +58,12 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
         MaxItems = maxItems,
         IncludeSections = includeSections,
         PrettyTables = prettyTables,
-        TableMode = format == "tsv" ? MarkoutTableMode.Tsv : MarkoutTableMode.Pretty
+        TableMode = format switch
+        {
+            "tsv" => MarkoutTableMode.Tsv,
+            "jsonl" => MarkoutTableMode.Jsonl,
+            _ => MarkoutTableMode.Pretty
+        }
     };
 
     (IMarkoutFormatter formatter, StringWriter output) CreateWriter()
@@ -69,7 +74,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
         {
             "ansi" => new AnsiFormatter(terminal),
             "spectre" => new SpectreFormatter(AnsiConsole.Console),
-            "table" or "tsv" => new TableFormatter(),
+            "table" or "tsv" or "jsonl" => new TableFormatter(),
             "diagram" => new DiagramFormatter(),
             _ => new MarkdownFormatter(),
         };
@@ -108,9 +113,9 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     StringWriter Summary()
     {
         var (fmt, output) = CreateWriter();
-        if (format is "table" or "tsv" && includeSections == null)
+        if (format is "table" or "tsv" or "jsonl" && includeSections == null)
         {
-            Console.Error.WriteLine("table/TSV format requires a section flag with summary: --actors, --shows, or --cities");
+            Console.Error.WriteLine("table/TSV/JSONL format requires a section flag with summary: --actors, --shows, or --cities");
             return output;
         }
         var overview = new CanConOverview

--- a/samples/GitHubRepo/GitHubRepo.cs
+++ b/samples/GitHubRepo/GitHubRepo.cs
@@ -12,7 +12,7 @@ using Spectre.Console;
 
 var repoArg = new Argument<string>("repo") { DefaultValueFactory = _ => "dotnet/runtime", Description = "GitHub repository (owner/repo)" };
 var formatOption = new Option<string>("--format", "-f") { DefaultValueFactory = _ => "spectre", Description = "Output format" };
-formatOption.AcceptOnlyFromAmong("spectre", "markdown", "table", "tsv");
+formatOption.AcceptOnlyFromAmong("spectre", "markdown", "table", "tsv", "jsonl");
 var sectionOption = new Option<string?>("--section", "-s") { Description = "Section to display" };
 
 var rootCommand = new RootCommand("GitHub repository report — fields, charts, metrics, and tables via Markout")
@@ -58,20 +58,29 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
     var options = section is not null
         ? new MarkoutWriterOptions { IncludeSections = new HashSet<string> { section } }
         : new MarkoutWriterOptions();
-    if (format == "tsv")
-        options.TableMode = MarkoutTableMode.Tsv;
+    options.TableMode = format switch
+    {
+        "tsv" => MarkoutTableMode.Tsv,
+        "jsonl" => MarkoutTableMode.Jsonl,
+        _ => options.TableMode
+    };
 
     IMarkoutFormatter formatter = format switch
     {
         "markdown" => new MarkdownFormatter(),
-        "table" or "tsv" => new TableFormatter(),
+        "table" or "tsv" or "jsonl" => new TableFormatter(),
         _ => new SpectreFormatter(AnsiConsole.Console),
     };
 
-    var tableOptions = format is "table" or "tsv"
+    var tableOptions = format is "table" or "tsv" or "jsonl"
         ? new MarkoutWriterOptions
         {
-            TableMode = format == "tsv" ? MarkoutTableMode.Tsv : MarkoutTableMode.Pretty,
+            TableMode = format switch
+            {
+                "tsv" => MarkoutTableMode.Tsv,
+                "jsonl" => MarkoutTableMode.Jsonl,
+                _ => MarkoutTableMode.Pretty
+            },
             IncludeDescription = false,
             IncludeSections = options.IncludeSections ?? new HashSet<string> { "Releases" }
         }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.1</Version>
+    <Version>0.13.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutTableMode.cs
+++ b/src/Markout/MarkoutTableMode.cs
@@ -13,5 +13,10 @@ public enum MarkoutTableMode
     /// <summary>
     /// Render normalized tab-separated values.
     /// </summary>
-    Tsv
+    Tsv,
+
+    /// <summary>
+    /// Render JSON Lines with one object per table row.
+    /// </summary>
+    Jsonl
 }

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -189,7 +189,7 @@ public class MarkoutWriterOptions
 
     /// <summary>
     /// Header naming style for table formatters. Auto uses stable names for TSV
-    /// and display labels for pretty tables.
+    /// and JSONL, and display labels for pretty tables.
     /// </summary>
     public MarkoutTableHeaderStyle TableHeaderStyle
     {

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -1,4 +1,7 @@
 using Markout.Formatting;
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
 
 namespace Markout;
 
@@ -18,10 +21,18 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
 
     void ITableFormatter.FormatTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows, MarkoutWriterOptions options)
     {
-        if (options.TableMode == MarkoutTableMode.Tsv)
-            WriteTsvTable(w, headers, rows, skippedRows);
-        else
-            WritePrettyTable(w, headers, rows, skippedRows);
+        switch (options.TableMode)
+        {
+            case MarkoutTableMode.Tsv:
+                WriteTsvTable(w, headers, rows, skippedRows);
+                break;
+            case MarkoutTableMode.Jsonl:
+                WriteJsonlTable(w, headers, rows);
+                break;
+            default:
+                WritePrettyTable(w, headers, rows, skippedRows);
+                break;
+        }
     }
 
     void IFieldFormatter.FormatFieldName(TextWriter w, string key, bool bold)
@@ -87,6 +98,26 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
 
         if (skippedRows > 0)
             w.WriteLine($"\n... and {skippedRows} more");
+    }
+
+    private static void WriteJsonlTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows)
+    {
+        foreach (var row in rows)
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            using var json = new Utf8JsonWriter(buffer);
+            json.WriteStartObject();
+            for (int i = 0; i < headers.Length; i++)
+            {
+                var value = i < row.Length ? row[i] : "";
+                json.WriteString(headers[i] ?? "", value ?? "");
+            }
+            json.WriteEndObject();
+            json.Flush();
+
+            w.Write(Encoding.UTF8.GetString(buffer.WrittenSpan));
+            w.WriteLine();
+        }
     }
 
     private static void WriteTsvRow(TextWriter w, ReadOnlySpan<string> values)

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -140,7 +140,7 @@ public class TableWriter
         {
             MarkoutTableHeaderStyle.DisplayName => header.DisplayName,
             MarkoutTableHeaderStyle.StableName => header.Key,
-            _ when _options.TableMode == MarkoutTableMode.Tsv => header.Key,
+            _ when _options.TableMode is MarkoutTableMode.Tsv or MarkoutTableMode.Jsonl => header.Key,
             _ => header.DisplayName
         };
     }

--- a/tests/Markout.Tests/TableFormatterTests.cs
+++ b/tests/Markout.Tests/TableFormatterTests.cs
@@ -130,7 +130,6 @@ public class TableFormatterTests
 
         var output = sw.ToString().ReplaceLineEndings("\n");
         Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
-        Assert.Contains("\\\"", output);
         Assert.Contains("\\n", output);
         Assert.Contains("\\t", output);
 

--- a/tests/Markout.Tests/TableFormatterTests.cs
+++ b/tests/Markout.Tests/TableFormatterTests.cs
@@ -1,5 +1,6 @@
 using Markout;
 using Markout.Formatting;
+using System.Text.Json;
 
 namespace Markout.Tests;
 
@@ -78,6 +79,84 @@ public class TableFormatterTests
         Assert.Equal(
             "Return Type\tSim\nstring\t0.50\n",
             sw.ToString().ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TableFormatter_JsonlMode_UsesStableHeadersByDefault()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl };
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+        writer.WriteTable(
+            ["Return Type", "Sim"],
+            ["ReturnType", "Similarity"],
+            [["string", "0.50"]]);
+
+        Assert.Equal(
+            "{\"return_type\":\"string\",\"similarity\":\"0.50\"}\n",
+            sw.ToString().ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void TableFormatter_JsonlMode_CanUseDisplayHeaders()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions
+        {
+            TableMode = MarkoutTableMode.Jsonl,
+            TableHeaderStyle = MarkoutTableHeaderStyle.DisplayName
+        };
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+        writer.WriteTable(
+            ["Return Type", "Sim"],
+            ["ReturnType", "Similarity"],
+            [["string", "0.50"]]);
+
+        using var document = JsonDocument.Parse(sw.ToString());
+        var root = document.RootElement;
+        Assert.Equal("string", root.GetProperty("Return Type").GetString());
+        Assert.Equal("0.50", root.GetProperty("Sim").GetString());
+    }
+
+    [Fact]
+    public void TableFormatter_JsonlMode_EscapesJsonSyntaxAndPreservesCellText()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl };
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+        writer.WriteTable(
+            ["Name", "Notes"],
+            [["Alice \"A.\"", "line 1\nline 2\tTabbed"]]);
+
+        var output = sw.ToString().ReplaceLineEndings("\n");
+        Assert.Single(output.Split('\n', StringSplitOptions.RemoveEmptyEntries));
+        Assert.Contains("\\\"", output);
+        Assert.Contains("\\n", output);
+        Assert.Contains("\\t", output);
+
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.Equal("Alice \"A.\"", root.GetProperty("name").GetString());
+        Assert.Equal("line 1\nline 2\tTabbed", root.GetProperty("notes").GetString());
+    }
+
+    [Fact]
+    public void TableFormatter_JsonlMode_DoesNotEmitTruncationFooter()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions
+        {
+            TableMode = MarkoutTableMode.Jsonl,
+            MaxItems = 1
+        };
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+        writer.WriteTable(
+            ["Name"],
+            [["Alice"], ["Bob"], ["Carol"]]);
+
+        var output = sw.ToString().ReplaceLineEndings("\n");
+        Assert.Equal("{\"name\":\"Alice\"}\n", output);
+        Assert.DoesNotContain("more", output);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `MarkoutTableMode.Jsonl` for JSON Lines table output
- use stable snake_case property names by default and JSON escaping via `Utf8JsonWriter`
- add sample/docs coverage and bump Markout package version to `0.13.2`

## Validation
- `dotnet test Markout.sln --no-restore --verbosity minimal`
- `dotnet pack src/Markout/Markout.csproj --configuration Release --no-restore --verbosity minimal`