### PR TITLE
Add semantic inline code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Formatters declare which shapes they support by implementing capability interfac
 ### Format promises
 
 - Markdown table cell values normalize pipe characters to `&#124;`; they do not emit escaped pipes (`\|`).
+- Semantic inline `<code>...</code>` tags render as Markdown code spans and as plain text in table, TSV, and JSONL output.
 - `TableFormatter` with `MarkoutTableMode.Tsv` uses stable snake_case headers by default and never emits embedded tabs or newlines in table cells.
 - `TableFormatter` with `MarkoutTableMode.Jsonl` uses stable snake_case property names by default and emits one JSON object per table row.
 - `TableFormatter` with `MarkoutTableMode.Pretty` renders the same projection as TSV, with each column starting at a uniform position across rows.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -890,6 +890,14 @@ MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), context, 
 
 Header style is configurable. `Auto` uses display names for pretty tables and stable names for TSV and JSONL.
 
+Semantic inline tags let producers describe presentation without hard-coding Markdown. Use `<code>...</code>` in string values when the content is code-like or literal. Markdown renders it as a code span, while pretty table, TSV, and JSONL output emit the decoded text without tags or backticks.
+
+```csharp
+writer.WriteTable(
+    ["Select", "Signature"],
+    [["<code>Serialize:1</code>", "<code>string Serialize&lt;T&gt;(T value)</code>"]]);
+```
+
 ```csharp
 var options = new MarkoutWriterOptions
 {

--- a/src/Markout/DiagramFormatter.cs
+++ b/src/Markout/DiagramFormatter.cs
@@ -13,11 +13,11 @@ public class DiagramFormatter : IMarkoutFormatter,
 
     void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
     {
-        w.Write(text);
+        w.Write(FormatHelper.RenderInlinePlainText(text));
         if (!string.IsNullOrEmpty(context))
         {
             w.Write(" (");
-            w.Write(context);
+            w.Write(FormatHelper.RenderInlinePlainText(context));
             w.Write(')');
         }
     }
@@ -33,7 +33,7 @@ public class DiagramFormatter : IMarkoutFormatter,
     void ITreeFormatter.FormatTreeNode(TextWriter w, string text, string prefix)
     {
         w.Write(prefix);
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
@@ -45,7 +45,7 @@ public class DiagramFormatter : IMarkoutFormatter,
             w.Write(node.Badge);
             w.Write(' ');
         }
-        w.WriteLine(node.Text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(node.Text));
 
         if (node.Children is { Count: > 0 })
         {

--- a/src/Markout/Formatting/FormatHelper.cs
+++ b/src/Markout/Formatting/FormatHelper.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace Markout.Formatting;
 
 /// <summary>
@@ -5,6 +7,22 @@ namespace Markout.Formatting;
 /// </summary>
 public static class FormatHelper
 {
+    private const string CodeStart = "<code>";
+    private const string CodeEnd = "</code>";
+    private static readonly SearchValues<char> InlineTagSentinel = SearchValues.Create("<");
+
+    /// <summary>
+    /// Renders semantic inline tags for Markdown output.
+    /// </summary>
+    public static string RenderInlineMarkdown(string? value)
+        => RenderInline(value, codeFormatter: FormatMarkdownCodeSpan);
+
+    /// <summary>
+    /// Renders semantic inline tags as plain text for non-Markdown output.
+    /// </summary>
+    public static string RenderInlinePlainText(string? value)
+        => RenderInline(value, codeFormatter: static text => text);
+
     /// <summary>
     /// Formats the numeric value displayed at the end of a metric bar.
     /// </summary>
@@ -142,5 +160,93 @@ public static class FormatHelper
         string clean = text.Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
 
         return clean.Length <= maxLength ? clean : clean[..(maxLength - 3)] + "...";
+    }
+
+    private static string RenderInline(string? value, Func<string, string> codeFormatter)
+    {
+        if (string.IsNullOrEmpty(value))
+            return "";
+
+        var start = IndexOfCodeStart(value, 0);
+        if (start < 0)
+            return value;
+
+        var sb = new System.Text.StringBuilder(value.Length);
+        var cursor = 0;
+        while (start >= 0)
+        {
+            var contentStart = start + CodeStart.Length;
+            var end = value.IndexOf(CodeEnd, contentStart, StringComparison.Ordinal);
+            if (end < 0)
+                break;
+
+            sb.Append(value, cursor, start - cursor);
+            var encoded = value.Substring(contentStart, end - contentStart);
+            sb.Append(codeFormatter(DecodeXmlText(encoded)));
+
+            cursor = end + CodeEnd.Length;
+            start = IndexOfCodeStart(value, cursor);
+        }
+
+        if (cursor == 0)
+            return value;
+
+        sb.Append(value, cursor, value.Length - cursor);
+        return sb.ToString();
+    }
+
+    private static int IndexOfCodeStart(string value, int startIndex)
+    {
+        var span = value.AsSpan(startIndex);
+        while (true)
+        {
+            var relative = span.IndexOfAny(InlineTagSentinel);
+            if (relative < 0)
+                return -1;
+
+            var absolute = startIndex + relative;
+            if (value.AsSpan(absolute).StartsWith(CodeStart, StringComparison.Ordinal))
+                return absolute;
+
+            var next = relative + 1;
+            startIndex += next;
+            span = span[next..];
+        }
+    }
+
+    private static string DecodeXmlText(string value)
+        => value
+            .Replace("&lt;", "<", StringComparison.Ordinal)
+            .Replace("&gt;", ">", StringComparison.Ordinal)
+            .Replace("&quot;", "\"", StringComparison.Ordinal)
+            .Replace("&apos;", "'", StringComparison.Ordinal)
+            .Replace("&amp;", "&", StringComparison.Ordinal);
+
+    private static string FormatMarkdownCodeSpan(string value)
+    {
+        var delimiter = value.Contains('`')
+            ? new string('`', LongestBacktickRun(value) + 1)
+            : "`";
+        var padding = delimiter.Length > 1 ? " " : "";
+        return $"{delimiter}{padding}{value}{padding}{delimiter}";
+    }
+
+    private static int LongestBacktickRun(string value)
+    {
+        var longest = 0;
+        var current = 0;
+        foreach (var c in value)
+        {
+            if (c == '`')
+            {
+                current++;
+                longest = Math.Max(longest, current);
+            }
+            else
+            {
+                current = 0;
+            }
+        }
+        return longest;
     }
 }

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -53,7 +53,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
         for (int i = 0; i < fields.Length; i++)
         {
             ((IFieldFormatter)this).FormatFieldName(w, fields[i].Key, bold);
-            w.Write(fields[i].Value);
+            w.Write(FormatHelper.RenderInlineMarkdown(fields[i].Value));
             w.WriteLine("  "); // Two trailing spaces for markdown hard line break
         }
     }
@@ -98,7 +98,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             foreach (var value in row)
             {
                 w.Write(' ');
-                w.Write(FormatHelper.EscapeTableCell(value));
+                w.Write(FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(value)));
                 w.Write(" |");
             }
             w.WriteLine();
@@ -127,7 +127,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             {
                 for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
                 {
-                    var escaped = FormatHelper.EscapeTableCell(row[i]);
+                    var escaped = FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(row[i]));
                     widths[i] = Math.Max(widths[i], escaped.Length);
                 }
             }
@@ -173,7 +173,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             for (int i = 0; i < headers.Length; i++)
             {
                 w.Write(' ');
-                var value = i < row.Length ? FormatHelper.EscapeTableCell(row[i]) : "";
+                var value = i < row.Length ? FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(row[i])) : "";
 
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = defaultEnd[i] - rowStart - CellPadding;
@@ -231,7 +231,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             var rowEnd = new int[colCount];
             for (int i = 0; i < colCount; i++)
             {
-                var value = i < row.Length ? FormatHelper.EscapeTableCell(row[i]) : "";
+                var value = i < row.Length ? FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(row[i])) : "";
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = defaultEnd[i] - rowStart - CellPadding;
                 int padWidth = Math.Max(value.Length, space);
@@ -351,7 +351,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             for (int i = 0; i < _streamingWidths.Length; i++)
             {
                 w.Write(' ');
-                var value = i < values.Length ? FormatHelper.EscapeTableCell(values[i]) : "";
+                var value = i < values.Length ? FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(values[i])) : "";
 
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = _streamingDefaultEnd![i] - rowStart - CellPadding;
@@ -368,7 +368,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             foreach (var value in values)
             {
                 w.Write(' ');
-                w.Write(FormatHelper.EscapeTableCell(value));
+                w.Write(FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(value)));
                 w.Write(" |");
             }
         }
@@ -455,7 +455,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
     void IListFormatter.FormatListItem(TextWriter w, string text)
     {
         w.Write("- ");
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlineMarkdown(text));
     }
 
     void IListFormatter.FormatArray(TextWriter w, string key, ReadOnlySpan<string> items, bool bold)
@@ -475,7 +475,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
         foreach (var item in items)
         {
             w.Write("- ");
-            w.WriteLine(item);
+            w.WriteLine(FormatHelper.RenderInlineMarkdown(item));
         }
     }
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.2</Version>
+    <Version>0.13.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/PlainTextFormatter.cs
+++ b/src/Markout/PlainTextFormatter.cs
@@ -48,7 +48,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
         {
             w.Write(fields[i].Key.PadRight(maxKeyWidth));
             w.Write("  ");
-            w.WriteLine(fields[i].Value);
+            w.WriteLine(FormatHelper.RenderInlinePlainText(fields[i].Value));
         }
     }
 
@@ -62,7 +62,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
         foreach (var row in rows)
         {
             for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
-                widths[i] = Math.Max(widths[i], row[i].Length);
+                widths[i] = Math.Max(widths[i], FormatHelper.RenderInlinePlainText(row[i]).Length);
         }
 
         // Header
@@ -91,9 +91,9 @@ public class PlainTextFormatter : IMarkoutFormatter,
             for (int i = 0; i < row.Length; i++)
             {
                 if (i < row.Length - 1)
-                    w.Write(row[i].PadRight(widths[i] + ColumnGap));
+                    w.Write(FormatHelper.RenderInlinePlainText(row[i]).PadRight(widths[i] + ColumnGap));
                 else
-                    w.Write(row[i]);
+                    w.Write(FormatHelper.RenderInlinePlainText(row[i]));
             }
             w.WriteLine();
         }
@@ -118,7 +118,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
 
     void IBlockFormatter.FormatParagraph(TextWriter w, string text)
     {
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     void IBlockFormatter.FormatCallout(TextWriter w, CalloutSeverity severity, string message)
@@ -135,12 +135,12 @@ public class PlainTextFormatter : IMarkoutFormatter,
 
         w.Write(label);
         w.Write(": ");
-        w.WriteLine(message);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(message));
     }
 
     void IBlockFormatter.FormatQuotation(TextWriter w, string text)
     {
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     void IBlockFormatter.FormatRule(TextWriter w)
@@ -152,12 +152,12 @@ public class PlainTextFormatter : IMarkoutFormatter,
     {
         w.Write(item.Term);
         w.Write(": ");
-        w.WriteLine(item.Text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(item.Text));
 
         if (item.Detail != null)
         {
             w.Write("  ");
-            w.WriteLine(item.Detail);
+            w.WriteLine(FormatHelper.RenderInlinePlainText(item.Detail));
         }
     }
 
@@ -165,7 +165,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
 
     void IListFormatter.FormatListItem(TextWriter w, string text)
     {
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     void IListFormatter.FormatArray(TextWriter w, string key, ReadOnlySpan<string> items, bool bold)
@@ -173,7 +173,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
         w.Write(key);
         w.WriteLine(":");
         foreach (var item in items)
-            w.WriteLine(item);
+            w.WriteLine(FormatHelper.RenderInlinePlainText(item));
     }
 
     // ── ITreeFormatter ──
@@ -199,7 +199,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
             w.Write(node.Badge);
             w.Write(' ');
         }
-        w.WriteLine(node.Text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(node.Text));
 
         if (node.Children is { Count: > 0 })
         {

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -1,5 +1,6 @@
 using Markout.Formatting;
 using System.Buffers;
+using System.Text.Encodings.Web;
 using System.Text;
 using System.Text.Json;
 
@@ -12,6 +13,10 @@ namespace Markout;
 public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter
 {
     private const int ColumnGap = 2;
+    private static readonly JsonWriterOptions JsonWriterOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
     private readonly bool _showHeader;
 
     public TableFormatter(bool showHeader = true)
@@ -47,14 +52,14 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         {
             if (i > 0)
                 w.Write(" | ");
-            w.Write(FormatHelper.NormalizeTableCell(fields[i].Value));
+            w.Write(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(fields[i].Value)));
         }
         w.WriteLine();
     }
 
     void IListFormatter.FormatListItem(TextWriter w, string text)
     {
-        w.WriteLine(FormatHelper.NormalizeTableCell(text));
+        w.WriteLine(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(text)));
     }
 
     void IListFormatter.FormatArray(TextWriter w, string key, ReadOnlySpan<string> items, bool bold)
@@ -63,7 +68,7 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         w.WriteLine(":");
 
         foreach (var item in items)
-            w.WriteLine(FormatHelper.NormalizeTableCell(item));
+            w.WriteLine(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(item)));
     }
 
     private void WriteTsvTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows)
@@ -87,7 +92,7 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         foreach (var row in rows)
         {
             for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
-                widths[i] = Math.Max(widths[i], FormatHelper.NormalizeTableCell(row[i]).Length);
+                widths[i] = Math.Max(widths[i], FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(row[i])).Length);
         }
 
         if (_showHeader)
@@ -105,11 +110,11 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         foreach (var row in rows)
         {
             var buffer = new ArrayBufferWriter<byte>();
-            using var json = new Utf8JsonWriter(buffer);
+            using var json = new Utf8JsonWriter(buffer, JsonWriterOptions);
             json.WriteStartObject();
             for (int i = 0; i < headers.Length; i++)
             {
-                var value = i < row.Length ? row[i] : "";
+                var value = i < row.Length ? FormatHelper.RenderInlinePlainText(row[i]) : "";
                 json.WriteString(headers[i] ?? "", value ?? "");
             }
             json.WriteEndObject();
@@ -126,7 +131,7 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         {
             if (i > 0)
                 w.Write('\t');
-            w.Write(FormatHelper.NormalizeTableCell(values[i]));
+            w.Write(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i])));
         }
         w.WriteLine();
     }
@@ -137,7 +142,7 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         {
             if (i > 0)
                 w.Write('\t');
-            w.Write(FormatHelper.NormalizeTableCell(values[i]));
+            w.Write(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i])));
         }
         w.WriteLine();
     }
@@ -146,7 +151,7 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
     {
         for (int i = 0; i < values.Length; i++)
         {
-            var value = FormatHelper.NormalizeTableCell(values[i]);
+            var value = FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i]));
             if (i < values.Length - 1)
                 w.Write(value.PadRight(widths[i] + ColumnGap));
             else
@@ -159,7 +164,7 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
     {
         for (int i = 0; i < values.Length; i++)
         {
-            var value = FormatHelper.NormalizeTableCell(values[i]);
+            var value = FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i]));
             if (i < values.Length - 1)
                 w.Write(value.PadRight(widths[i] + ColumnGap));
             else

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -77,7 +77,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
         for (int i = 0; i < fields.Length; i++)
         {
             ((IFieldFormatter)this).FormatFieldName(w, fields[i].Key, bold);
-            w.WriteLine(fields[i].Value);
+            w.WriteLine(FormatHelper.RenderInlinePlainText(fields[i].Value));
         }
     }
 
@@ -89,7 +89,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
         foreach (var row in rows)
         {
             for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
-                widths[i] = Math.Max(widths[i], row[i].Length);
+                widths[i] = Math.Max(widths[i], FormatHelper.RenderInlinePlainText(row[i]).Length);
         }
 
         // Headers (uppercase)
@@ -119,9 +119,9 @@ public class UnicodeFormatter : IMarkoutFormatter,
             for (int i = 0; i < row.Length; i++)
             {
                 if (i < row.Length - 1)
-                    w.Write(row[i].PadRight(widths[i] + ColumnGap));
+                    w.Write(FormatHelper.RenderInlinePlainText(row[i]).PadRight(widths[i] + ColumnGap));
                 else
-                    w.Write(row[i]);
+                    w.Write(FormatHelper.RenderInlinePlainText(row[i]));
             }
             w.WriteLine();
         }
@@ -138,7 +138,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
     void IListFormatter.FormatListItem(TextWriter w, string text)
     {
         w.Write("• ");
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     void IListFormatter.FormatArray(TextWriter w, string key, ReadOnlySpan<string> items, bool bold)
@@ -148,7 +148,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
         foreach (var item in items)
         {
             w.Write("  • ");
-            w.WriteLine(item);
+            w.WriteLine(FormatHelper.RenderInlinePlainText(item));
         }
     }
 
@@ -174,12 +174,12 @@ public class UnicodeFormatter : IMarkoutFormatter,
             _ => "• "
         };
         w.Write(prefix);
-        w.WriteLine(message);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(message));
     }
 
     void IBlockFormatter.FormatParagraph(TextWriter w, string text)
     {
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     void IBlockFormatter.FormatQuotation(TextWriter w, string text)
@@ -193,7 +193,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
                 w.WriteLine();
                 w.Write("│ ");
             }
-            w.Write(lines[i].TrimEnd('\r'));
+            w.Write(FormatHelper.RenderInlinePlainText(lines[i].TrimEnd('\r')));
         }
         w.WriteLine();
     }
@@ -211,7 +211,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
         if (!string.IsNullOrEmpty(item.Text))
         {
             w.Write(" — ");
-            w.Write(item.Text);
+            w.Write(FormatHelper.RenderInlinePlainText(item.Text));
         }
         w.WriteLine();
     }
@@ -225,7 +225,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
     void ITreeFormatter.FormatTreeNode(TextWriter w, string text, string prefix)
     {
         w.Write(prefix);
-        w.WriteLine(text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
     private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
@@ -237,7 +237,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
             w.Write(node.Badge);
             w.Write(' ');
         }
-        w.WriteLine(node.Text);
+        w.WriteLine(FormatHelper.RenderInlinePlainText(node.Text));
 
         if (node.Children is { Count: > 0 })
         {

--- a/tests/Markout.Tests/FormatHelperTests.cs
+++ b/tests/Markout.Tests/FormatHelperTests.cs
@@ -77,4 +77,36 @@ public class FormatHelperTests
     {
         Assert.Equal(expected, FormatHelper.ToSnakeCase(value));
     }
+
+    [Fact]
+    public void RenderInlineMarkdown_RendersCodeTagsAsMarkdownCodeSpans()
+    {
+        Assert.Equal(
+            "Use `List<T>` here",
+            FormatHelper.RenderInlineMarkdown("Use <code>List&lt;T&gt;</code> here"));
+    }
+
+    [Fact]
+    public void RenderInlineMarkdown_UsesLongerFenceWhenCodeContainsBackticks()
+    {
+        Assert.Equal(
+            "Use `` `literal` `` here",
+            FormatHelper.RenderInlineMarkdown("Use <code>`literal`</code> here"));
+    }
+
+    [Fact]
+    public void RenderInlinePlainText_StripsCodeTagsAndDecodesXmlText()
+    {
+        Assert.Equal(
+            "Use List<T> & Span<T> here",
+            FormatHelper.RenderInlinePlainText("Use <code>List&lt;T&gt; &amp; Span&lt;T&gt;</code> here"));
+    }
+
+    [Fact]
+    public void RenderInlinePlainText_LeavesUnmatchedCodeTagsUnchanged()
+    {
+        Assert.Equal(
+            "Use <code>List&lt;T&gt; here",
+            FormatHelper.RenderInlinePlainText("Use <code>List&lt;T&gt; here"));
+    }
 }

--- a/tests/Markout.Tests/InlineFormattingTests.cs
+++ b/tests/Markout.Tests/InlineFormattingTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+
+namespace Markout.Tests;
+
+public class InlineFormattingTests
+{
+    [Fact]
+    public void MarkdownFormatter_RendersCodeTagsInFieldsTablesAndLists()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new MarkdownFormatter());
+
+        writer.WriteFields(new MarkoutField("Signature", "<code>List&lt;T&gt;</code>"));
+        writer.WriteTable(["Name"], [["<code>Serialize:1</code>"]]);
+        writer.WriteList(["Use <code>Span&lt;T&gt;</code>"]);
+
+        var output = sw.ToString().ReplaceLineEndings("\n");
+        Assert.Contains("Signature: `List<T>`", output);
+        Assert.Contains("| `Serialize:1` |", output);
+        Assert.Contains("- Use `Span<T>`", output);
+    }
+
+    [Fact]
+    public void TsvFormatter_StripsCodeTagsAndDecodesXmlText()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv };
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+
+        writer.WriteTable(
+            ["Signature"],
+            ["Signature"],
+            [["<code>List&lt;T&gt;</code>"]]);
+
+        Assert.Equal("signature\nList<T>\n", sw.ToString().ReplaceLineEndings("\n"));
+    }
+
+    [Fact]
+    public void JsonlFormatter_StripsCodeTagsAndDecodesXmlText()
+    {
+        var sw = new StringWriter();
+        var options = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl };
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+
+        writer.WriteTable(
+            ["Signature"],
+            ["Signature"],
+            [["<code>List&lt;T&gt;</code>"]]);
+
+        Assert.Contains("\"signature\":\"List<T>\"", sw.ToString());
+
+        using var document = JsonDocument.Parse(sw.ToString());
+        Assert.Equal("List<T>", document.RootElement.GetProperty("signature").GetString());
+    }
+
+    [Fact]
+    public void PlainTextFormatter_StripsCodeTagsAndDecodesXmlText()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new PlainTextFormatter());
+
+        writer.WriteFields(new MarkoutField("Signature", "<code>List&lt;T&gt;</code>"));
+
+        Assert.Contains("List<T>", sw.ToString());
+        Assert.DoesNotContain("<code>", sw.ToString());
+        Assert.DoesNotContain("`List", sw.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- Add semantic inline `<code>...</code>` handling so producers can mark code-like values without hard-coding Markdown.
- Render `<code>` as Markdown code spans and as decoded plain text for plain/table/TSV/JSONL renderers.
- Use relaxed JSON escaping for JSONL row values so decoded text such as `List<T>` remains readable.
- Bump Markout to `0.13.3`.

Fixes #104.

## Validation
- `dotnet build src/Markout -c Release --nologo`
- `dotnet run --project tests/Markout.Tests -c Release`
- `npx markdownlint-cli README.md docs/user-guide.md`