### PR TITLE
Escape pipes inside table-cell code spans as \| (0.13.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Formatters declare which shapes they support by implementing capability interfac
 
 ### Format promises
 
-- Markdown table cell values normalize pipe characters to `&#124;`; they do not emit escaped pipes (`\|`).
+- Markdown table cell values normalize pipe characters to `&#124;`. The exception is a pipe inside a rendered `<code>` span, which is escaped as `\|`: GFM unescapes `\|` while splitting table rows (before code-span parsing), whereas `&#124;` would render literally inside a code span.
 - Semantic inline `<code>...</code>` tags render as Markdown code spans and as plain text in table, TSV, and JSONL output.
 - `TableFormatter` with `MarkoutTableMode.Tsv` uses stable snake_case headers by default and never emits embedded tabs or newlines in table cells.
 - `TableFormatter` with `MarkoutTableMode.Jsonl` uses stable snake_case property names by default and emits one JSON object per table row.

--- a/src/Markout/Formatting/FormatHelper.cs
+++ b/src/Markout/Formatting/FormatHelper.cs
@@ -18,6 +18,16 @@ public static class FormatHelper
         => RenderInline(value, codeFormatter: FormatMarkdownCodeSpan);
 
     /// <summary>
+    /// Renders semantic inline tags for a Markdown table cell, escaping cell-breaking characters in
+    /// one code-span-aware pass. Pipes in ordinary text become <c>&amp;#124;</c>, but pipes inside a
+    /// rendered code span are escaped as <c>\|</c>: GFM unescapes <c>\|</c> while splitting table
+    /// rows, before code-span parsing, whereas <c>&amp;#124;</c> would render literally inside a code
+    /// span.
+    /// </summary>
+    public static string RenderInlineMarkdownTableCell(string? value)
+        => RenderInline(value, codeFormatter: FormatMarkdownCodeSpanForTableCell, textFormatter: EscapeTableCell);
+
+    /// <summary>
     /// Renders semantic inline tags as plain text for non-Markdown output.
     /// </summary>
     public static string RenderInlinePlainText(string? value)
@@ -162,14 +172,15 @@ public static class FormatHelper
         return clean.Length <= maxLength ? clean : clean[..(maxLength - 3)] + "...";
     }
 
-    private static string RenderInline(string? value, Func<string, string> codeFormatter)
+    private static string RenderInline(
+        string? value, Func<string, string> codeFormatter, Func<string, string>? textFormatter = null)
     {
         if (string.IsNullOrEmpty(value))
             return "";
 
         var start = IndexOfCodeStart(value, 0);
         if (start < 0)
-            return value;
+            return textFormatter is null ? value : textFormatter(value);
 
         var sb = new System.Text.StringBuilder(value.Length);
         var cursor = 0;
@@ -180,7 +191,7 @@ public static class FormatHelper
             if (end < 0)
                 break;
 
-            sb.Append(value, cursor, start - cursor);
+            AppendText(sb, value, cursor, start - cursor, textFormatter);
             var encoded = value.Substring(contentStart, end - contentStart);
             sb.Append(codeFormatter(DecodeXmlText(encoded)));
 
@@ -189,10 +200,19 @@ public static class FormatHelper
         }
 
         if (cursor == 0)
-            return value;
+            return textFormatter is null ? value : textFormatter(value);
 
-        sb.Append(value, cursor, value.Length - cursor);
+        AppendText(sb, value, cursor, value.Length - cursor, textFormatter);
         return sb.ToString();
+    }
+
+    private static void AppendText(
+        System.Text.StringBuilder sb, string value, int start, int length, Func<string, string>? textFormatter)
+    {
+        if (textFormatter is null)
+            sb.Append(value, start, length);
+        else
+            sb.Append(textFormatter(value.Substring(start, length)));
     }
 
     private static int IndexOfCodeStart(string value, int startIndex)
@@ -229,6 +249,22 @@ public static class FormatHelper
             : "`";
         var padding = delimiter.Length > 1 ? " " : "";
         return $"{delimiter}{padding}{value}{padding}{delimiter}";
+    }
+
+    private static string FormatMarkdownCodeSpanForTableCell(string value)
+    {
+        // A literal pipe inside a table-cell code span must be escaped as \| (GFM strips the
+        // backslash while splitting table rows, before code-span parsing); &#124; would render
+        // literally inside a code span. Newlines are collapsed to spaces as in other cell text.
+        if (value.Contains('|') || value.Contains('\n') || value.Contains('\r'))
+        {
+            value = value
+                .Replace("\r\n", " ")
+                .Replace("\n", " ")
+                .Replace("\r", " ")
+                .Replace("|", "\\|");
+        }
+        return FormatMarkdownCodeSpan(value);
     }
 
     private static int LongestBacktickRun(string value)

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -98,7 +98,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             foreach (var value in row)
             {
                 w.Write(' ');
-                w.Write(FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(value)));
+                w.Write(FormatHelper.RenderInlineMarkdownTableCell(value));
                 w.Write(" |");
             }
             w.WriteLine();
@@ -127,7 +127,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             {
                 for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
                 {
-                    var escaped = FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(row[i]));
+                    var escaped = FormatHelper.RenderInlineMarkdownTableCell(row[i]);
                     widths[i] = Math.Max(widths[i], escaped.Length);
                 }
             }
@@ -173,7 +173,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             for (int i = 0; i < headers.Length; i++)
             {
                 w.Write(' ');
-                var value = i < row.Length ? FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(row[i])) : "";
+                var value = i < row.Length ? FormatHelper.RenderInlineMarkdownTableCell(row[i]) : "";
 
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = defaultEnd[i] - rowStart - CellPadding;
@@ -231,7 +231,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             var rowEnd = new int[colCount];
             for (int i = 0; i < colCount; i++)
             {
-                var value = i < row.Length ? FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(row[i])) : "";
+                var value = i < row.Length ? FormatHelper.RenderInlineMarkdownTableCell(row[i]) : "";
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = defaultEnd[i] - rowStart - CellPadding;
                 int padWidth = Math.Max(value.Length, space);
@@ -351,7 +351,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             for (int i = 0; i < _streamingWidths.Length; i++)
             {
                 w.Write(' ');
-                var value = i < values.Length ? FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(values[i])) : "";
+                var value = i < values.Length ? FormatHelper.RenderInlineMarkdownTableCell(values[i]) : "";
 
                 int rowStart = i == 0 ? 0 : rowEnd[i - 1] + 1;
                 int space = _streamingDefaultEnd![i] - rowStart - CellPadding;
@@ -368,7 +368,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             foreach (var value in values)
             {
                 w.Write(' ');
-                w.Write(FormatHelper.EscapeTableCell(FormatHelper.RenderInlineMarkdown(value)));
+                w.Write(FormatHelper.RenderInlineMarkdownTableCell(value));
                 w.Write(" |");
             }
         }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.3</Version>
+    <Version>0.13.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Markout.Tests/FormatHelperTests.cs
+++ b/tests/Markout.Tests/FormatHelperTests.cs
@@ -68,6 +68,33 @@ public class FormatHelperTests
         Assert.Equal("left&#124;right", FormatHelper.EscapeTableCell("left|right"));
     }
 
+    [Fact]
+    public void RenderInlineMarkdownTableCell_EscapesPipeInsideCodeSpanAsBackslash()
+    {
+        // &#124; renders literally inside a code span; \| is unescaped by GFM table parsing.
+        Assert.Equal("`operator \\|`", FormatHelper.RenderInlineMarkdownTableCell("<code>operator |</code>"));
+    }
+
+    [Fact]
+    public void RenderInlineMarkdownTableCell_KeepsEntityForPipeOutsideCodeSpan()
+    {
+        Assert.Equal("left&#124;right", FormatHelper.RenderInlineMarkdownTableCell("left|right"));
+    }
+
+    [Fact]
+    public void RenderInlineMarkdownTableCell_HandlesPipeInsideAndOutsideCodeSpan()
+    {
+        Assert.Equal(
+            "a&#124;b `c \\| d`",
+            FormatHelper.RenderInlineMarkdownTableCell("a|b <code>c | d</code>"));
+    }
+
+    [Fact]
+    public void RenderInlineMarkdownTableCell_PlainTextUnchanged()
+    {
+        Assert.Equal("System.Boolean", FormatHelper.RenderInlineMarkdownTableCell("System.Boolean"));
+    }
+
     [Theory]
     [InlineData("ReturnType", "return_type")]
     [InlineData("Return Type", "return_type")]


### PR DESCRIPTION
Fixes the highest-value finding from the dotnet-inspect ↔ Markout boundary review: a pipe inside a `<code>` span in a Markdown table cell rendered literally as `&#124;` on GitHub.

## The bug

Markdown table cells are rendered as `EscapeTableCell(RenderInlineMarkdown(value))`. `RenderInlineMarkdown` turns `<code>operator |</code>` into a backtick code span `` `operator |` ``; then `EscapeTableCell` blindly rewrites every pipe — including the one now inside the code span — to `&#124;`. Per CommonMark/GFM, entity references are **not** decoded inside code spans, so GitHub displayed the literal text `operator &#124;` for any signature containing `operator |` (bitwise/logical-or operators, flags helpers, etc.).

## The fix

Merge the inline render and the cell escape into one code-span-aware pass, `RenderInlineMarkdownTableCell`:

- Pipes in **ordinary** cell text still become `&#124;` (the documented format promise, unchanged).
- A pipe inside a **code span** is escaped as `\|`. GFM unescapes `\|` while splitting table rows — *before* code-span parsing — so it survives into the span and renders as a literal pipe. (The GFM table spec explicitly supports `\|` "including inside other inline spans".)

The six `MarkdownFormatter` table-cell call sites now use the combined function. `RenderInline` gained an optional `textFormatter`, with the existing no-allocation fast path preserved for the non-table callers. README format-promise updated to document the code-span exception. Version bumped 0.13.3 → 0.13.4.

## Tests

Added `FormatHelperTests` cases for a pipe inside a code span (`` `operator \|` ``), outside (`&#124;`), and mixed. All 540 Markout.Tests pass; full solution builds with 0 warnings.

## Consumer verification

Packed locally and pointed dotnet-inspect at it; `member System.Numerics.BigInteger -m op_BitwiseOr` now renders the signature code span as `` `... operator \|(...)` `` (correct) while the plain-text name column keeps `operator &#124;` (also correct). dotnet-inspect picks this up by bumping its Markout reference to 0.13.4 once published — no consumer code change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)