### PR TITLE
Escape structural characters in table-cell and heading text (0.13.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ Formatters declare which shapes they support by implementing capability interfac
 
 ### Format promises
 
-- Markdown table cell values normalize pipe characters to `&#124;`. The exception is a pipe inside a rendered `<code>` span, which is escaped as `\|`: GFM unescapes `\|` while splitting table rows (before code-span parsing), whereas `&#124;` would render literally inside a code span.
+- Markdown table-cell and heading text is treated as literal data: the structural characters `&`, `<`, `>`, and backtick are escaped to entities (`&amp;`, `&lt;`, `&gt;`, `&#96;`) so the value renders verbatim rather than being interpreted as HTML or a code span. Table cells additionally normalize the delimiting pipe to `&#124;`.
+- The exception is content inside a rendered `<code>` span, where those characters are literal: there, a pipe is escaped as `\|` (GFM unescapes it while splitting table rows, before code-span parsing) and angle brackets/ampersands need no escaping.
 - Semantic inline `<code>...</code>` tags render as Markdown code spans and as plain text in table, TSV, and JSONL output.
 - `TableFormatter` with `MarkoutTableMode.Tsv` uses stable snake_case headers by default and never emits embedded tabs or newlines in table cells.
 - `TableFormatter` with `MarkoutTableMode.Jsonl` uses stable snake_case property names by default and emits one JSON object per table row.

--- a/src/Markout/Formatting/FormatHelper.cs
+++ b/src/Markout/Formatting/FormatHelper.cs
@@ -41,20 +41,37 @@ public static class FormatHelper
         return value == Math.Floor(value) ? ((int)value).ToString() : value.ToString("0.#");
     }
 
+    private static readonly SearchValues<char> CellEscapeChars = SearchValues.Create("&<>`|\n\r");
+
     /// <summary>
-    /// Escapes Markdown table cell characters and newlines in a table cell value.
+    /// Escapes the HTML/Markdown-structural characters in plain (non-code) Markdown text so the value
+    /// renders literally: <c>&amp;</c>, <c>&lt;</c>, <c>&gt;</c>, and backtick. Entities are used
+    /// because they decode for display in normal text context; the ampersand is escaped first so the
+    /// introduced entities are not double-escaped. The backtick is escaped so free text (e.g. a
+    /// package description) cannot open a code span that would in turn render the other entities
+    /// literally. Used for both table-cell and heading text.
+    /// </summary>
+    public static string EscapeMarkdownText(string value)
+        => value
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("`", "&#96;");
+
+    /// <summary>
+    /// Escapes Markdown table cell text: the structural characters (<see cref="EscapeMarkdownText"/>)
+    /// plus the cell-delimiting pipe, with newlines collapsed to spaces.
     /// </summary>
     public static string EscapeTableCell(string value)
     {
-        if (value.Contains('|') || value.Contains('\n') || value.Contains('\r'))
-        {
-            return value
-                .Replace("|", "&#124;")
-                .Replace("\r\n", " ")
-                .Replace("\n", " ")
-                .Replace("\r", " ");
-        }
-        return value;
+        if (value.AsSpan().IndexOfAny(CellEscapeChars) < 0)
+            return value;
+
+        return EscapeMarkdownText(value)
+            .Replace("|", "&#124;")
+            .Replace("\r\n", " ")
+            .Replace("\n", " ")
+            .Replace("\r", " ");
     }
 
     /// <summary>

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -21,12 +21,12 @@ public class MarkdownFormatter : IMarkoutFormatter,
     {
         w.Write(HeadingPrefixes[level]);
         w.Write(' ');
-        w.Write(text);
+        w.Write(FormatHelper.EscapeMarkdownText(text));
 
         if (!string.IsNullOrEmpty(context))
         {
             w.Write(" (");
-            w.Write(context);
+            w.Write(FormatHelper.EscapeMarkdownText(context));
             w.Write(')');
         }
     }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.4</Version>
+    <Version>0.13.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Markout.Tests/FormatHelperTests.cs
+++ b/tests/Markout.Tests/FormatHelperTests.cs
@@ -95,6 +95,51 @@ public class FormatHelperTests
         Assert.Equal("System.Boolean", FormatHelper.RenderInlineMarkdownTableCell("System.Boolean"));
     }
 
+    [Fact]
+    public void EscapeTableCell_EscapesAngleBrackets()
+    {
+        // Raw <T> would be eaten as an HTML tag by rendered-Markdown viewers.
+        Assert.Equal("System.Collections.Generic.IList&lt;T&gt;",
+            FormatHelper.EscapeTableCell("System.Collections.Generic.IList<T>"));
+    }
+
+    [Fact]
+    public void EscapeTableCell_EscapesAmpersandFirst()
+    {
+        // & is escaped before the introduced entities, so it is not double-escaped.
+        Assert.Equal("a &amp; b &lt;c&gt;", FormatHelper.EscapeTableCell("a & b <c>"));
+    }
+
+    [Fact]
+    public void EscapeTableCell_EscapesBacktickSoFreeTextCannotOpenCodeSpan()
+    {
+        // The smoking-gun case: author backticks around angle brackets in a description. Escaping
+        // the backticks prevents a code span from forming, so the &lt;/&gt; entities decode normally.
+        Assert.Equal("a &#96;&lt;App&gt;.deps.json&#96; b",
+            FormatHelper.EscapeTableCell("a `<App>.deps.json` b"));
+    }
+
+    [Fact]
+    public void EscapeTableCell_PlainTextUnchanged()
+    {
+        Assert.Equal("Parses input", FormatHelper.EscapeTableCell("Parses input"));
+    }
+
+    [Fact]
+    public void EscapeMarkdownText_EscapesHeadingAngleBrackets()
+    {
+        Assert.Equal("System.Collections.Generic.List&lt;T&gt;",
+            FormatHelper.EscapeMarkdownText("System.Collections.Generic.List<T>"));
+    }
+
+    [Fact]
+    public void RenderInlineMarkdownTableCell_CodeSpanKeepsAngleBracketsLiteral()
+    {
+        // Inside a genuine <code> span, angle brackets are literal (no entity needed).
+        Assert.Equal("`IEnumerable<T>`",
+            FormatHelper.RenderInlineMarkdownTableCell("<code>IEnumerable&lt;T&gt;</code>"));
+    }
+
     [Theory]
     [InlineData("ReturnType", "return_type")]
     [InlineData("Return Type", "return_type")]

--- a/tests/Markout.Tests/NestedStructureTests.cs
+++ b/tests/Markout.Tests/NestedStructureTests.cs
@@ -1574,10 +1574,13 @@ public class DistributionTests
 
 public class MultiIgnorePropertyTests
 {
+    // Code-like column values are marked with <code> semantic tags (which render as Markdown code
+    // spans and are stripped for TSV/JSONL), not literal backticks — literal backticks/angle brackets
+    // in cell data are now escaped as structural characters.
     private static readonly List<ApiMemberRow> TestRows =
     [
-        new("`Parse:1`", "Parse", "`string Parse(string)`", "Parses input"),
-        new("`Parse:2`", "Parse", "`string Parse(ReadOnlySpan<char>)`", "Parses span"),
+        new("<code>Parse:1</code>", "Parse", "<code>string Parse(string)</code>", "Parses input"),
+        new("<code>Parse:2</code>", "Parse", "<code>string Parse(ReadOnlySpan&lt;char&gt;)</code>", "Parses span"),
     ];
 
     [Fact]


### PR DESCRIPTION
Fixes the angle-bracket finding from the dotnet-inspect ↔ Markout boundary review: raw `<`/`>` in cell and heading text rendered as eaten HTML tags (`List<T>` → "List") on GitHub. Same class as the pipe bug, now generalized.

## What changed

Plain (non-code) Markdown text — table cells and headings — is now treated as **literal data**. The structural characters `&`, `<`, `>`, and backtick are escaped to entities (`&amp;`, `&lt;`, `&gt;`, `&#96;`), so a type name or a package description renders verbatim instead of being interpreted as HTML or opening a stray code span. Table cells keep the pipe → `&#124;` normalization. Content inside a genuine `<code>` span is untouched (angle brackets literal, pipe → `\|`).

`EscapeMarkdownText` is the shared core, used by both `EscapeTableCell` and `FormatHeading`.

## Why this exact character set

Data-driven, from scanning ~11k real `nuspec`/`csproj` description/release-note/summary fields under `~/git`:

| Char | Freq in descriptions | Decision |
|---|---|---|
| `<` `>` | 2.7% | escape — the dominant real bug |
| `` ` `` | 0.2% (9 distinct, all paired) | escape — **required**: an author's free-text code span otherwise re-renders the `&lt;`/`&gt;` entities literally (e.g. a description with `` `<ApplicationName>.deps.json` ``) |
| `&` | — | escape first, so introduced entities aren't double-escaped |
| `\|` | **0%** | already handled (code-span `\|`); non-issue in descriptions |
| `*` `_` `[` `]` `~` | <0.6% | **left alone** — rare and mostly author-intended; escaping `[ ]` would suppress real `[#123](url)` links |

## Tests / verification

546 Markout.Tests pass (6 new: angle brackets, ampersand-first ordering, the backtick smoking-gun, code-span literals). The one set of tests that used literal backticks in data was switched to `<code>` tags — the sanctioned marking that also strips cleanly for TSV/JSONL.

Verified end-to-end against a locally-packed 0.13.5: a generic type now renders `# …List&lt;T&gt;` and `| …IList&lt;T&gt; |` (→ `List<T>` on GitHub), signature code spans keep `<T>` literal, and `operator |` still uses `\|` in its code span. dotnet-inspect picks this up with a version bump to 0.13.5 — no consumer code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)