### PR TITLE
Add MarkoutSection EmptyText fallback for empty collections

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -107,6 +107,7 @@ That's it. The output is Markdown by default.
 - `Level` — Heading level (default: 2 for `##`)
 - `GroupBy` — Group items by a property value
 - `ShowWhenProperty` — Boolean property controlling visibility
+- `EmptyText` — Fallback paragraph shown when the collection is non-null but empty (`null` still omits the section)
 - `IgnoreProperty` — Comma-separated column names to hide
 
 ## Built-in Shape Types

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -627,6 +627,25 @@ public List<string>? Errors { get; set; }
 
 When `HasErrors` is `false`, the entire Errors section — heading and content — is omitted.
 
+### Empty-State Fallback
+
+Use `EmptyText` to render a fallback paragraph when a section's collection is **non-null but empty**. The heading is still emitted, followed by the fallback text in place of the table or list:
+
+```csharp
+[MarkoutSection(Name = "Callers", EmptyText = "No callers found in this assembly.")]
+public List<CallerRow>? Callers { get; set; }
+```
+
+| `Callers` value | Output |
+|-----------------|--------|
+| non-empty list | `## Callers` + table |
+| empty list (`[]`) | `## Callers` + paragraph `No callers found in this assembly.` |
+| `null` | section omitted entirely |
+
+This makes the section a union of "table OR fallback description." Because a `null` collection still omits the section, the caller controls whether the fallback appears by choosing an empty collection over `null` — useful when a section is explicitly requested and you want to confirm "nothing found" rather than rendering silence.
+
+`EmptyText` applies to every count-gated collection section (tables, string lists, fields, trees, metrics, descriptions, breakdowns) and composes with `ShowWhenProperty` (a `false` guard still omits the section, fallback included).
+
 ### Collection Truncation
 
 Use `[MarkoutMaxItems]` to limit the number of items rendered, with an ellipsis message:

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -524,6 +524,7 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}    writer.{writeMethod}(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({propAccess}));");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.ComplexArray && prop.ElementProperties != null)
         {
@@ -576,6 +577,8 @@ internal static class SerializerEmitter
             }
 
             sb.AppendLine($"{indent}}}");
+            if (!prop.IsUnwrapped)
+                EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.StringArray)
         {
@@ -595,6 +598,7 @@ internal static class SerializerEmitter
             }
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.Tree)
         {
@@ -614,6 +618,7 @@ internal static class SerializerEmitter
             }
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.Metric)
         {
@@ -623,6 +628,7 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}    writer.WriteMetrics({propAccess});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.Description)
         {
@@ -632,6 +638,7 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}    writer.WriteDescriptions({propAccess});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.Breakdown)
         {
@@ -641,6 +648,7 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.CodeSection)
         {
@@ -716,6 +724,26 @@ internal static class SerializerEmitter
             name = baseName + index++;
 
         return name;
+    }
+
+    private static void EmitSectionEmptyFallback(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string indent,
+        int effectiveSectionLevel,
+        string sectionName)
+    {
+        if (prop.SectionEmptyText == null)
+            return;
+
+        var headlessArg = prop.SectionHeadless ? ", headless: true" : "";
+        sb.AppendLine($"{indent}else if ({propAccess} != null)");
+        sb.AppendLine($"{indent}{{");
+        sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+        sb.AppendLine($"{indent}    writer.WriteParagraph(\"{EmitHelpers.EscapeString(prop.SectionEmptyText)}\");");
+        sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+        sb.AppendLine($"{indent}}}");
     }
 
     private static void EmitNonSectionProperty(

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -178,6 +178,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? LinkTextProperty { get; }
     public IReadOnlyList<(string Key, string Value)>? ValueMap { get; }
     public bool IsUnwrapped { get; }
+    public string? SectionEmptyText { get; }
 
     public PropertyMetadata(
         string name,
@@ -222,7 +223,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         bool isLink = false,
         string? linkTextProperty = null,
         IReadOnlyList<(string Key, string Value)>? valueMap = null,
-        bool isUnwrapped = false)
+        bool isUnwrapped = false,
+        string? sectionEmptyText = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -267,6 +269,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         LinkTextProperty = linkTextProperty;
         ValueMap = valueMap;
         IsUnwrapped = isUnwrapped;
+        SectionEmptyText = sectionEmptyText;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -315,6 +318,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                LinkTextProperty == other.LinkTextProperty &&
                ValueMapEqual(ValueMap, other.ValueMap) &&
                IsUnwrapped == other.IsUnwrapped &&
+               SectionEmptyText == other.SectionEmptyText &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -348,6 +352,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (LinkTextProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (ValueMap?.Count ?? 0);
             hash = hash * 397 ^ IsUnwrapped.GetHashCode();
+            hash = hash * 397 ^ (SectionEmptyText?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -240,6 +240,7 @@ internal static class TypeParser
         string? sectionShowWhenProperty = null;
         string? sectionGroupByProperty = null;
         bool sectionHeadless = false;
+        string? sectionEmptyText = null;
         List<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null;
 
         if (isSection)
@@ -268,6 +269,8 @@ internal static class TypeParser
                         sectionGroupByProperty = gb;
                     else if (named.Key == "Headless" && named.Value.Value is bool hl)
                         sectionHeadless = hl;
+                    else if (named.Key == "EmptyText" && named.Value.Value is string et)
+                        sectionEmptyText = et;
                 }
             }
         }
@@ -504,7 +507,8 @@ internal static class TypeParser
             isLink,
             linkTextProperty,
             valueMap,
-            isUnwrapped);
+            isUnwrapped,
+            sectionEmptyText);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutSectionAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSectionAttribute.cs
@@ -60,4 +60,12 @@ public sealed class MarkoutSectionAttribute : Attribute
     /// but no heading (e.g., ##) is emitted. Use for preamble content that should be a named section.
     /// </summary>
     public bool Headless { get; set; }
+
+    /// <summary>
+    /// Gets or sets fallback text rendered as a paragraph when the section's collection is
+    /// non-null but empty. The section heading is still emitted, followed by this text in place
+    /// of the table or list. When the collection is null the section is omitted entirely, so the
+    /// caller controls whether the fallback appears by choosing an empty collection over null.
+    /// </summary>
+    public string? EmptyText { get; set; }
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.5</Version>
+    <Version>0.13.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Markout.Tests/EmptyTextFallbackTests.cs
+++ b/tests/Markout.Tests/EmptyTextFallbackTests.cs
@@ -1,0 +1,92 @@
+using Markout;
+
+namespace Markout.Tests;
+
+[MarkoutSerializable]
+public class CallersContainer
+{
+    public string? Member { get; set; }
+
+    [MarkoutIgnoreInTable]
+    [MarkoutSection(Name = "Callers", EmptyText = "No in-assembly callers found.")]
+    public List<CallerRow>? Callers { get; set; }
+
+    [MarkoutSection(Name = "Tags", EmptyText = "None found.")]
+    public List<string>? Tags { get; set; }
+}
+
+[MarkoutSerializable]
+public class CallerRow
+{
+    public string? Caller { get; set; }
+    public string? Kind { get; set; }
+}
+
+[MarkoutContext(typeof(CallersContainer))]
+public partial class EmptyTextContext : MarkoutSerializerContext
+{
+}
+
+public class EmptyTextFallbackTests
+{
+    [Fact]
+    public void NonEmptyCollection_RendersTable_NotFallback()
+    {
+        var model = new CallersContainer
+        {
+            Member = "Serialize",
+            Callers = new List<CallerRow> { new() { Caller = "Foo", Kind = "call" } },
+        };
+
+        var mdf = MarkoutSerializer.Serialize(model, EmptyTextContext.Default);
+
+        Assert.Contains("## Callers", mdf);
+        Assert.Contains("| Foo |", mdf);
+        Assert.DoesNotContain("No in-assembly callers found.", mdf);
+    }
+
+    [Fact]
+    public void EmptyCollection_RendersHeadingAndFallbackParagraph()
+    {
+        var model = new CallersContainer
+        {
+            Member = "Serialize",
+            Callers = new List<CallerRow>(),
+        };
+
+        var mdf = MarkoutSerializer.Serialize(model, EmptyTextContext.Default);
+
+        Assert.Contains("## Callers", mdf);
+        Assert.Contains("No in-assembly callers found.", mdf);
+    }
+
+    [Fact]
+    public void NullCollection_OmitsSectionEntirely()
+    {
+        var model = new CallersContainer
+        {
+            Member = "Serialize",
+            Callers = null,
+        };
+
+        var mdf = MarkoutSerializer.Serialize(model, EmptyTextContext.Default);
+
+        Assert.DoesNotContain("## Callers", mdf);
+        Assert.DoesNotContain("No in-assembly callers found.", mdf);
+    }
+
+    [Fact]
+    public void EmptyStringArray_RendersFallbackParagraph()
+    {
+        var model = new CallersContainer
+        {
+            Member = "Serialize",
+            Tags = new List<string>(),
+        };
+
+        var mdf = MarkoutSerializer.Serialize(model, EmptyTextContext.Default);
+
+        Assert.Contains("## Tags", mdf);
+        Assert.Contains("None found.", mdf);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an `EmptyText` option to `[MarkoutSection]` that renders a fallback paragraph when a section's collection is **non-null but empty**, instead of omitting the section.

```csharp
[MarkoutSection(Name = "Callers", EmptyText = "No callers found in this assembly.")]
public List<CallerRow>? Callers { get; set; }
```

| `Callers` value | Output |
|-----------------|--------|
| non-empty list | `## Callers` + table |
| empty list (`[]`) | `## Callers` + paragraph `No callers found in this assembly.` |
| `null` | section omitted entirely |

A `null` collection still omits the section, so the caller controls whether the fallback appears by choosing an empty collection over `null` — a union of "table OR fallback description." This is useful when a section is explicitly requested and the caller wants to confirm "nothing found" rather than render silence.

## Details

- New `string? EmptyText` on `MarkoutSectionAttribute`, plumbed through `TypeParser` to `PropertyMetadata` to `SerializerEmitter`.
- The generator emits an `else if (collection != null)` branch after the existing count gate that writes the heading plus `WriteParagraph(EmptyText)`.
- Applies to every count-gated collection section kind: complex-array tables, string-array lists, field collections, trees, metrics, descriptions, breakdowns. Unwrapped collections (no heading) are excluded.
- Composes with `ShowWhenProperty` (a `false` guard still omits the section, fallback included).

## Tests

- New `EmptyTextFallbackTests` covering: non-empty to table, empty to fallback paragraph, null to omitted, and empty string-array to fallback.
- Full suite green (536 tests, `-p:ExcludeAnsi=true`).

## Docs

- `docs/user-guide.md`: new "Empty-State Fallback" section.
- `SKILL.md`: `EmptyText` added to the `[MarkoutSection]` property list.

Version bumped to 0.13.6.
