### PR TITLE
Add AGENTS.md package grounding (0.13.7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,10 +57,12 @@ MarkoutSerializer.Serialize(report, Console.Out, ReportContext.Default);
   `List<TreeNode>`, `List<Description>`, `Callout`) or they get mistreated as table columns.
 
 ## Built-in shape types (use as model properties for rich output)
+
 `Metric` (bar chart), `Breakdown`/`Segment` (stacked bar), `Callout` (alert), `TreeNode`
 (hierarchy), `Description` (term + text), `CodeSection` (code block). e.g. `new Metric("Build", 4.2)`.
 
 ## Other output formats (still Markdown by default)
+
 Pass a formatter to change output: `new MarkdownFormatter()` (default), `PlainTextFormatter`,
 `UnicodeFormatter`, `TableFormatter` (compact/TSV/JSONL via `MarkoutWriterOptions.TableMode`).
 e.g. `MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), ReportContext.Default);`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+---
+name: markout
+description: >-
+  Source-generated .NET serializer that renders objects as Markdown (also ANSI terminal,
+  plain text, pretty tables, TSV). Reach for it when a CLI or tool needs structured, human-
+  or agent-readable output instead of hand-built strings. It looks like System.Text.Json
+  source generation but the rules differ — there is NO reflection fallback, so it requires a
+  generated MarkoutSerializerContext and Markout-specific attributes. See the body for the
+  required pattern.
+---
+
+# Markout — produce Markdown/structured output from objects
+
+Source-generated serializer. Default output is Markdown. Package `Markout` (includes the
+source generator; no extra package needed).
+
+## The required pattern (3 parts — all mandatory)
+
+```csharp
+using Markout;
+
+// 1. Annotate every model type. List<T> -> table, scalar -> field.
+[MarkoutSerializable(TitleProperty = nameof(Title))]   // TitleProperty -> the H1 heading
+public class Report
+{
+    public string Title { get; set; } = "";
+    public int Count { get; set; }
+    [MarkoutSection(Name = "Items")]                    // -> "## Items" heading
+    public List<Row>? Items { get; set; }              // List<T> -> a table
+}
+
+[MarkoutSerializable]
+public class Row { public string Name { get; set; } = ""; public string Value { get; set; } = ""; }
+
+// 2. Register EVERY type on a partial context (the source generator fills it in).
+[MarkoutContext(typeof(Report))]
+[MarkoutContext(typeof(Row))]
+public partial class ReportContext : MarkoutSerializerContext { }
+
+// 3. Serialize THROUGH the context.
+MarkoutSerializer.Serialize(report, Console.Out, ReportContext.Default);
+```
+
+## Gotchas (where intuition from System.Text.Json is wrong)
+
+- **No reflection fallback.** There is no `Serialize(obj)` overload. EVERY `MarkoutSerializer.Serialize`
+  overload takes a `MarkoutSerializerContext` (or `MarkoutTypeInfo<T>`). Skipping the context does
+  not compile. This is the #1 mistake.
+- **Register every type.** A model used in output but missing `[MarkoutSerializable]` +
+  `[MarkoutContext(typeof(T))]` will not serialize. The context class MUST be `partial`.
+- **Attributes are Markout's, not System.Text.Json's:** `[MarkoutSerializable]` (not
+  `[JsonSerializable]`), `[MarkoutContext]`, `[MarkoutSection(Name=...)]`, `TitleProperty`,
+  `[MarkoutPropertyName]`, `[MarkoutIgnore]`. Do not use `Json*` attributes.
+- **Rendering is driven by type, not markup:** `List<T>` -> table; scalar (`string`/`int`/`bool`) ->
+  a `Field | Value` row; `[MarkoutSection(Name="X")]` -> a `## X` heading above the property.
+- **Put `[MarkoutIgnoreInTable]` on non-tabular list properties** (`List<Metric>`, `List<Breakdown>`,
+  `List<TreeNode>`, `List<Description>`, `Callout`) or they get mistreated as table columns.
+
+## Built-in shape types (use as model properties for rich output)
+`Metric` (bar chart), `Breakdown`/`Segment` (stacked bar), `Callout` (alert), `TreeNode`
+(hierarchy), `Description` (term + text), `CodeSection` (code block). e.g. `new Metric("Build", 4.2)`.
+
+## Other output formats (still Markdown by default)
+Pass a formatter to change output: `new MarkdownFormatter()` (default), `PlainTextFormatter`,
+`UnicodeFormatter`, `TableFormatter` (compact/TSV/JSONL via `MarkoutWriterOptions.TableMode`).
+e.g. `MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), ReportContext.Default);`

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.6</Version>
+    <Version>0.13.7</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,6 +30,9 @@
           PackagePath="analyzers/dotnet/cs"
           Visible="false" />
     <None Include="$(MSBuildThisFileDirectory)..\..\README.md"
+          Pack="true"
+          PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)..\..\AGENTS.md"
           Pack="true"
           PackagePath="\" />
   </ItemGroup>


### PR DESCRIPTION
## What

Ship an **`AGENTS.md` grounding file** in the package root (alongside `README.md`) and bump the patch version `0.13.6 → 0.13.7`.

## Why

This lets us validate package grounding against a **real, published-from-nuget.org package** (not a faked/local one). When an agent resolves the `Markout` package, it gets a short, dense directive describing:

- The **required source-generation pattern** (annotate models → register on a `partial MarkoutSerializerContext` → `Serialize` through the context).
- The **System.Text.Json look-alike gotchas** — chiefly: **no reflection fallback**, so every `MarkoutSerializer.Serialize` overload requires a context. A model running on STJ intuition writes code that does not compile.

In our harness, this grounding gives a clean tier-conditioned signal on Markout: do-no-harm + ~3× token / ~½ tool-call efficiency on a frontier agent, and a **fail→pass correctness rescue** on a weaker (Haiku-class) agent.

## Changes

- Add `AGENTS.md` (hand-authored grounding).
- Pack it into the `.nupkg` root via `<None Pack="true" PackagePath="\">` in `Markout.csproj`.
- Patch bump `0.13.6 → 0.13.7`.

## Verification

`dotnet pack -c Release` succeeds and `AGENTS.md` (3390 B) is present in the package root:

```
3390   AGENTS.md
18757  README.md
```