### PR TITLE
Bump to 0.13.8 (publish AGENTS.md grounding)

### DIFF
--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.7</Version>
+    <Version>0.13.8</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

`0.13.7` was published to nuget.org from commit `61c2ba7` (#110) **before** the AGENTS.md grounding landed, so the published `0.13.7` does **not** contain `AGENTS.md` — and nuget.org versions are immutable.

PR #111 added `AGENTS.md` (and packing) to `main` but, having branched from a stale local `main`, bumped to the **already-taken** `0.13.7`. So `main` currently can't publish the grounding (version collision).

This bumps to **`0.13.8`** so the next release publishes the package **with** `AGENTS.md`.

## After merge

Run the **Publish** workflow (`workflow_dispatch`) against the CI run for this commit to push `0.13.8` to nuget.org. Verify the published nupkg contains `AGENTS.md` at the root.
