### PR TITLE
Fix incorrect MarkoutLink example in the integration guide

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -94,7 +94,7 @@ That's it. The output is Markdown by default.
 | `[MarkoutIgnore]` | Exclude from output | |
 | `[MarkoutIgnoreInTable]` | Exclude from table columns | |
 | `[MarkoutMaxItems(N)]` | Truncate long lists | `[MarkoutMaxItems(10)]` |
-| `[MarkoutLink(nameof(Url))]` | Render as hyperlink | `[MarkoutLink(nameof(HtmlUrl))]` |
+| `[MarkoutLink(TextProperty = nameof(...))]` | Render a URL property as a hyperlink | `[MarkoutLink(TextProperty = nameof(Title))]` on the URL property |
 | `[MarkoutUnwrap]` | Inline collection without section heading | |
 | `[MarkoutIgnoreColumnWhen(...)]` | Conditionally hide table column | |
 | `[MarkoutValueMap("k=v", ...)]` | Map values to display strings | |


### PR DESCRIPTION
## Problem

`SKILL.md`'s attribute reference showed:

```csharp
[MarkoutLink(nameof(Url))]
```

but `MarkoutLinkAttribute` has **no positional constructor** — that example does not compile (`CS1729: 'MarkoutLinkAttribute' does not contain a constructor that takes 1 arguments`).

## Fix

The correct usage places the attribute on the URL-bearing property and names the text property via `TextProperty`:

```csharp
[MarkoutLink(TextProperty = nameof(Title))]
public string Url { get; set; } = "";
```

Verified against the shipped 0.13.x surface: this renders `[Title](Url)` in a table/field. Found while exercising the full Markout API surface for package-grounding evals.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>