### PR TITLE
Add HeadingLevelOffset to render a document as a nested section (0.14.0)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -880,6 +880,24 @@ var options = new MarkoutWriterOptions
 
 > From the [SectionFiltering](../samples/Serialization/SectionFiltering.cs) sample.
 
+### Heading Level Offset
+
+`HeadingLevelOffset` shifts every rendered heading by a fixed amount (default
+`0`). Set it to `1` to render a document as a nested section — "print a section,
+elide the H1" — so its title drops from `#` to `##` and any sections shift down
+with it. This lets serialized output be appended under an existing document
+without introducing a second top-level heading:
+
+```csharp
+var options = new MarkoutWriterOptions { HeadingLevelOffset = 1 };
+// # Skills        ->  ## Skills
+// ## Subsection   ->  ### Subsection
+```
+
+Rendered levels are clamped to the valid `1`–`6` range. The offset only affects
+rendered heading depth; logical section identity (used by `IncludeSections`)
+is unchanged.
+
 ### Context-Level Options
 
 Set defaults via `[MarkoutContextOptions]`:

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.13.9</Version>
+    <Version>0.14.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -103,7 +103,7 @@ public class MarkoutWriter
         if (_hasContent)
             _writer.WriteLine();
 
-        hf.FormatHeading(_writer, level, text, context);
+        hf.FormatHeading(_writer, RenderHeadingLevel(level), text, context);
         _writer.WriteLine();
         _hasContent = true;
         _needsBlankLine = true;
@@ -892,6 +892,14 @@ public class MarkoutWriter
 
     // ── Private infrastructure ──
 
+    private int RenderHeadingLevel(int level)
+    {
+        var adjusted = level + _options.HeadingLevelOffset;
+        if (adjusted < 1) return 1;
+        if (adjusted > 6) return 6;
+        return adjusted;
+    }
+
     private void UpdateSectionState(int level, string text)
     {
         if (level == 2)
@@ -980,7 +988,7 @@ public class MarkoutWriter
         if (_hasContent)
             _writer.WriteLine();
 
-        hf.FormatHeading(_writer, level, text, context);
+        hf.FormatHeading(_writer, RenderHeadingLevel(level), text, context);
         _writer.WriteLine();
         _hasContent = true;
         _needsBlankLine = true;

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -20,6 +20,7 @@ public class MarkoutWriterOptions
     private Func<MarkoutTableHeader, string>? _formatTableHeader;
     private MarkoutTableMode _tableMode;
     private MarkoutTableHeaderStyle _tableHeaderStyle;
+    private int _headingLevelOffset;
 
     /// <summary>
     /// Gets the default options instance. This instance is read-only.
@@ -198,6 +199,28 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _tableHeaderStyle = value;
+        }
+    }
+
+    /// <summary>
+    /// Offset added to every heading level at render time. Default is 0, which
+    /// leaves levels unchanged.
+    /// <para>
+    /// Set to 1 to render a serialized document as a nested section ("print a
+    /// section, elide the H1"): the document title drops from H1 to H2 and any
+    /// sections shift down one level, so the output can be appended under an
+    /// existing document without introducing a second H1. Rendered levels are
+    /// clamped to the valid 1–6 range; logical section identity (used by
+    /// <see cref="IncludeSections"/>) is unaffected.
+    /// </para>
+    /// </summary>
+    public int HeadingLevelOffset
+    {
+        get => _headingLevelOffset;
+        set
+        {
+            ThrowIfReadOnly();
+            _headingLevelOffset = value;
         }
     }
 

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -35,6 +35,69 @@ public class MarkoutWriterTests
     }
 
     [Fact]
+    public void HeadingLevelOffset_ShiftsHeadingDown()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(), new MarkoutWriterOptions { HeadingLevelOffset = 1 });
+        orch.WriteHeading(1, "Title");
+        Assert.Equal("## Title", orch.ToString());
+    }
+
+    [Fact]
+    public void HeadingLevelOffset_ShiftsSectionHeadingDown()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(), new MarkoutWriterOptions { HeadingLevelOffset = 1 });
+        orch.WriteSectionStart(2, "Section");
+        Assert.Equal("### Section", orch.ToString());
+    }
+
+    [Fact]
+    public void HeadingLevelOffset_ClampsToSix()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(), new MarkoutWriterOptions { HeadingLevelOffset = 3 });
+        orch.WriteHeading(5, "Deep");
+        Assert.Equal("###### Deep", orch.ToString());
+    }
+
+    [Fact]
+    public void HeadingLevelOffset_NegativeClampsToOne()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(), new MarkoutWriterOptions { HeadingLevelOffset = -5 });
+        orch.WriteHeading(2, "Up");
+        Assert.Equal("# Up", orch.ToString());
+    }
+
+    [Fact]
+    public void HeadingLevelOffset_DefaultZero_LeavesLevelUnchanged()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteHeading(1, "Title");
+        Assert.Equal("# Title", orch.ToString());
+    }
+
+    [Fact]
+    public void HeadingLevelOffset_DoesNotChangeLogicalSectionFiltering()
+    {
+        // IncludeSections keys off the logical level-2 section name, which must
+        // still match even when the rendered heading is shifted by the offset.
+        var options = new MarkoutWriterOptions
+        {
+            HeadingLevelOffset = 1,
+            IncludeSections = ["Keep"],
+        };
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        orch.WriteSectionStart(2, "Keep");
+        orch.WriteParagraph("kept");
+        orch.WriteSectionStart(2, "Drop");
+        orch.WriteParagraph("dropped");
+
+        var output = orch.ToString();
+        Assert.Contains("### Keep", output);
+        Assert.Contains("kept", output);
+        Assert.DoesNotContain("Drop", output);
+        Assert.DoesNotContain("dropped", output);
+    }
+
+    [Fact]
     public void MarkdownFormatter_WriteFields_Renders()
     {
         var orch = MarkoutWriter.Create(new MarkdownFormatter());


### PR DESCRIPTION
## Summary

Adds `MarkoutWriterOptions.HeadingLevelOffset` (default `0`), which shifts every
rendered heading level by a fixed amount. Setting it to `1` renders a serialized
document **as a nested section** — "print a section, elide the H1" — so the title
drops from `#` to `##` and any sections shift down with it. This lets serialized
output be appended under an existing document without introducing a second
top-level heading.

```csharp
var options = new MarkoutWriterOptions { HeadingLevelOffset = 1 };
// # Skills        ->  ## Skills
// ## Subsection   ->  ### Subsection
```

## Motivation

`dotnet-inspect skill` prints a baseline skill document and wants to append a
generated `## Skills` section (heading + intro description + table) underneath
it. A serialized view's title renders at H1, and sections have no description
slot — so there was no way to emit `## Skills` + description + table as one
serialize call. `HeadingLevelOffset = 1` lets the view be authored as a normal
titled + described document and rendered one level down.

## Implementation

- Applied in `MarkoutWriter` at both heading render sites (`WriteHeading` and
  `WriteSectionHeading`) via a clamped `RenderHeadingLevel` helper. Rendered
  levels are clamped to the valid 1–6 range.
- **Logical section identity is unaffected**: `UpdateSectionState` /
  `IncludeSections` still key off the original level, so section filtering keeps
  working under an offset.
- Documented in `docs/user-guide.md`; package version bumped to `0.14.0`.

## Tests

New `MarkoutWriterTests` cover: heading shift, section-heading shift, clamping
(high and negative), default no-op, and that section filtering still matches
under an offset. Full suite green (544 tests).
