### PR TITLE
Make TreeNode children an IEnumerable and badge a property (0.15.0)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -757,15 +757,15 @@ Use `List<TreeNode>` for hierarchical data with box-drawing characters:
 ```csharp
 var tree = new[]
 {
-    new TreeNode("CEO", new[]
-    {
-        new TreeNode("VP Engineering", new[]
-        {
+    new TreeNode("CEO",
+    [
+        new TreeNode("VP Engineering",
+        [
             new TreeNode("Dev Team Lead"),
             new TreeNode("QA Team Lead")
-        }),
+        ]),
         new TreeNode("VP Sales")
-    })
+    ])
 };
 
 writer.WriteTree(tree);
@@ -779,11 +779,11 @@ writer.WriteTree(tree);
    └─ VP Sales
 ```
 
-`TreeNode` supports optional icons:
+`TreeNode` supports optional icons via the `Badge` property:
 
 ```csharp
-new TreeNode("Critical Issue", "🔴")
-new TreeNode("Warning", "🟡")
+new TreeNode("Critical Issue") { Badge = "🔴" }
+new TreeNode("Warning") { Badge = "🟡" }
 ```
 
 > The [LatestCves](../samples/LatestCves/LatestCves.cs) sample uses trees with icons to display CVE severity.

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -60,6 +60,9 @@ MarkoutSerializer.Serialize(report, Console.Out, ReportContext.Default);
 
 `Metric` (bar chart), `Breakdown`/`Segment` (stacked bar), `Callout` (alert), `TreeNode`
 (hierarchy), `Description` (term + text), `CodeSection` (code block). e.g. `new Metric("Build", 4.2)`.
+Pass children as a list/array/collection expression, never as trailing arguments:
+`new TreeNode("root", [new TreeNode("leaf")])`. `Badge` is an optional property:
+`new TreeNode("root") { Badge = "📁" }`.
 
 ## Other output formats (still Markdown by default)
 

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -250,9 +250,9 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
                         .Where(s => s.CanadianActors.Contains(actor.Name))
                         .ToList();
                     if (actorShows.Count == 0) return null;
-                    return new TreeNode(actor.Name, null,
+                    return new TreeNode(actor.Name,
                         actorShows.GroupBy(s => s.Location).OrderBy(g => g.Key)
-                            .Select(g => new TreeNode(g.Key, null, g.Select(s => new TreeNode($"{s.Title} ({s.Years})")).ToArray())).ToArray());
+                            .Select(g => new TreeNode(g.Key, g.Select(s => new TreeNode($"{s.Title} ({s.Years})")))));
                 })
                 .Where(n => n is not null)
                 .ToList()!
@@ -336,9 +336,9 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
             FilmographyTree = topActors.Select(actor =>
             {
                 var actorShows = shows.Where(s => s.CanadianActors.Contains(actor.Name)).ToList();
-                return new TreeNode(actor.Name, null,
+                return new TreeNode(actor.Name,
                     actorShows.GroupBy(s => s.Location).Select(g =>
-                        new TreeNode(g.Key, null, g.Select(s => new TreeNode(s.Title)).ToArray())).ToArray());
+                        new TreeNode(g.Key, g.Select(s => new TreeNode(s.Title)))));
             }).ToList(),
             Quote = "The world needs more Canada.\n— Bono, 2003"
         };

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -76,14 +76,14 @@ foreach (var (version, vi) in versionData.OrderByDescending(v => decimal.TryPars
                 "LOW" => "🟢",
                 _ => null
             };
-            return new TreeNode(label, badge);
+            return new TreeNode(label) { Badge = badge };
         })
         .ToList();
 
     if (cves.Count == 0)
         cves.Add(new TreeNode("None"));
 
-    tree.Add(new TreeNode($"{version} (last updated: {date})", null, [..cves]));
+    tree.Add(new TreeNode($"{version} (last updated: {date})", cves));
 }
 
 // Count severity distribution

--- a/samples/Serialization/ShapeGallery.cs
+++ b/samples/Serialization/ShapeGallery.cs
@@ -83,12 +83,12 @@ public static class ShapeGallery
         // Hierarchy — tree
         writer.WriteHeading(2, "Project Structure");
         writer.WriteTree(
-            new TreeNode("src", null,
-                new TreeNode("Markout", null, new TreeNode("MarkoutWriter.cs"), new TreeNode("MarkoutShape.cs")),
-                new TreeNode("Markout.SourceGeneration", null, new TreeNode("Parser"), new TreeNode("Emitter")),
-                new TreeNode("Markout.Ansi.Spectre", null, new TreeNode("SpectreFormatter.cs"))),
-            new TreeNode("tests", null,
-                new TreeNode("Markout.Tests")));
+            new TreeNode("src", [
+                new TreeNode("Markout", [new TreeNode("MarkoutWriter.cs"), new TreeNode("MarkoutShape.cs")]),
+                new TreeNode("Markout.SourceGeneration", [new TreeNode("Parser"), new TreeNode("Emitter")]),
+                new TreeNode("Markout.Ansi.Spectre", [new TreeNode("SpectreFormatter.cs")])]),
+            new TreeNode("tests", [
+                new TreeNode("Markout.Tests")]));
 
         // Quotation — code section
         writer.WriteHeading(2, "Quick Start");

--- a/samples/Serialization/ShapeWriterUsage.cs
+++ b/samples/Serialization/ShapeWriterUsage.cs
@@ -78,11 +78,11 @@ public static class ShapeWriterUsage
         var tree = new TreeWriter(Console.Out);
 
         tree.WriteTree([
-            new TreeNode("src", null,
-                new TreeNode("Markout", null,
+            new TreeNode("src", [
+                new TreeNode("Markout", [
                     new TreeNode("MarkoutWriter.cs"),
-                    new TreeNode("MarkdownFormatter.cs")),
-                new TreeNode("Markout.Templates")),
+                    new TreeNode("MarkdownFormatter.cs")]),
+                new TreeNode("Markout.Templates")]),
             new TreeNode("tests"),
         ]);
         // └─ src

--- a/samples/Serialization/WriterUsage.cs
+++ b/samples/Serialization/WriterUsage.cs
@@ -78,13 +78,13 @@ public static class WriterUsage
         writer.WriteHeading(1, "Organization");
 
         writer.WriteTree(
-            new TreeNode("CEO", null,
-                new TreeNode("VP Engineering", null,
+            new TreeNode("CEO", [
+                new TreeNode("VP Engineering", [
                     new TreeNode("Dev Team Lead"),
-                    new TreeNode("QA Team Lead")),
-                new TreeNode("VP Sales", null,
+                    new TreeNode("QA Team Lead")]),
+                new TreeNode("VP Sales", [
                     new TreeNode("Account Manager"),
-                    new TreeNode("Sales Rep"))));
+                    new TreeNode("Sales Rep")])]));
 
         Console.WriteLine(writer.ToString());
         // # Organization

--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -146,14 +146,13 @@ public static class Demos
         // Project to TreeNode structure
         var tree = shoes.Select(s => new TreeNode(
             $"{s.Model} ({s.Category}, ${s.Price})",
-            null,
-            [..s.Reviews?.Select(r =>
+            s.Reviews?.Select(r =>
             {
                 var comment = r.Comment.Length > 40
                     ? r.Comment.Substring(0, 37) + "..."
                     : r.Comment;
                 return new TreeNode($"\"{comment}\" — {r.Author} ({r.Rating}★)");
-            }) ?? []]));
+            })));
 
         var writer = new MarkoutWriter(output, new MarkdownFormatter());
         

--- a/src/Markout.Demo/README.md
+++ b/src/Markout.Demo/README.md
@@ -181,7 +181,7 @@ This demonstrates that when you need custom formatting, you project your data to
 ```csharp
 var tree = shoes.Select(s => new TreeNode(
     $"{s.Model} ({s.Category}, ${s.Price})",
-    s.Reviews?.Select(r => $"\"{r.Comment}\" — {r.Author}")
+    s.Reviews?.Select(r => new TreeNode($"\"{r.Comment}\" — {r.Author}"))
 ));
 writer.WriteTree(tree);
 ```

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.14.0</Version>
+    <Version>0.15.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutSchemaInfo.cs
+++ b/src/Markout/MarkoutSchemaInfo.cs
@@ -286,8 +286,7 @@ public sealed class MarkoutSchemaInfo
         return props.Select(p => p.Children.Count > 0
             ? new TreeNode(
                 $"{p.Name}: {p.TypeName} → {p.Rendering}",
-                null,
-                [..ToTreeNodes(p.Children)])
+                ToTreeNodes(p.Children))
             : new TreeNode($"{p.Name}: {p.TypeName} → {p.Rendering}")
         ).ToList();
     }

--- a/src/Markout/TreeNode.cs
+++ b/src/Markout/TreeNode.cs
@@ -25,21 +25,13 @@ public class TreeNode
     public List<TreeNode>? Children { get; set; }
 
     /// <summary>
-    /// Creates a leaf node with optional badge.
+    /// Creates a tree node. Pass <paramref name="children"/> (a list, array, or
+    /// collection expression) to add child nodes, or omit for a leaf. Set
+    /// <see cref="Badge"/> via an object initializer if needed.
     /// </summary>
-    public TreeNode(string text, string? badge = null)
+    public TreeNode(string text, IEnumerable<TreeNode>? children = null)
     {
         Text = text;
-        Badge = badge;
-    }
-
-    /// <summary>
-    /// Creates a tree node with children. Pass null for badge if not needed.
-    /// </summary>
-    public TreeNode(string text, string? badge, params ReadOnlySpan<TreeNode> children)
-    {
-        Text = text;
-        Badge = badge;
-        Children = children.Length > 0 ? [..children] : null;
+        Children = children?.ToList();
     }
 }

--- a/tests/Markout.Tests/DiagramFormatterTests.cs
+++ b/tests/Markout.Tests/DiagramFormatterTests.cs
@@ -21,9 +21,9 @@ public class DiagramFormatterTests
     {
         var orch = MarkoutWriter.Create(new DiagramFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
+            new TreeNode("Root", [
                 new TreeNode("Child A"),
-                new TreeNode("Child B")));
+                new TreeNode("Child B")]));
         var output = orch.ToString();
         Assert.Contains("Root", output);
         Assert.Contains("Child A", output);

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -286,7 +286,7 @@ public class MarkoutWriterTests
     public void MarkdownFormatter_WriteTree_Renders()
     {
         var orch = MarkoutWriter.Create(new MarkdownFormatter());
-        var result = orch.WriteTree(new TreeNode("Root", null, new TreeNode("Child")));
+        var result = orch.WriteTree(new TreeNode("Root", [new TreeNode("Child")]));
         Assert.True(result);
         var output = orch.ToString();
         Assert.Contains("Root", output);

--- a/tests/Markout.Tests/MermaidFormatterTests.cs
+++ b/tests/Markout.Tests/MermaidFormatterTests.cs
@@ -49,9 +49,9 @@ public class MermaidFormatterTests
     {
         var orch = MarkoutWriter.Create(new MermaidFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
+            new TreeNode("Root", [
                 new TreeNode("Child A"),
-                new TreeNode("Child B")));
+                new TreeNode("Child B")]));
         var output = orch.ToString();
         Assert.Contains("graph TD", output);
     }
@@ -61,9 +61,9 @@ public class MermaidFormatterTests
     {
         var orch = MarkoutWriter.Create(new MermaidFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
+            new TreeNode("Root", [
                 new TreeNode("Child A"),
-                new TreeNode("Child B")));
+                new TreeNode("Child B")]));
         var output = orch.ToString();
         Assert.Contains("\"Root\"", output);
         Assert.Contains("\"Child A\"", output);
@@ -75,9 +75,9 @@ public class MermaidFormatterTests
     {
         var orch = MarkoutWriter.Create(new MermaidFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
+            new TreeNode("Root", [
                 new TreeNode("Child A"),
-                new TreeNode("Child B")));
+                new TreeNode("Child B")]));
         var output = orch.ToString();
         // Root is n0, children are n1 and n2
         Assert.Contains("n0 --> n1", output);
@@ -89,9 +89,9 @@ public class MermaidFormatterTests
     {
         var orch = MarkoutWriter.Create(new MermaidFormatter());
         orch.WriteTree(
-            new TreeNode("A", null,
-                new TreeNode("B", null,
-                    new TreeNode("C"))));
+            new TreeNode("A", [
+                new TreeNode("B", [
+                    new TreeNode("C")])]));
         var output = orch.ToString();
         Assert.Contains("\"A\"", output);
         Assert.Contains("\"B\"", output);
@@ -120,7 +120,7 @@ public class MermaidFormatterTests
     {
         var options = new MarkoutWriterOptions { IncludeBadges = true };
         var orch = MarkoutWriter.Create(new MermaidFormatter(), options);
-        orch.WriteTree(new TreeNode("Libraries", "📁"));
+        orch.WriteTree(new TreeNode("Libraries") { Badge = "📁" });
         var output = orch.ToString();
         Assert.Contains("📁 Libraries", output);
     }
@@ -130,7 +130,7 @@ public class MermaidFormatterTests
     {
         var options = new MarkoutWriterOptions { IncludeBadges = false };
         var orch = MarkoutWriter.Create(new MermaidFormatter(), options);
-        orch.WriteTree(new TreeNode("Libraries", "📁"));
+        orch.WriteTree(new TreeNode("Libraries") { Badge = "📁" });
         var output = orch.ToString();
         Assert.DoesNotContain("📁", output);
         Assert.Contains("\"Libraries\"", output);
@@ -189,11 +189,11 @@ public class MermaidFormatterTests
     {
         var orch = MarkoutWriter.Create(new MermaidFormatter());
         orch.WriteTree(
-            new TreeNode("A", null,
+            new TreeNode("A", [
                 new TreeNode("A1"),
-                new TreeNode("A2")),
-            new TreeNode("B", null,
-                new TreeNode("B1")));
+                new TreeNode("A2")]),
+            new TreeNode("B", [
+                new TreeNode("B1")]));
         var output = orch.ToString();
         // 5 nodes total: n0 (A), n1 (A1), n2 (A2), n3 (B), n4 (B1)
         Assert.Contains("n0[", output);

--- a/tests/Markout.Tests/SerializerTests.cs
+++ b/tests/Markout.Tests/SerializerTests.cs
@@ -380,8 +380,8 @@ public class SerializerTests
             Name = "MyClass",
             Kind = "class",
             Members = [
-                new TreeNode("Inherits", null, new TreeNode("BaseClass")),
-                new TreeNode("Properties (2)", null, new TreeNode("string Name"), new TreeNode("int Count"))
+                new TreeNode("Inherits", [new TreeNode("BaseClass")]),
+                new TreeNode("Properties (2)", [new TreeNode("string Name"), new TreeNode("int Count")])
             ]
         };
 
@@ -407,9 +407,9 @@ public class SerializerTests
         {
             Title = "Package Contents",
             Files = [
-                new TreeNode("lib", null,
-                    new TreeNode("net8.0", null, new TreeNode("MyLib.dll")),
-                    new TreeNode("net9.0", null, new TreeNode("MyLib.dll")))
+                new TreeNode("lib", [
+                    new TreeNode("net8.0", [new TreeNode("MyLib.dll")]),
+                    new TreeNode("net9.0", [new TreeNode("MyLib.dll")])])
             ]
         };
 

--- a/tests/Markout.Tests/UnicodeFormatterTests.cs
+++ b/tests/Markout.Tests/UnicodeFormatterTests.cs
@@ -105,9 +105,9 @@ public class UnicodeFormatterTests
         var sw = new StringWriter();
         var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
+            new TreeNode("Root", [
                 new TreeNode("Child A"),
-                new TreeNode("Child B")));
+                new TreeNode("Child B")]));
         var output = sw.ToString();
         Assert.Contains("Root", output);
         Assert.Contains("Child A", output);
@@ -122,10 +122,10 @@ public class UnicodeFormatterTests
         var sw = new StringWriter();
         var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
-                new TreeNode("Parent", null,
+            new TreeNode("Root", [
+                new TreeNode("Parent", [
                     new TreeNode("Child 1"),
-                    new TreeNode("Child 2"))));
+                    new TreeNode("Child 2")])]));
         var output = sw.ToString();
         Assert.Contains("Root", output);
         Assert.Contains("Parent", output);
@@ -141,10 +141,10 @@ public class UnicodeFormatterTests
         var sw = new StringWriter();
         var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteTree(
-            new TreeNode("Root", null,
-                new TreeNode("Parent 1", null,
-                    new TreeNode("Child")),
-                new TreeNode("Parent 2")));
+            new TreeNode("Root", [
+                new TreeNode("Parent 1", [
+                    new TreeNode("Child")]),
+                new TreeNode("Parent 2")]));
         var output = sw.ToString();
         Assert.Contains("│", output); // Vertical line should appear in prefix
     }


### PR DESCRIPTION
Fixes #118.

## Problem

`TreeNode`'s constructor placed a required `badge` argument **between** `text` and its `children`, so the idiomatic call site did not compile — the one built-in shape that broke the pattern set by every other shape. The toxic case is a **collection** of children (trees built from data), which no natural call form could pass without a `[..]` spread or `.ToArray()`.

## Change

Replace the two constructors with a single, intuitive shape (restoring the pre-#79 signature):

```csharp
TreeNode(string text, IEnumerable<TreeNode>? children = null)
```

- **`Badge` → property**, set via object initializer (`new TreeNode("root") { Badge = "📁" }`). It's an optional decorative glyph, absent on most nodes; and `params` can't follow a skippable optional parameter, so badge can't stay a constructor slot once children lead.
- **`children` → `IEnumerable<TreeNode>?`** so leaf, literal, and from-data trees all compile as written:

```csharp
new TreeNode("leaf");                    // ✅ leaf
new TreeNode("root", [child]);           // ✅ collection expression
new TreeNode("root", listFromData);      // ✅ List/array/IEnumerable directly — no spread
```

## Call sites & docs

- Removed the now-unnecessary `[..]`/`.ToArray()` workarounds from the repo's own from-data sites (`LatestCves`, `CanadianContent`, `Demos`, `MarkoutSchemaInfo`).
- Updated literal trees to collection expressions (`Serialization` samples, tests).
- Fixed the non-compiling doc examples: user guide, demo README, and the **package grounding** (`grounding/markout/AGENTS.md`) now shows the correct construction — the grounding is the agent-facing doc where this issue's recovery loop kept surfacing.
- Bumped version to **0.15.0** (breaking API change, pre-1.0).

## Verification

- `dotnet build Markout.sln -c Release` — succeeds (0 warnings).
- Standalone samples (`CanadianContent`, `LatestCves`) build.
- `Markout.Tests` — **544 passed, 0 failed**.
- `markdownlint` clean on changed markdown.