### PR TITLE
Move Coding Agent Integration Guide to a conventional skill (skills/markout)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "markout",
+  "description": "Markout skills for coding assistants",
+  "version": "0.15.0",
+  "author": {
+    "name": "Richard Lander"
+  },
+  "license": "MIT",
+  "keywords": ["dotnet", "markout", "markdown", "serializer"]
+}

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: markout
+version: 0.15.0
+description: Source-generated .NET serializer that renders objects as Markdown (also ANSI terminal, plain text, pretty tables, TSV/JSONL). Use it when a CLI or tool needs structured, human- or agent-readable output instead of hand-built strings; it requires a generated MarkoutSerializerContext and Markout attributes (no reflection fallback).
+---
+
 # Markout — Coding Agent Integration Guide
 
 Markout is a .NET source-generated serializer that turns objects into readable documents and compact tabular output (Markdown, ANSI terminal, plain text, pretty tables, TSV). Use it whenever a CLI tool needs structured output instead of raw `Console.WriteLine`.


### PR DESCRIPTION
The authored `SKILL.md` (the Coding Agent Integration Guide / Textbook) sat at the repo root with no frontmatter — not a valid, discoverable Claude skill. This restructures it to the conventional Anthropic plugin layout, matching [`richlander/dotnet-skills`](https://github.com/richlander/dotnet-skills):

```
.claude-plugin/plugin.json      # plugin manifest
skills/markout/SKILL.md          # the guide, now with name/version/description frontmatter
```

**Why:** `SKILL.md` is an optional, maintainer-authored skill (the Textbook). It is not grounding (that is `AGENTS.md`, which stays under `grounding/`). Making it a proper skill lets tools load it natively and lets the grounding eval consume it as the Textbook arm.

**Please sanity-check the metadata I chose** (adjust freely):
- `plugin.json` version `0.15.0`, keywords, description.
- `SKILL.md` frontmatter `version: 0.15.0` and `description`.

No content changes to the guide itself — only the move + frontmatter.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
