### PR TITLE
Composite-cell shapes for multi-format tables (#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,4 @@ $RECYCLE.BIN/
 *.swp
 artifacts/
 _worktree/
+.worktrees/

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -150,9 +150,18 @@ public readonly record struct Metric(string Label, double Value);
 // Description — a term with explanatory text
 public readonly record struct Description(string Term, string Text, string? Detail = null);
 
-// Composition — a labeled breakdown of proportional parts
-public readonly record struct Segment(string Category, int Count);
-public readonly record struct Breakdown(string Label, Segment[] Segments);
+// Composition — a labeled breakdown of proportional parts (slices of a shared whole)
+public readonly record struct Slice(string Category, int Count);
+public readonly record struct Breakdown(string Label, Slice[] Slices);
+
+// Composite cells — data-only cells that render densely and decompose into typed columns.
+// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit] configure derivation/format.
+public readonly record struct Change<V>(V Before, V After);        // before → after (+ derived delta)
+public readonly record struct Fraction(double Count, double Total); // 24/24
+public readonly record struct Share(double Value, double Whole);    // 5056 (24%)
+public readonly record struct Percent(double Part, double Whole);   // 93%
+public readonly record struct Segment(string Label, double Value);
+public readonly record struct Segments(params Segment[] Parts);     // 21/171/236
 
 // Hierarchy — a recursive node with children
 public class TreeNode { ... }

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -58,11 +58,26 @@ MarkoutSerializer.Serialize(report, Console.Out, ReportContext.Default);
 
 ## Built-in shape types (use as model properties for rich output)
 
-`Metric` (bar chart), `Breakdown`/`Segment` (stacked bar), `Callout` (alert), `TreeNode`
+`Metric` (bar chart), `Breakdown`/`Slice` (stacked bar), `Callout` (alert), `TreeNode`
 (hierarchy), `Description` (term + text), `CodeSection` (code block). e.g. `new Metric("Build", 4.2)`.
 Pass children as a list/array/collection expression, never as trailing arguments:
 `new TreeNode("root", [new TreeNode("leaf")])`. `Badge` is an optional property:
 `new TreeNode("root") { Badge = "📁" }`.
+
+## Composite table cells (dense Markdown + decomposed columns from one model)
+
+Composite cells are data-only scalar properties: `FieldLayout.Table` renders a dense Markdown
+value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from one declaration.
+
+- `Change<V>` — a `before → after` change (NOT `Comparison`, which collides with `System.Comparison<T>`).
+  `[MarkoutDelta(Delta.Percent)]` on a numeric `Change<V>` appends the signed change, e.g.
+  `98555 → 61190 (−38%)`; `Delta.Absolute` appends the signed difference.
+- `Fraction(count, total)` → `24/24`; `Share(value, whole)` → `5056 (24%)`
+  (`[MarkoutUnit("s")]` → `103s (93%)`); `Percent(part, whole)` → `93%`;
+  `Segments(new Segment(label, value), ...)` → `21/171/236` (labels become column names).
+- `Change<V>` nests over composites: `Change<Fraction>`, `Change<Share>`, `Change<Segments>`.
+  A zero denominator renders `—` rather than `NaN`/`Inf`. e.g.
+  `[MarkoutPropertyName("Session IET"), MarkoutDelta(Delta.Percent)] public Change<long> SessionIet { get; init; }`.
 
 ## Other output formats (still Markdown by default)
 

--- a/samples/CanadianContent/CanadianContent.cs
+++ b/samples/CanadianContent/CanadianContent.cs
@@ -300,7 +300,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
             Breakdown = [new Breakdown("All Shows", shows
                 .GroupBy(s => s.Type)
                 .OrderByDescending(g => g.Count())
-                .Select(g => new Segment(g.Key, g.Count()))
+                .Select(g => new Slice(g.Key, g.Count()))
                 .ToArray())]
         };
         MarkoutSerializer.Serialize(view, output, fmt, CanConContext.Default, options);
@@ -331,7 +331,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
             GenreMix = [new Breakdown("All Shows", shows
                 .GroupBy(s => s.Type)
                 .OrderByDescending(g => g.Count())
-                .Select(g => new Segment(g.Key, g.Count()))
+                .Select(g => new Slice(g.Key, g.Count()))
                 .ToArray())],
             FilmographyTree = topActors.Select(actor =>
             {

--- a/samples/DateBars/DateBars.cs
+++ b/samples/DateBars/DateBars.cs
@@ -19,11 +19,11 @@ var view = new DateProgress
     Title = $"{icon}  {now:dddd, MMMM d, yyyy — h:mm tt}",
     Progress =
     [
-        new Breakdown("Month",  [new Segment("Elapsed", now.Month),     new Segment("Remaining", 12 - now.Month)]),
-        new Breakdown("Day",    [new Segment("Elapsed", now.Day),       new Segment("Remaining", daysInMonth - now.Day)]),
-        new Breakdown("Year",   [new Segment("Elapsed", now.DayOfYear), new Segment("Remaining", daysInYear - now.DayOfYear)]),
-        new Breakdown("Hour",   [new Segment("Elapsed", now.Hour),      new Segment("Remaining", 24 - now.Hour)]),
-        new Breakdown("Minute", [new Segment("Elapsed", now.Minute),    new Segment("Remaining", 60 - now.Minute)]),
+        new Breakdown("Month",  [new Slice("Elapsed", now.Month),     new Slice("Remaining", 12 - now.Month)]),
+        new Breakdown("Day",    [new Slice("Elapsed", now.Day),       new Slice("Remaining", daysInMonth - now.Day)]),
+        new Breakdown("Year",   [new Slice("Elapsed", now.DayOfYear), new Slice("Remaining", daysInYear - now.DayOfYear)]),
+        new Breakdown("Hour",   [new Slice("Elapsed", now.Hour),      new Slice("Remaining", 24 - now.Hour)]),
+        new Breakdown("Minute", [new Slice("Elapsed", now.Minute),    new Slice("Remaining", 60 - now.Minute)]),
     ]
 };
 

--- a/samples/DotNetReleases/DotNetReleases.cs
+++ b/samples/DotNetReleases/DotNetReleases.cs
@@ -24,7 +24,7 @@ var view = new ReleasesView
     TypeBreakdown = [new Breakdown("Release Types", releases
         .GroupBy(r => r.ReleaseType?.ToUpperInvariant() ?? "UNKNOWN")
         .OrderByDescending(g => g.Count())
-        .Select(g => new Segment(g.Key, g.Count()))
+        .Select(g => new Slice(g.Key, g.Count()))
         .ToArray())],
     Releases = releases.Select(r => new ReleaseRow
     {

--- a/samples/GitHubRepo/GitHubRepo.cs
+++ b/samples/GitHubRepo/GitHubRepo.cs
@@ -117,7 +117,7 @@ async Task Run(ParseResult parseResult, CancellationToken ct)
             ? [new Breakdown("By bytes", languages
                 .OrderByDescending(kv => kv.Value)
                 .Take(maxLanguages)
-                .Select(kv => new Segment(kv.Key, (int)(kv.Value * 100 / totalBytes)))
+                .Select(kv => new Slice(kv.Key, (int)(kv.Value * 100 / totalBytes)))
                 .ToArray())]
             : null,
         ContributorMetrics = useMetrics ? contributors

--- a/samples/LatestCves/LatestCves.cs
+++ b/samples/LatestCves/LatestCves.cs
@@ -102,7 +102,7 @@ var view = new CveReport
         ? new Callout(CalloutSeverity.Caution, $"{criticalCount} critical severity CVE(s) found. Update affected runtimes immediately.")
         : default,
     SeverityBreakdown = severityCounts.Count > 0
-        ? [new Breakdown("By Severity", severityCounts.Select(kv => new Segment(kv.Key, kv.Value)).ToArray())]
+        ? [new Breakdown("By Severity", severityCounts.Select(kv => new Slice(kv.Key, kv.Value)).ToArray())]
         : null,
     Releases = tree
 };

--- a/samples/Serialization/ShapeGallery.cs
+++ b/samples/Serialization/ShapeGallery.cs
@@ -74,9 +74,9 @@ public static class ShapeGallery
         writer.WriteHeading(2, "Code Breakdown");
         writer.WriteBreakdown([
             new Breakdown("By Language", [
-                new Segment("C#", 85),
-                new Segment("MSBuild", 10),
-                new Segment("JSON", 5),
+                new Slice("C#", 85),
+                new Slice("MSBuild", 10),
+                new Slice("JSON", 5),
             ]),
         ]);
 

--- a/samples/Serialization/ShapeGallery.cs
+++ b/samples/Serialization/ShapeGallery.cs
@@ -9,7 +9,7 @@ namespace Markout.Samples.Serialization;
 public static class ShapeGallery
 {
     /// <summary>
-    /// Renders all ten data relationships through the writer API.
+    /// Renders the built-in data relationships through the writer API.
     /// </summary>
     public static void WriteAllShapes()
     {
@@ -79,6 +79,16 @@ public static class ShapeGallery
                 new Slice("JSON", 5),
             ]),
         ]);
+
+        // Composite cells — dense in Markdown, decomposed into typed columns in TSV/JSONL
+        writer.WriteHeading(2, "Quality Card");
+        writer.WriteCompositeTable(
+            new("tasks correct", new Change<Fraction>(new Fraction(24, 24), new Fraction(24, 24))),
+            new("tool calls: web / bash / other", new Change<Segments>(
+                new Segments(new Segment("web", 21), new Segment("bash", 171), new Segment("other", 236)),
+                new Segments(new Segment("web", 0), new Segment("bash", 75), new Segment("other", 183)))),
+            new("output tok (% of IET)", new Change<Share>(new Share(5056, 21067), new Share(3129, 13037))),
+            new("Session IET", new Change<long>(98555, 61190), new MarkoutCellFormat(Delta.Percent)));
 
         // Hierarchy — tree
         writer.WriteHeading(2, "Project Structure");

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -132,7 +132,7 @@ public List<Metric>? Metrics { get; set; }
 [MarkoutSection(Name = "Distribution")]
 [MarkoutIgnoreInTable]
 public List<Breakdown>? Distribution { get; set; }
-// Usage: new Breakdown("By Type", [new Segment("Critical", 3), new Segment("Low", 12)])
+// Usage: new Breakdown("By Type", [new Slice("Critical", 3), new Slice("Low", 12)])
 
 // Alert box
 [MarkoutIgnoreInTable]
@@ -156,6 +156,61 @@ public List<Description>? Terms { get; set; }
 public CodeSection? SourceCode { get; set; }
 // Usage: new CodeSection("csharp", "public class Foo { }")
 ```
+
+## Composite Table Cells (one model → dense Markdown + decomposed columns)
+
+Composite cells are data-only value types used as **scalar properties**. With
+`FieldLayout.Table` (the default) each property becomes a row: Markdown renders a dense,
+human-readable value, while `TableFormatter` (TSV/JSONL) decomposes the same cell into typed
+columns — no pre-stringifying, one declaration serves both.
+
+| Shape | Dense Markdown | Decomposed columns |
+|---|---|---|
+| `Change<V>` (+`[MarkoutDelta(Delta.Percent)]`) | `98555 → 61190 (−38%)` | `before`, `after`, `delta_pct` |
+| `Fraction(count, total)` | `24/24` | `count`, `total` |
+| `Share(value, whole)` (+`[MarkoutUnit("s")]`) | `5056 (24%)` / `103s (93%)` | `value`, `pct` |
+| `Percent(part, whole)` | `93%` | `pct` |
+| `Segments(Segment(label, value)…)` | `21/171/236` | one column per `label` |
+| `Change<Segments>` | `21/171/236 → 0/75/183` | `{label}_before`, `{label}_after` |
+| `Change<Fraction>` | `24/24 → 24/24` | `before_count`, `before_total`, `after_count`, `after_total` |
+
+`Change<V>` is named `Change` (not `Comparison`) to avoid colliding with `System.Comparison<T>`.
+A zero denominator renders `—` instead of `NaN`/`Inf`.
+
+```csharp
+[MarkoutSerializable]   // FieldLayout.Table is the default — properties become rows
+public class QualityCard
+{
+    [MarkoutPropertyName("tasks correct")]
+    public Change<Fraction> TasksCorrect { get; set; }              // 24/24 → 24/24
+
+    [MarkoutPropertyName("tool calls: web / bash / other")]
+    public Change<Segments> ToolCalls { get; set; }                 // 21/171/236 → 0/75/183
+
+    [MarkoutPropertyName("tool-turn secs (% of turn time)"), MarkoutUnit("s")]
+    public Change<Share> ToolTurnSecs { get; set; }                 // 103s (93%) → 61s (90%)
+
+    [MarkoutPropertyName("Session IET"), MarkoutDelta(Delta.Percent)]
+    public Change<long> SessionIet { get; set; }                    // 98555 → 61190 (−38%)
+
+    public string? Verdict { get; set; }                            // BETTER
+}
+
+[MarkoutContext(typeof(QualityCard))]
+public partial class QualityCardContext : MarkoutSerializerContext { }
+
+// Dense Markdown table:
+MarkoutSerializer.Serialize(card, Console.Out, QualityCardContext.Default);
+
+// Same rows, decomposed to JSONL — one record per property, typed columns:
+var jsonl = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl };
+MarkoutSerializer.Serialize(card, Console.Out, new TableFormatter(), QualityCardContext.Default, jsonl);
+// {"field":"Session IET","before":"98555","after":"61190","delta_pct":"-38", ...}
+// {"field":"tool calls: web / bash / other","web_before":"21","bash_before":"171", ...}
+```
+
+Composite cells derive only intrinsics (delta from before/after, percent from part/whole).
+Markout does not aggregate or bind external data — hand it already-correct values.
 
 ## Choosing a Formatter
 

--- a/src/Markout.Ansi.Spectre/SpectreFormatter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreFormatter.cs
@@ -275,8 +275,8 @@ public class SpectreFormatter : IMarkoutFormatter,
 
     void IMetricsFormatter.FormatBreakdown(TextWriter w, IReadOnlyList<Breakdown> items, int? maxBarWidth, bool uniformBarWidth, MarkoutWriterOptions options)
     {
-        var categories = items.SelectMany(b => b.Segments).Select(s => s.Category).Distinct().ToList();
-        var maxTotal = items.Max(b => b.Segments.Sum(s => s.Count));
+        var categories = items.SelectMany(b => b.Slices).Select(s => s.Category).Distinct().ToList();
+        var maxTotal = items.Max(b => b.Slices.Sum(s => s.Count));
         if (maxTotal == 0) return;
 
         var labelWidth = items.Max(b => b.Label.Length);
@@ -289,7 +289,7 @@ public class SpectreFormatter : IMarkoutFormatter,
             SgrBold(w, item.Label.PadRight(labelWidth));
             w.Write("  ");
             var bw = 0;
-            foreach (var seg in item.Segments)
+            foreach (var seg in item.Slices)
             {
                 var catIndex = categories.IndexOf(seg.Category);
                 Sgr(w, DistributionSgrColors[catIndex % DistributionSgrColors.Length]);
@@ -301,7 +301,7 @@ public class SpectreFormatter : IMarkoutFormatter,
             if (maxBarChars > bw) w.Write(new string(' ', maxBarChars - bw));
             w.Write("  ");
             Sgr(w, SgrDarkGray);
-            w.Write(string.Join(", ", item.Segments.Where(s => s.Count > 0).Select(s => $"{s.Count} {s.Category}")));
+            w.Write(string.Join(", ", item.Slices.Where(s => s.Count > 0).Select(s => $"{s.Count} {s.Category}")));
             SgrReset(w);
             w.WriteLine();
         }

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -13,6 +13,10 @@ internal static class EmitHelpers
     {
         var access = nullable ? $"{propAccess}.Value" : propAccess;
 
+        // Composite cell: render its dense, human-readable form
+        if (prop.Kind == PropertyKind.CompositeCell)
+            return $"global::Markout.MarkoutCell.ToInlineString({access}, {DeltaLiteral(prop)}, {UnitLiteral(prop)})";
+
         // Value formatter takes highest priority
         if (prop.ValueFormatterTypeName != null)
         {
@@ -128,6 +132,10 @@ internal static class EmitHelpers
 
     private static string GetTableCellValueCore(PropertyMetadata prop, string propAccess, string itemExpr)
     {
+        // Composite cell in a table column renders its dense form (no per-column decomposition).
+        if (prop.Kind == PropertyKind.CompositeCell)
+            return $"global::Markout.MarkoutCell.ToInlineString({propAccess}, {DeltaLiteral(prop)}, {UnitLiteral(prop)})";
+
         if (prop.IsNullableValueType)
         {
             if (prop.ValueFormatterTypeName != null)
@@ -336,6 +344,18 @@ internal static class EmitHelpers
                (prop.Kind == PropertyKind.StringArray || prop.Kind == PropertyKind.ComplexArray);
     }
 
+    /// <summary>Emits the runtime Markout.Delta enum literal for a composite cell property.</summary>
+    public static string DeltaLiteral(PropertyMetadata prop) => prop.DeltaMode switch
+    {
+        MarkoutDeltaKind.Percent => "global::Markout.Delta.Percent",
+        MarkoutDeltaKind.Absolute => "global::Markout.Delta.Absolute",
+        _ => "global::Markout.Delta.None"
+    };
+
+    /// <summary>Emits the unit string literal (or <c>null</c>) for a composite cell property.</summary>
+    public static string UnitLiteral(PropertyMetadata prop)
+        => prop.Unit == null ? "null" : $"\"{EscapeString(prop.Unit)}\"";
+
     public static bool IsScalarKind(PropertyKind kind)
     {
         return kind is
@@ -347,7 +367,8 @@ internal static class EmitHelpers
             PropertyKind.Decimal or
             PropertyKind.DateTime or
             PropertyKind.DateTimeOffset or
-            PropertyKind.Enum;
+            PropertyKind.Enum or
+            PropertyKind.CompositeCell;
     }
 
     public static string EscapeString(string s)

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -419,10 +419,12 @@ internal static class EmitHelpers
             PropertyKind.StringArray => $"{propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0",
             PropertyKind.Formattable => $"{propAccess} != null",
             // Non-nullable value types (bool, int, etc.) are never null — no condition needed
+            // Reference-type composite cells can be null; value-type ones never are.
+            PropertyKind.CompositeCell => prop.IsReferenceTypeCell ? $"{propAccess} != null" : null,
             PropertyKind.Boolean or PropertyKind.Int32 or PropertyKind.Int64
                 or PropertyKind.Double or PropertyKind.Decimal
                 or PropertyKind.DateTime or PropertyKind.DateTimeOffset
-                or PropertyKind.Enum or PropertyKind.CompositeCell => null,
+                or PropertyKind.Enum => null,
             _ => $"{propAccess} != null"
         };
     }

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -444,7 +444,8 @@ internal static class EmitHelpers
             PropertyKind.Double or PropertyKind.Decimal => $"{propAccess} != 0",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset => $"{propAccess} != default",
             PropertyKind.Enum => $"{propAccess} != default({prop.TypeName})",
-            PropertyKind.CompositeCell => $"!{propAccess}.Equals(default({prop.TypeName}))",
+            // Null-safe for both value-type and reference-type IMarkoutCell implementations.
+            PropertyKind.CompositeCell => $"!global::System.Collections.Generic.EqualityComparer<{prop.TypeName}>.Default.Equals({propAccess}, default({prop.TypeName}))",
             PropertyKind.StringArray => $"{propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0",
             PropertyKind.Formattable => $"{propAccess} != null",
             _ => $"{propAccess} != null"

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -422,7 +422,7 @@ internal static class EmitHelpers
             PropertyKind.Boolean or PropertyKind.Int32 or PropertyKind.Int64
                 or PropertyKind.Double or PropertyKind.Decimal
                 or PropertyKind.DateTime or PropertyKind.DateTimeOffset
-                or PropertyKind.Enum => null,
+                or PropertyKind.Enum or PropertyKind.CompositeCell => null,
             _ => $"{propAccess} != null"
         };
     }
@@ -444,6 +444,7 @@ internal static class EmitHelpers
             PropertyKind.Double or PropertyKind.Decimal => $"{propAccess} != 0",
             PropertyKind.DateTime or PropertyKind.DateTimeOffset => $"{propAccess} != default",
             PropertyKind.Enum => $"{propAccess} != default({prop.TypeName})",
+            PropertyKind.CompositeCell => $"!{propAccess}.Equals(default({prop.TypeName}))",
             PropertyKind.StringArray => $"{propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0",
             PropertyKind.Formattable => $"{propAccess} != null",
             _ => $"{propAccess} != null"

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -173,6 +173,15 @@ internal static class FieldEmitter
         string? sectionHeading = null,
         int sectionLevel = 2)
     {
+        // Composite-cell shapes render as a dense table (Markdown) that decomposes into
+        // typed columns for structured formatters. Route the whole field set through the
+        // composite-card path so composite and plain rows share one table.
+        if (scalarProps.Any(p => p.Kind == PropertyKind.CompositeCell))
+        {
+            EmitCompositeCard(sb, scalarProps, valueExpr, indentLevel, nestingDepth, sectionHeading, sectionLevel);
+            return;
+        }
+
         var indent = new string(' ', indentLevel * 4);
         bool useBuilder = scalarProps.Any(p => p.IsNullableValueType || p.Kind == PropertyKind.String
             || EmitHelpers.IsJoinedArray(p)
@@ -272,6 +281,121 @@ internal static class FieldEmitter
             if (sectionHeading != null)
                 sb.AppendLine($"{indent}writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
             sb.AppendLine($"{indent}writer.WriteFieldsTable(new global::Markout.MarkoutField[] {{ {string.Join(", ", fields)} }});");
+        }
+    }
+
+    /// <summary>
+    /// Emits a composite-cell table: builds a <c>List&lt;MarkoutCompositeRow&gt;</c> from composite
+    /// and plain scalar properties, then calls <c>writer.WriteCompositeTable(...)</c>. The writer
+    /// renders a dense <c>Field | Value</c> table for document formatters and decomposes each cell
+    /// into typed columns for structured formatters.
+    /// </summary>
+    private static void EmitCompositeCard(
+        StringBuilder sb,
+        List<PropertyMetadata> scalarProps,
+        string valueExpr,
+        int indentLevel,
+        int nestingDepth,
+        string? sectionHeading,
+        int sectionLevel)
+    {
+        var indent = new string(' ', indentLevel * 4);
+        var rowsVar = nestingDepth == 0 ? "__cells" : $"__cells{nestingDepth}";
+
+        sb.AppendLine($"{indent}var {rowsVar} = new global::System.Collections.Generic.List<global::Markout.MarkoutCompositeRow>();");
+
+        foreach (var prop in scalarProps)
+        {
+            var propAccess = $"{valueExpr}.{prop.Name}";
+            var fieldIndent = indent;
+
+            if (prop.ShowWhenProperty != null)
+            {
+                sb.AppendLine($"{indent}if ({valueExpr}.{prop.ShowWhenProperty})");
+                sb.AppendLine($"{indent}{{");
+                fieldIndent = indent + "    ";
+            }
+
+            if (prop.Kind == PropertyKind.CompositeCell)
+            {
+                var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)})";
+                sb.AppendLine($"{fieldIndent}{rowsVar}.Add(new global::Markout.MarkoutCompositeRow(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}, {format}));");
+            }
+            else
+            {
+                EmitScalarCompositeRow(sb, prop, propAccess, rowsVar, fieldIndent);
+            }
+
+            if (prop.ShowWhenProperty != null)
+                sb.AppendLine($"{indent}}}");
+        }
+
+        sb.AppendLine($"{indent}if ({rowsVar}.Count > 0)");
+        sb.AppendLine($"{indent}{{");
+        if (sectionHeading != null)
+            sb.AppendLine($"{indent}    writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
+        sb.AppendLine($"{indent}    writer.WriteCompositeTable(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({rowsVar}));");
+        sb.AppendLine($"{indent}}}");
+    }
+
+    /// <summary>
+    /// Emits a plain scalar property as a <c>MarkoutCompositeRow.Scalar(...)</c> so it can share a
+    /// table with composite rows. Mirrors the field-table null/empty/skip guards.
+    /// </summary>
+    private static void EmitScalarCompositeRow(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string rowsVar,
+        string indent)
+    {
+        string RowAdd(string valueStr) =>
+            $"{rowsVar}.Add(global::Markout.MarkoutCompositeRow.Scalar(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));";
+
+        if (prop.IsNullableValueType)
+        {
+            var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess, nullable: true);
+            sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+            sb.AppendLine($"{indent}    {RowAdd(valueStr)}");
+        }
+        else if (prop.Kind == PropertyKind.String)
+        {
+            var valueStr = EmitHelpers.WrapWithValueMap(prop, propAccess);
+            sb.AppendLine($"{indent}if (!string.IsNullOrEmpty({propAccess}))");
+            sb.AppendLine($"{indent}    {RowAdd(valueStr)}");
+        }
+        else if (EmitHelpers.IsJoinedArray(prop))
+        {
+            var countProp = prop.IsArray ? "Length" : "Count";
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{countProp} > 0)");
+            sb.AppendLine($"{indent}    {RowAdd(EmitHelpers.GetScalarValueExpression(prop, propAccess))}");
+        }
+        else
+        {
+            var valueStr = EmitHelpers.GetScalarValueExpression(prop, propAccess);
+            if (prop.SkipWhenDefault)
+            {
+                var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
+                sb.AppendLine($"{indent}if ({condition})");
+                sb.AppendLine($"{indent}    {RowAdd(valueStr)}");
+            }
+            else if (prop.SkipWhenNull)
+            {
+                var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
+                if (condition != null)
+                {
+                    sb.AppendLine($"{indent}if ({condition})");
+                    sb.AppendLine($"{indent}    {RowAdd(valueStr)}");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}{RowAdd(valueStr)}");
+                }
+            }
+            else
+            {
+                sb.AppendLine($"{indent}{RowAdd(valueStr)}");
+            }
         }
     }
 

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -318,8 +318,7 @@ internal static class FieldEmitter
 
             if (prop.Kind == PropertyKind.CompositeCell)
             {
-                var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)})";
-                sb.AppendLine($"{fieldIndent}{rowsVar}.Add(new global::Markout.MarkoutCompositeRow(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {propAccess}, {format}));");
+                EmitCompositeCellRow(sb, prop, propAccess, rowsVar, fieldIndent);
             }
             else
             {
@@ -336,6 +335,54 @@ internal static class FieldEmitter
             sb.AppendLine($"{indent}    writer.WriteHeading({sectionLevel}, \"{EmitHelpers.EscapeString(sectionHeading)}\");");
         sb.AppendLine($"{indent}    writer.WriteCompositeTable(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({rowsVar}));");
         sb.AppendLine($"{indent}}}");
+    }
+
+    /// <summary>
+    /// Emits a composite-cell property as a <c>MarkoutCompositeRow</c>, honoring nullable and
+    /// skip guards so a null/default composite is not rendered as a blank row.
+    /// </summary>
+    private static void EmitCompositeCellRow(
+        StringBuilder sb,
+        PropertyMetadata prop,
+        string propAccess,
+        string rowsVar,
+        string indent)
+    {
+        var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)})";
+
+        string RowAdd(string cellExpr) =>
+            $"{rowsVar}.Add(new global::Markout.MarkoutCompositeRow(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {cellExpr}, {format}));";
+
+        if (prop.IsNullableValueType)
+        {
+            // Nullable composite: the underlying struct boxes cleanly to IMarkoutCell.
+            var valueExpr = $"{propAccess}.Value";
+            sb.AppendLine($"{indent}if ({propAccess}.HasValue)");
+            sb.AppendLine($"{indent}    {RowAdd(valueExpr)}");
+        }
+        else if (prop.SkipWhenDefault)
+        {
+            var condition = EmitHelpers.GetNonDefaultCondition(prop, propAccess);
+            sb.AppendLine($"{indent}if ({condition})");
+            sb.AppendLine($"{indent}    {RowAdd(propAccess)}");
+        }
+        else if (prop.SkipWhenNull)
+        {
+            var condition = EmitHelpers.GetNonNullCondition(prop, propAccess);
+            if (condition != null)
+            {
+                sb.AppendLine($"{indent}if ({condition})");
+                sb.AppendLine($"{indent}    {RowAdd(propAccess)}");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}{RowAdd(propAccess)}");
+            }
+        }
+        else
+        {
+            sb.AppendLine($"{indent}{RowAdd(propAccess)}");
+        }
     }
 
     /// <summary>

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -322,7 +322,7 @@ internal static class FieldEmitter
             }
             else
             {
-                EmitScalarCompositeRow(sb, prop, propAccess, rowsVar, fieldIndent);
+                EmitScalarCompositeRow(sb, prop, propAccess, valueExpr, rowsVar, fieldIndent);
             }
 
             if (prop.ShowWhenProperty != null)
@@ -393,11 +393,15 @@ internal static class FieldEmitter
         StringBuilder sb,
         PropertyMetadata prop,
         string propAccess,
+        string valueExpr,
         string rowsVar,
         string indent)
     {
-        string RowAdd(string valueStr) =>
-            $"{rowsVar}.Add(global::Markout.MarkoutCompositeRow.Scalar(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {valueStr}));";
+        string RowAdd(string valueStr)
+        {
+            var linked = EmitHelpers.WrapWithLink(prop, valueStr, valueExpr);
+            return $"{rowsVar}.Add(global::Markout.MarkoutCompositeRow.Scalar(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {linked}));";
+        }
 
         if (prop.IsNullableValueType)
         {

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -31,6 +31,16 @@ internal sealed class KnownTypeSymbols
     private INamedTypeSymbol? _breakdown;
     private bool _breakdownResolved;
 
+    private INamedTypeSymbol? _markoutCell;
+    private bool _markoutCellResolved;
+
+    private INamedTypeSymbol? _markoutDeltaAttribute;
+    private bool _markoutDeltaAttributeResolved;
+
+    private INamedTypeSymbol? _markoutUnitAttribute;
+    private bool _markoutUnitAttributeResolved;
+
+
     private INamedTypeSymbol? _dateTime;
     private bool _dateTimeResolved;
 
@@ -58,6 +68,9 @@ internal sealed class KnownTypeSymbols
     public INamedTypeSymbol? CodeSection => Resolve(ref _codeSection, ref _codeSectionResolved, "Markout.CodeSection");
     public INamedTypeSymbol? Callout => Resolve(ref _callout, ref _calloutResolved, "Markout.Callout");
     public INamedTypeSymbol? Breakdown => Resolve(ref _breakdown, ref _breakdownResolved, "Markout.Breakdown");
+    public INamedTypeSymbol? IMarkoutCell => Resolve(ref _markoutCell, ref _markoutCellResolved, "Markout.IMarkoutCell");
+    public INamedTypeSymbol? MarkoutDeltaAttribute => Resolve(ref _markoutDeltaAttribute, ref _markoutDeltaAttributeResolved, "Markout.MarkoutDeltaAttribute");
+    public INamedTypeSymbol? MarkoutUnitAttribute => Resolve(ref _markoutUnitAttribute, ref _markoutUnitAttributeResolved, "Markout.MarkoutUnitAttribute");
     public INamedTypeSymbol? DateTime => Resolve(ref _dateTime, ref _dateTimeResolved, "System.DateTime");
     public INamedTypeSymbol? DateTimeOffset => Resolve(ref _dateTimeOffset, ref _dateTimeOffsetResolved, "System.DateTimeOffset");
     public INamedTypeSymbol? IDictionary => Resolve(ref _iDictionary, ref _iDictionaryResolved, "System.Collections.Generic.IDictionary`2");

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -180,6 +180,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public IReadOnlyList<(string Key, string Value)>? ValueMap { get; }
     public bool IsUnwrapped { get; }
     public string? SectionEmptyText { get; }
+    public MarkoutDeltaKind DeltaMode { get; }
+    public string? Unit { get; }
 
     public PropertyMetadata(
         string name,
@@ -226,7 +228,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? linkTextProperty = null,
         IReadOnlyList<(string Key, string Value)>? valueMap = null,
         bool isUnwrapped = false,
-        string? sectionEmptyText = null)
+        string? sectionEmptyText = null,
+        MarkoutDeltaKind deltaMode = MarkoutDeltaKind.None,
+        string? unit = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -273,6 +277,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         ValueMap = valueMap;
         IsUnwrapped = isUnwrapped;
         SectionEmptyText = sectionEmptyText;
+        DeltaMode = deltaMode;
+        Unit = unit;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -323,6 +329,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                ValueMapEqual(ValueMap, other.ValueMap) &&
                IsUnwrapped == other.IsUnwrapped &&
                SectionEmptyText == other.SectionEmptyText &&
+               DeltaMode == other.DeltaMode &&
+               Unit == other.Unit &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -358,6 +366,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (ValueMap?.Count ?? 0);
             hash = hash * 397 ^ IsUnwrapped.GetHashCode();
             hash = hash * 397 ^ (SectionEmptyText?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (int)DeltaMode;
+            hash = hash * 397 ^ (Unit?.GetHashCode() ?? 0);
             return hash;
         }
     }
@@ -458,5 +468,16 @@ internal enum PropertyKind
     CodeSection,
     Callout,
     Breakdown,
+    CompositeCell,
     Other
+}
+
+/// <summary>
+/// Internal representation of Markout.Delta. Values mirror the runtime enum.
+/// </summary>
+internal enum MarkoutDeltaKind
+{
+    None = 0,
+    Percent = 1,
+    Absolute = 2
 }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -182,6 +182,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? SectionEmptyText { get; }
     public MarkoutDeltaKind DeltaMode { get; }
     public string? Unit { get; }
+    public bool IsReferenceTypeCell { get; }
 
     public PropertyMetadata(
         string name,
@@ -230,7 +231,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         bool isUnwrapped = false,
         string? sectionEmptyText = null,
         MarkoutDeltaKind deltaMode = MarkoutDeltaKind.None,
-        string? unit = null)
+        string? unit = null,
+        bool isReferenceTypeCell = false)
     {
         Name = name;
         DisplayName = displayName;
@@ -279,6 +281,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         SectionEmptyText = sectionEmptyText;
         DeltaMode = deltaMode;
         Unit = unit;
+        IsReferenceTypeCell = isReferenceTypeCell;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -331,6 +334,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                SectionEmptyText == other.SectionEmptyText &&
                DeltaMode == other.DeltaMode &&
                Unit == other.Unit &&
+               IsReferenceTypeCell == other.IsReferenceTypeCell &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -368,6 +372,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionEmptyText?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (int)DeltaMode;
             hash = hash * 397 ^ (Unit?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ IsReferenceTypeCell.GetHashCode();
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -489,6 +489,10 @@ internal static class TypeParser
             ));
         }
 
+        // Reference-type IMarkoutCell implementations need null guards for skip attributes
+        // (built-in composite shapes are value types and never null).
+        bool isReferenceTypeCell = kind == PropertyKind.CompositeCell && prop.Type.IsReferenceType;
+
         return new PropertyMetadata(
             prop.Name,
             displayName,
@@ -536,7 +540,8 @@ internal static class TypeParser
             isUnwrapped,
             sectionEmptyText,
             deltaMode,
-            unit);
+            unit,
+            isReferenceTypeCell);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -31,6 +31,8 @@ internal static class TypeParser
     private const string MarkoutValueMapAttribute = "Markout.MarkoutValueMapAttribute";
     private const string MarkoutUnwrapAttribute = "Markout.MarkoutUnwrapAttribute";
     private const string MarkoutIgnoreColumnWhenAttribute = "Markout.MarkoutIgnoreColumnWhenAttribute";
+    private const string MarkoutDeltaAttribute = "Markout.MarkoutDeltaAttribute";
+    private const string MarkoutUnitAttribute = "Markout.MarkoutUnitAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -440,6 +442,26 @@ internal static class TypeParser
                 valueMap = entries;
         }
 
+        // Parse [MarkoutDelta] — derived-change mode for a numeric Comparison<> cell
+        MarkoutDeltaKind deltaMode = MarkoutDeltaKind.None;
+        var deltaAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutDeltaAttribute);
+        if (deltaAttr != null && deltaAttr.ConstructorArguments.Length > 0 &&
+            deltaAttr.ConstructorArguments[0].Value is int deltaValue)
+        {
+            deltaMode = (MarkoutDeltaKind)deltaValue;
+        }
+
+        // Parse [MarkoutUnit] — unit suffix for a Share cell value
+        string? unit = null;
+        var unitAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutUnitAttribute);
+        if (unitAttr != null && unitAttr.ConstructorArguments.Length > 0 &&
+            unitAttr.ConstructorArguments[0].Value is string unitValue)
+        {
+            unit = unitValue;
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -512,7 +534,9 @@ internal static class TypeParser
             linkTextProperty,
             valueMap,
             isUnwrapped,
-            sectionEmptyText);
+            sectionEmptyText,
+            deltaMode,
+            unit);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)
@@ -554,6 +578,11 @@ internal static class TypeParser
         // Callout type - renders as admonition block
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.Callout))
             return (PropertyKind.Callout, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+
+        // Composite-cell shapes (Comparison<>, Fraction, Share, Percent, Segments) implement IMarkoutCell
+        if (knownTypes.IMarkoutCell != null &&
+            type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, knownTypes.IMarkoutCell)))
+            return (PropertyKind.CompositeCell, null, null, false, null, null, true, FieldLayoutKind.Table, false);
 
         // Enum types
         if (type.TypeKind == TypeKind.Enum)
@@ -817,7 +846,8 @@ internal static class TypeParser
             PropertyKind.Decimal or 
             PropertyKind.DateTime or 
             PropertyKind.DateTimeOffset or
-            PropertyKind.Enum;
+            PropertyKind.Enum or
+            PropertyKind.CompositeCell;
     }
 
     private static string GetKindDisplayName(PropertyKind kind)

--- a/src/Markout/Attributes/MarkoutDeltaAttribute.cs
+++ b/src/Markout/Attributes/MarkoutDeltaAttribute.cs
@@ -1,0 +1,15 @@
+namespace Markout;
+
+/// <summary>
+/// Appends a derived change to a numeric <see cref="Change{V}"/> cell:
+/// <see cref="Delta.Percent"/> appends the signed percent change
+/// (<c>(After − Before) / Before × 100</c>), and <see cref="Delta.Absolute"/> appends the
+/// signed difference. A zero <c>Before</c> renders a placeholder instead of infinity.
+/// </summary>
+/// <param name="mode">The derived-change mode.</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutDeltaAttribute(Delta mode) : Attribute
+{
+    /// <summary>The derived-change mode to append.</summary>
+    public Delta Mode { get; } = mode;
+}

--- a/src/Markout/Attributes/MarkoutUnitAttribute.cs
+++ b/src/Markout/Attributes/MarkoutUnitAttribute.cs
@@ -1,0 +1,14 @@
+namespace Markout;
+
+/// <summary>
+/// Renders a <see cref="Share"/> value with a unit suffix, e.g. <c>[MarkoutUnit("s")]</c>
+/// turns <c>103 (93%)</c> into <c>103s (93%)</c>. The suffix appears only in the dense form;
+/// the decomposed <c>value</c> column stays numeric.
+/// </summary>
+/// <param name="unit">The unit suffix (e.g. <c>"s"</c>).</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutUnitAttribute(string unit) : Attribute
+{
+    /// <summary>The unit suffix appended to the value.</summary>
+    public string Unit { get; } = unit;
+}

--- a/src/Markout/Breakdown.cs
+++ b/src/Markout/Breakdown.cs
@@ -1,16 +1,16 @@
 namespace Markout;
 
 /// <summary>
-/// A single segment in a breakdown, representing a category and its count.
+/// A single slice in a breakdown: a proportional part of a shared whole.
 /// </summary>
 /// <param name="Category">The category label (e.g., "Critical", "High").</param>
-/// <param name="Count">The number of items in this category.</param>
-public readonly record struct Segment(string Category, int Count);
+/// <param name="Count">The number of items in this slice.</param>
+public readonly record struct Slice(string Category, int Count);
 
 /// <summary>
 /// A labeled breakdown showing the proportional composition of categories.
-/// Used with <see cref="MarkoutWriter.WriteBreakdown"/> to render stacked segments.
+/// Used with <see cref="MarkoutWriter.WriteBreakdown"/> to render stacked slices.
 /// </summary>
 /// <param name="Label">The row label (e.g., "Jan 2025", ".NET 9").</param>
-/// <param name="Segments">The category segments, rendered left-to-right in order.</param>
-public readonly record struct Breakdown(string Label, Segment[] Segments);
+/// <param name="Slices">The category slices, rendered left-to-right in order.</param>
+public readonly record struct Breakdown(string Label, Slice[] Slices);

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -1,0 +1,79 @@
+namespace Markout;
+
+/// <summary>
+/// A <c>before → after</c> change. When <typeparamref name="V"/> is a composite shape
+/// (<see cref="Fraction"/>, <see cref="Share"/>, <see cref="Percent"/>, <see cref="Segments"/>)
+/// the halves render and decompose recursively. When <typeparamref name="V"/> is numeric,
+/// <see cref="MarkoutDeltaAttribute"/> appends a derived change, e.g. <c>98555 → 61190 (−38%)</c>.
+/// </summary>
+/// <typeparam name="V">The compared value type (numeric scalar or a composite shape).</typeparam>
+/// <param name="Before">The value before.</param>
+/// <param name="After">The value after.</param>
+public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
+{
+    /// <inheritdoc/>
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+    {
+        if (Before is IMarkoutCell beforeCell && After is IMarkoutCell afterCell)
+        {
+            beforeCell.FormatInline(writer, format);
+            writer.Write(CellText.Arrow);
+            afterCell.FormatInline(writer, format);
+            return;
+        }
+
+        writer.Write(CellText.Scalar(Before));
+        writer.Write(CellText.Arrow);
+        writer.Write(CellText.Scalar(After));
+
+        if (format.Delta == Delta.None)
+            return;
+
+        writer.Write(" (");
+        writer.Write(DeltaSuffix(format.Delta));
+        writer.Write(')');
+    }
+
+    /// <inheritdoc/>
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+    {
+        if (Before is IMarkoutCell beforeCell && After is IMarkoutCell afterCell)
+        {
+            beforeCell.Decompose(fields, "before", format);
+            afterCell.Decompose(fields, "after", format);
+            return;
+        }
+
+        fields.Add(new MarkoutField("before", CellText.Scalar(Before)));
+        fields.Add(new MarkoutField("after", CellText.Scalar(After)));
+
+        if (format.Delta == Delta.Percent)
+            fields.Add(new MarkoutField("deltaPct", DeltaValue(Delta.Percent)));
+        else if (format.Delta == Delta.Absolute)
+            fields.Add(new MarkoutField("deltaAbs", DeltaValue(Delta.Absolute)));
+    }
+
+    private string DeltaSuffix(Delta mode)
+    {
+        if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
+            return CellText.Placeholder;
+        return mode switch
+        {
+            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / before * 100),
+            Delta.Absolute => CellText.SignedNumber(after - before),
+            _ => CellText.Placeholder
+        };
+    }
+
+    private string DeltaValue(Delta mode)
+    {
+        if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
+            return CellText.Placeholder;
+        return mode switch
+        {
+            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / before * 100),
+            Delta.Absolute => CellText.Number(after - before),
+            _ => CellText.Placeholder
+        };
+    }
+}

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -14,11 +14,13 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
     {
-        if (Before is IMarkoutCell beforeCell && After is IMarkoutCell afterCell)
+        // If either half is a composite shape, render both as shapes (a null half writes nothing)
+        // so a nullable composite side never leaks a struct ToString via the scalar path.
+        if (Before is IMarkoutCell || After is IMarkoutCell)
         {
-            beforeCell.FormatInline(writer, format);
+            (Before as IMarkoutCell)?.FormatInline(writer, format);
             writer.Write(CellText.Arrow);
-            afterCell.FormatInline(writer, format);
+            (After as IMarkoutCell)?.FormatInline(writer, format);
             return;
         }
 
@@ -37,10 +39,10 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
     /// <inheritdoc/>
     public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
     {
-        if (Before is IMarkoutCell beforeCell && After is IMarkoutCell afterCell)
+        if (Before is IMarkoutCell || After is IMarkoutCell)
         {
-            beforeCell.Decompose(fields, CellText.SideKey(side, "before"), format);
-            afterCell.Decompose(fields, CellText.SideKey(side, "after"), format);
+            (Before as IMarkoutCell)?.Decompose(fields, CellText.SideKey(side, "before"), format);
+            (After as IMarkoutCell)?.Decompose(fields, CellText.SideKey(side, "after"), format);
             return;
         }
 
@@ -59,7 +61,8 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             return CellText.Placeholder;
         return mode switch
         {
-            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / before * 100),
+            // Divide by |before| so a rise from a negative base reports as a gain, not a loss.
+            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / Math.Abs(before) * 100),
             Delta.Absolute => CellText.SignedNumber(after - before),
             _ => CellText.Placeholder
         };
@@ -71,7 +74,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             return CellText.Placeholder;
         return mode switch
         {
-            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / before * 100),
+            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / Math.Abs(before) * 100),
             Delta.Absolute => CellText.Number(after - before),
             _ => CellText.Placeholder
         };

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -63,7 +63,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         {
             // Divide by |before| so a rise from a negative base reports as a gain, not a loss.
             Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / Math.Abs(before) * 100),
-            Delta.Absolute => CellText.SignedNumber(after - before),
+            Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: true),
             _ => CellText.Placeholder
         };
     }
@@ -75,7 +75,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         return mode switch
         {
             Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / Math.Abs(before) * 100),
-            Delta.Absolute => CellText.Number(after - before),
+            Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: false),
             _ => CellText.Placeholder
         };
     }

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -39,18 +39,18 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
     {
         if (Before is IMarkoutCell beforeCell && After is IMarkoutCell afterCell)
         {
-            beforeCell.Decompose(fields, "before", format);
-            afterCell.Decompose(fields, "after", format);
+            beforeCell.Decompose(fields, CellText.SideKey(side, "before"), format);
+            afterCell.Decompose(fields, CellText.SideKey(side, "after"), format);
             return;
         }
 
-        fields.Add(new MarkoutField("before", CellText.Scalar(Before)));
-        fields.Add(new MarkoutField("after", CellText.Scalar(After)));
+        fields.Add(new MarkoutField(CellText.SideKey(side, "before"), CellText.Scalar(Before)));
+        fields.Add(new MarkoutField(CellText.SideKey(side, "after"), CellText.Scalar(After)));
 
         if (format.Delta == Delta.Percent)
-            fields.Add(new MarkoutField("deltaPct", DeltaValue(Delta.Percent)));
+            fields.Add(new MarkoutField(CellText.SideKey(side, "deltaPct"), DeltaValue(Delta.Percent)));
         else if (format.Delta == Delta.Absolute)
-            fields.Add(new MarkoutField("deltaAbs", DeltaValue(Delta.Absolute)));
+            fields.Add(new MarkoutField(CellText.SideKey(side, "deltaAbs"), DeltaValue(Delta.Absolute)));
     }
 
     private string DeltaSuffix(Delta mode)

--- a/src/Markout/Delta.cs
+++ b/src/Markout/Delta.cs
@@ -1,0 +1,17 @@
+namespace Markout;
+
+/// <summary>
+/// Controls the derived change appended to a numeric <see cref="Change{V}"/>
+/// via <see cref="MarkoutDeltaAttribute"/>.
+/// </summary>
+public enum Delta
+{
+    /// <summary>No derived change is appended.</summary>
+    None,
+
+    /// <summary>Append the signed percent change: <c>(After − Before) / Before × 100</c>.</summary>
+    Percent,
+
+    /// <summary>Append the signed absolute difference: <c>After − Before</c>.</summary>
+    Absolute
+}

--- a/src/Markout/Formatting/ICompositeCellFormatter.cs
+++ b/src/Markout/Formatting/ICompositeCellFormatter.cs
@@ -1,0 +1,15 @@
+namespace Markout.Formatting;
+
+/// <summary>
+/// Capability interface for formatters that decompose composite cells into typed columns
+/// instead of rendering them densely. Structured formatters (e.g. <see cref="TableFormatter"/>
+/// in TSV/JSONL modes) opt in; document formatters render the dense form.
+/// </summary>
+public interface ICompositeCellFormatter
+{
+    /// <summary>
+    /// When <c>true</c>, <see cref="MarkoutWriter.WriteCompositeTable"/> decomposes each cell
+    /// into typed columns; otherwise it renders a dense <c>Field | Value</c> table.
+    /// </summary>
+    bool DecomposesCompositeCells { get; }
+}

--- a/src/Markout/Fraction.cs
+++ b/src/Markout/Fraction.cs
@@ -1,0 +1,25 @@
+namespace Markout;
+
+/// <summary>
+/// A count out of a total, rendered as <c>24/24</c>. Decomposes into <c>count</c> and
+/// <c>total</c> columns (prefixed with the comparison side when nested).
+/// </summary>
+/// <param name="Count">The numerator.</param>
+/// <param name="Total">The denominator.</param>
+public readonly record struct Fraction(double Count, double Total) : IMarkoutCell
+{
+    /// <inheritdoc/>
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+    {
+        writer.Write(CellText.Number(Count));
+        writer.Write('/');
+        writer.Write(CellText.Number(Total));
+    }
+
+    /// <inheritdoc/>
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+    {
+        fields.Add(new MarkoutField(CellText.SideKey(side, "count"), CellText.Number(Count)));
+        fields.Add(new MarkoutField(CellText.SideKey(side, "total"), CellText.Number(Total)));
+    }
+}

--- a/src/Markout/IMarkoutCell.cs
+++ b/src/Markout/IMarkoutCell.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// A composite table cell that can render as a dense, human-readable string and
+/// decompose into typed columns/fields for structured output (TSV/JSONL/JSON).
+/// Implemented by the data-only shape types (<see cref="Change{V}"/>,
+/// <see cref="Fraction"/>, <see cref="Share"/>, <see cref="Percent"/>,
+/// <see cref="Segments"/>). The concrete type picks the rendering; formatting and
+/// derivation config arrive via <see cref="MarkoutCellFormat"/>.
+/// </summary>
+public interface IMarkoutCell
+{
+    /// <summary>
+    /// Writes the dense, human-readable form of the cell (e.g. <c>98555 → 61190 (−38%)</c>).
+    /// </summary>
+    /// <param name="writer">The output writer.</param>
+    /// <param name="format">Render-time derivation/format options.</param>
+    void FormatInline(TextWriter writer, in MarkoutCellFormat format);
+
+    /// <summary>
+    /// Adds the decomposed, typed fields for this cell to <paramref name="fields"/>.
+    /// </summary>
+    /// <param name="fields">The collection to append decomposed fields to.</param>
+    /// <param name="side">
+    /// When non-null, a nesting side (<c>"before"</c>/<c>"after"</c>) supplied by an
+    /// enclosing <see cref="Change{V}"/>. Each shape decides how to combine the side
+    /// with its own field names.
+    /// </param>
+    /// <param name="format">Render-time derivation/format options.</param>
+    void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format);
+}

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -522,11 +522,11 @@ public class MarkdownFormatter : IMarkoutFormatter,
         {
             var item = items[0];
             var total = 0;
-            foreach (var seg in item.Segments) total += seg.Count;
+            foreach (var seg in item.Slices) total += seg.Count;
             if (total == 0) total = 1;
 
             var headers = new[] { "Category", "Count", "%" };
-            var rows = item.Segments
+            var rows = item.Slices
                 .Where(s => s.Count > 0)
                 .Select(s => new[] { s.Category, s.Count.ToString(), $"{s.Count * 100.0 / total:F0}" })
                 .ToList();
@@ -540,10 +540,10 @@ public class MarkdownFormatter : IMarkoutFormatter,
             foreach (var item in items)
             {
                 var total = 0;
-                foreach (var seg in item.Segments) total += seg.Count;
+                foreach (var seg in item.Slices) total += seg.Count;
                 if (total == 0) total = 1;
 
-                foreach (var seg in item.Segments.Where(s => s.Count > 0))
+                foreach (var seg in item.Slices.Where(s => s.Count > 0))
                     rows.Add([item.Label, seg.Category, seg.Count.ToString(), $"{seg.Count * 100.0 / total:F0}"]);
             }
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.15.0</Version>
+    <Version>0.16.0</Version>
+    <PackageReleaseNotes>Add composite-cell shapes (Change&lt;V&gt;, Fraction, Share, Percent, Segments) with [MarkoutDelta]/[MarkoutUnit] for multi-format tables. BREAKING: the Breakdown element type Segment(Category, Count) is renamed to Slice(Category, Count) and Breakdown.Segments to Breakdown.Slices; update `new Segment(...)` to `new Slice(...)`.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -110,31 +110,28 @@ internal static class CellText
     /// <summary>
     /// Computes a signed absolute delta (<c>After − Before</c>), exact for integral and decimal
     /// types (a large <c>long</c>/<c>decimal</c> difference must not round through <c>double</c>).
+    /// Integral types subtract as <c>decimal</c> to avoid <c>long</c> wrap-around; a <c>decimal</c>
+    /// overflow falls back to <c>double</c> rather than throwing.
     /// </summary>
     public static string AbsoluteDelta(object? before, object? after, bool signed)
     {
         switch (before, after)
         {
             case (long b, long a):
-                return SignInt(a - b, signed);
+                return SignDecimal((decimal)a - (decimal)b, signed);
             case (ulong b, ulong a):
                 return SignDecimal((decimal)a - (decimal)b, signed);
             case (decimal b, decimal a):
-                return SignDecimal(a - b, signed);
-            default:
-                if (TryScalarDouble(before, out var bd) && TryScalarDouble(after, out var ad))
-                {
-                    var d = ad - bd;
-                    return signed ? SignedNumber(d) : Number(d);
-                }
-                return Placeholder;
+                try { return SignDecimal(a - b, signed); }
+                catch (OverflowException) { break; } // fall through to the double path
         }
-    }
 
-    private static string SignInt(long delta, bool signed)
-    {
-        var text = delta.ToString(CultureInfo.InvariantCulture);
-        return signed && delta > 0 ? "+" + text : text;
+        if (TryScalarDouble(before, out var bd) && TryScalarDouble(after, out var ad))
+        {
+            var d = ad - bd;
+            return signed ? SignedNumber(d) : Number(d);
+        }
+        return Placeholder;
     }
 
     private static string SignDecimal(decimal delta, bool signed)

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+
+namespace Markout;
+
+/// <summary>
+/// Entry points and shared helpers for composite cells (<see cref="IMarkoutCell"/>).
+/// </summary>
+public static class MarkoutCell
+{
+    /// <summary>
+    /// Renders a composite cell to its dense, human-readable string.
+    /// </summary>
+    /// <param name="cell">The cell to render (may be <c>null</c>).</param>
+    /// <param name="delta">The derived-change mode for a numeric <see cref="Change{V}"/>.</param>
+    /// <param name="unit">An optional unit suffix for a <see cref="Share"/> value.</param>
+    public static string ToInlineString(IMarkoutCell? cell, Delta delta = Delta.None, string? unit = null)
+    {
+        if (cell is null)
+            return string.Empty;
+        var sw = new StringWriter();
+        cell.FormatInline(sw, new MarkoutCellFormat(delta, unit));
+        return sw.ToString();
+    }
+}
+
+/// <summary>
+/// Shared text helpers for composite-cell rendering. Numbers use invariant culture;
+/// derived percentages round to the nearest whole percent; zero denominators render
+/// the placeholder rather than <c>NaN</c>/<c>Inf</c>.
+/// </summary>
+internal static class CellText
+{
+    /// <summary>Placeholder for a derivation with a zero denominator (em dash).</summary>
+    public const string Placeholder = "\u2014";
+
+    /// <summary>Separator between the before/after halves of a <see cref="Change{V}"/>.</summary>
+    public const string Arrow = " \u2192 ";
+
+    /// <summary>Formats a number without a trailing <c>.0</c> for integral values.</summary>
+    public static string Number(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            return Placeholder;
+        if (value == Math.Floor(value) && Math.Abs(value) < 1e15)
+            return ((long)value).ToString(CultureInfo.InvariantCulture);
+        return value.ToString("0.##", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Formats a percentage for dense output: rounded whole number plus <c>%</c>.</summary>
+    public static string Percent(double pct)
+        => PercentNumber(pct) + "%";
+
+    /// <summary>Formats a percentage for decomposed columns: rounded whole number, no <c>%</c>.</summary>
+    public static string PercentNumber(double pct)
+    {
+        if (double.IsNaN(pct) || double.IsInfinity(pct))
+            return Placeholder;
+        var rounded = Math.Round(pct, MidpointRounding.AwayFromZero);
+        return ((long)rounded).ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Formats a signed percentage for a delta suffix (explicit <c>+</c> for gains).</summary>
+    public static string SignedPercent(double pct)
+    {
+        if (double.IsNaN(pct) || double.IsInfinity(pct))
+            return Placeholder;
+        var text = PercentNumber(pct) + "%";
+        return pct > 0 ? "+" + text : text;
+    }
+
+    /// <summary>Formats a signed number for an absolute delta suffix (explicit <c>+</c> for gains).</summary>
+    public static string SignedNumber(double value)
+    {
+        var text = Number(value);
+        return value > 0 ? "+" + text : text;
+    }
+
+    /// <summary>Renders a scalar comparison value; numeric types drop trailing <c>.0</c>.</summary>
+    public static string Scalar(object? value) => value switch
+    {
+        null => string.Empty,
+        double d => Number(d),
+        float f => Number(f),
+        long l => Number(l),
+        int i => Number(i),
+        short or byte or sbyte or ushort or uint or ulong or decimal => Number(Convert.ToDouble(value, CultureInfo.InvariantCulture)),
+        _ => value.ToString() ?? string.Empty
+    };
+
+    /// <summary>Attempts to interpret a scalar comparison value as a double for derivations.</summary>
+    public static bool TryScalarDouble(object? value, out double result)
+    {
+        switch (value)
+        {
+            case double d: result = d; return true;
+            case float f: result = f; return true;
+            case long l: result = l; return true;
+            case int i: result = i; return true;
+            case short or byte or sbyte or ushort or uint or ulong or decimal:
+                result = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    /// <summary>Combines a decomposition <paramref name="side"/> with a sub-field name as <c>{side}_{sub}</c>.</summary>
+    public static string SideKey(string? side, string sub)
+        => side is null ? sub : side + "_" + sub;
+
+    /// <summary>Combines a segment <paramref name="label"/> with a decomposition side as <c>{label}_{side}</c>.</summary>
+    public static string LabelKey(string label, string? side)
+        => side is null ? label : label + "_" + side;
+}

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -81,9 +81,11 @@ internal static class CellText
         null => string.Empty,
         double d => Number(d),
         float f => Number(f),
-        long l => Number(l),
-        int i => Number(i),
-        short or byte or sbyte or ushort or uint or ulong or decimal => Number(Convert.ToDouble(value, CultureInfo.InvariantCulture)),
+        // Format integral and decimal types directly to preserve full precision
+        // (routing large long/ulong/decimal through double would round them).
+        decimal m => m.ToString(CultureInfo.InvariantCulture),
+        long or int or short or sbyte or byte or ushort or uint or ulong
+            => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
         _ => value.ToString() ?? string.Empty
     };
 

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -107,6 +107,42 @@ internal static class CellText
         }
     }
 
+    /// <summary>
+    /// Computes a signed absolute delta (<c>After − Before</c>), exact for integral and decimal
+    /// types (a large <c>long</c>/<c>decimal</c> difference must not round through <c>double</c>).
+    /// </summary>
+    public static string AbsoluteDelta(object? before, object? after, bool signed)
+    {
+        switch (before, after)
+        {
+            case (long b, long a):
+                return SignInt(a - b, signed);
+            case (ulong b, ulong a):
+                return SignDecimal((decimal)a - (decimal)b, signed);
+            case (decimal b, decimal a):
+                return SignDecimal(a - b, signed);
+            default:
+                if (TryScalarDouble(before, out var bd) && TryScalarDouble(after, out var ad))
+                {
+                    var d = ad - bd;
+                    return signed ? SignedNumber(d) : Number(d);
+                }
+                return Placeholder;
+        }
+    }
+
+    private static string SignInt(long delta, bool signed)
+    {
+        var text = delta.ToString(CultureInfo.InvariantCulture);
+        return signed && delta > 0 ? "+" + text : text;
+    }
+
+    private static string SignDecimal(decimal delta, bool signed)
+    {
+        var text = delta.ToString(CultureInfo.InvariantCulture);
+        return signed && delta > 0 ? "+" + text : text;
+    }
+
     /// <summary>Combines a decomposition <paramref name="side"/> with a sub-field name as <c>{side}_{sub}</c>.</summary>
     public static string SideKey(string? side, string sub)
         => side is null ? sub : side + "_" + sub;

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -1,0 +1,10 @@
+namespace Markout;
+
+/// <summary>
+/// Render-time configuration for a composite cell, sourced from property attributes
+/// (<see cref="MarkoutDeltaAttribute"/>, <see cref="MarkoutUnitAttribute"/>).
+/// Shapes are data-only; derivation/formatting options travel through this struct.
+/// </summary>
+/// <param name="Delta">The derived change mode for a numeric <see cref="Change{V}"/>.</param>
+/// <param name="Unit">An optional unit suffix (e.g. <c>"s"</c>) for a <see cref="Share"/> value.</param>
+public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string? Unit = null);

--- a/src/Markout/MarkoutCompositeRow.cs
+++ b/src/Markout/MarkoutCompositeRow.cs
@@ -1,0 +1,48 @@
+namespace Markout;
+
+/// <summary>
+/// One row of a composite table: a labeled cell rendered densely in Markdown and
+/// decomposed into typed columns/fields in structured formats. Emitted by the source
+/// generator for <c>[MarkoutSerializable]</c> models whose properties are composite shapes.
+/// </summary>
+public readonly struct MarkoutCompositeRow
+{
+    /// <summary>Creates a row from a composite cell and its render format.</summary>
+    public MarkoutCompositeRow(string label, IMarkoutCell cell, MarkoutCellFormat format = default)
+    {
+        Label = label;
+        Cell = cell;
+        Format = format;
+    }
+
+    /// <summary>The row label (the property display name).</summary>
+    public string Label { get; }
+
+    /// <summary>The composite cell for this row.</summary>
+    public IMarkoutCell Cell { get; }
+
+    /// <summary>Render-time derivation/format options for this row.</summary>
+    public MarkoutCellFormat Format { get; }
+
+    /// <summary>
+    /// Creates a row for a plain scalar value, rendered verbatim and decomposed to a single
+    /// <c>value</c> field. Lets scalar properties share one table with composite rows.
+    /// </summary>
+    public static MarkoutCompositeRow Scalar(string label, string? text)
+        => new(label, new ScalarCell(text));
+}
+
+/// <summary>
+/// Wraps a pre-rendered scalar string as an <see cref="IMarkoutCell"/> so plain properties
+/// can appear alongside composite cells in the same table.
+/// </summary>
+internal sealed class ScalarCell(string? text) : IMarkoutCell
+{
+    private readonly string _text = text ?? string.Empty;
+
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+        => writer.Write(_text);
+
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+        => fields.Add(new MarkoutField(CellText.SideKey(side, "value"), _text));
+}

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -365,11 +365,15 @@ public class MarkoutWriter
         if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
             return false;
 
-        if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
-            return WriteDecomposedCompositeTable(rows);
+        var projected = ProjectCompositeRows(rows);
+        if (projected.Length == 0)
+            return true;
 
-        var denseRows = new List<string[]>(rows.Length);
-        foreach (var row in rows)
+        if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
+            return WriteDecomposedCompositeTable(projected);
+
+        var denseRows = new List<string[]>(projected.Length);
+        foreach (var row in projected)
         {
             var sw = new StringWriter();
             row.Cell?.FormatInline(sw, row.Format);
@@ -377,6 +381,37 @@ public class MarkoutWriter
         }
 
         return WriteTable(["Field", "Value"], ["Field", "Value"], denseRows);
+    }
+
+    // Applies field projection (WithFields/WithoutFields) to composite rows by their label,
+    // mirroring how WriteFieldsTable projects Field | Value rows.
+    private MarkoutCompositeRow[] ProjectCompositeRows(ReadOnlySpan<MarkoutCompositeRow> rows)
+    {
+        if (_options.Projection == null)
+            return rows.ToArray();
+
+        var asFields = new MarkoutField[rows.Length];
+        for (int i = 0; i < rows.Length; i++)
+            asFields[i] = new MarkoutField(rows[i].Label, "");
+
+        var kept = ProjectFields(asFields);
+        var rowArray = rows.ToArray();
+        var result = new List<MarkoutCompositeRow>(kept.Length);
+        var consumed = new bool[rowArray.Length];
+        foreach (var field in kept)
+        {
+            for (int i = 0; i < rowArray.Length; i++)
+            {
+                if (!consumed[i] && rowArray[i].Label == field.Key)
+                {
+                    result.Add(rowArray[i]);
+                    consumed[i] = true;
+                    break;
+                }
+            }
+        }
+
+        return result.ToArray();
     }
 
     private bool WriteDecomposedCompositeTable(ReadOnlySpan<MarkoutCompositeRow> rows)
@@ -404,15 +439,28 @@ public class MarkoutWriter
         }
 
         // Leading "field" column names the property/row; remaining columns are the union keys.
+        // Stable header names are snake-cased for output, so disambiguate any that collide after
+        // normalization (or with the reserved leading column) to avoid silent duplicate keys.
         var headers = new string[keyOrder.Count + 1];
+        var headerNames = new string[keyOrder.Count + 1];
         headers[0] = "Field";
+        headerNames[0] = "field";
+        var usedStableKeys = new HashSet<string>(StringComparer.Ordinal) { "field" };
+
         for (int i = 0; i < keyOrder.Count; i++)
+        {
             headers[i + 1] = keyOrder[i];
 
-        var headerNames = new string[keyOrder.Count + 1];
-        headerNames[0] = "field";
-        for (int i = 0; i < keyOrder.Count; i++)
-            headerNames[i + 1] = keyOrder[i];
+            var stable = Formatting.FormatHelper.ToSnakeCase(keyOrder[i]);
+            if (!usedStableKeys.Add(stable))
+            {
+                int suffix = 2;
+                string candidate;
+                do { candidate = stable + "_" + suffix++; } while (!usedStableKeys.Add(candidate));
+                stable = candidate;
+            }
+            headerNames[i + 1] = stable;
+        }
 
         var outRows = new List<string[]>(rows.Length);
         for (int r = 0; r < decomposedRows.Length; r++)

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -451,7 +451,11 @@ public class MarkoutWriter
         {
             headers[i + 1] = keyOrder[i];
 
+            // TableWriter re-applies ToSnakeCase to stable names, so use a non-empty fixed point
+            // (ToSnakeCase(stable) == stable) and dedupe on it to guarantee unique output keys.
             var stable = Formatting.FormatHelper.ToSnakeCase(keyOrder[i]);
+            if (string.IsNullOrEmpty(stable))
+                stable = "column";
             if (!usedStableKeys.Add(stable))
             {
                 int suffix = 2;

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -350,7 +350,84 @@ public class MarkoutWriter
         return WriteTable(headers, ["Field", "Value"], rows);
     }
 
-    // ── Lists ──
+    /// <summary>
+    /// Writes a composite-cell table: one row per <see cref="MarkoutCompositeRow"/>. Formatters
+    /// that decompose composites (<see cref="Formatting.ICompositeCellFormatter"/>) emit one
+    /// typed column per decomposed field (union across rows, blank where absent); all others
+    /// render a dense two-column <c>Field | Value</c> table.
+    /// </summary>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
+    public bool WriteCompositeTable(params ReadOnlySpan<MarkoutCompositeRow> rows)
+    {
+        if (_sectionExcluded || rows.Length == 0)
+            return true;
+
+        if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
+            return false;
+
+        if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
+            return WriteDecomposedCompositeTable(rows);
+
+        var denseRows = new List<string[]>(rows.Length);
+        foreach (var row in rows)
+        {
+            var sw = new StringWriter();
+            row.Cell?.FormatInline(sw, row.Format);
+            denseRows.Add([row.Label, sw.ToString()]);
+        }
+
+        return WriteTable(["Field", "Value"], ["Field", "Value"], denseRows);
+    }
+
+    private bool WriteDecomposedCompositeTable(ReadOnlySpan<MarkoutCompositeRow> rows)
+    {
+        // First pass: decompose each row and collect the ordered union of column keys.
+        var keyOrder = new List<string>();
+        var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        var decomposedRows = new List<MarkoutField>[rows.Length];
+        var labels = new string[rows.Length];
+
+        for (int r = 0; r < rows.Length; r++)
+        {
+            var fields = new List<MarkoutField>();
+            rows[r].Cell?.Decompose(fields, null, rows[r].Format);
+            decomposedRows[r] = fields;
+            labels[r] = rows[r].Label;
+            foreach (var field in fields)
+            {
+                if (!keyIndex.ContainsKey(field.Key))
+                {
+                    keyIndex[field.Key] = keyOrder.Count;
+                    keyOrder.Add(field.Key);
+                }
+            }
+        }
+
+        // Leading "field" column names the property/row; remaining columns are the union keys.
+        var headers = new string[keyOrder.Count + 1];
+        headers[0] = "Field";
+        for (int i = 0; i < keyOrder.Count; i++)
+            headers[i + 1] = keyOrder[i];
+
+        var headerNames = new string[keyOrder.Count + 1];
+        headerNames[0] = "field";
+        for (int i = 0; i < keyOrder.Count; i++)
+            headerNames[i + 1] = keyOrder[i];
+
+        var outRows = new List<string[]>(rows.Length);
+        for (int r = 0; r < decomposedRows.Length; r++)
+        {
+            var values = new string[keyOrder.Count + 1];
+            values[0] = labels[r];
+            for (int i = 1; i < values.Length; i++)
+                values[i] = "";
+            foreach (var field in decomposedRows[r])
+                values[keyIndex[field.Key] + 1] = field.Value;
+            outRows.Add(values);
+        }
+
+        return WriteTable(headers, headerNames, outRows);
+    }
 
     /// <summary>
     /// Writes a single bullet list item.

--- a/src/Markout/Percent.cs
+++ b/src/Markout/Percent.cs
@@ -1,0 +1,21 @@
+namespace Markout;
+
+/// <summary>
+/// A percentage derived from a part and a whole, rendered as <c>93%</c>. Decomposes into
+/// a <c>pct</c> column (prefixed with the comparison side when nested). A zero whole renders
+/// the placeholder.
+/// </summary>
+/// <param name="Part">The part.</param>
+/// <param name="Whole">The whole. A zero renders the placeholder.</param>
+public readonly record struct Percent(double Part, double Whole) : IMarkoutCell
+{
+    /// <inheritdoc/>
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+        => writer.Write(Whole == 0 ? CellText.Placeholder : CellText.Percent(Part / Whole * 100));
+
+    /// <inheritdoc/>
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+        => fields.Add(new MarkoutField(
+            CellText.SideKey(side, "pct"),
+            Whole == 0 ? CellText.Placeholder : CellText.PercentNumber(Part / Whole * 100)));
+}

--- a/src/Markout/Segments.cs
+++ b/src/Markout/Segments.cs
@@ -1,0 +1,40 @@
+namespace Markout;
+
+/// <summary>
+/// A single labeled part of a <see cref="Segments"/> value. Labels drive the field names
+/// in structured (decomposed) output.
+/// </summary>
+/// <param name="Label">The part label (e.g. <c>"web"</c>, <c>"bash"</c>).</param>
+/// <param name="Value">The part value.</param>
+public readonly record struct Segment(string Label, double Value);
+
+/// <summary>
+/// A set of independent labeled parts with no shared denominator, rendered slash-joined as
+/// <c>21/171/236</c>. Each label becomes a decomposed field (as <c>{label}</c>, or
+/// <c>{label}_{side}</c> when nested in a <see cref="Change{V}"/>).
+/// </summary>
+/// <param name="Parts">The labeled parts, rendered left-to-right in order.</param>
+public readonly record struct Segments(params Segment[] Parts) : IMarkoutCell
+{
+    /// <inheritdoc/>
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+    {
+        if (Parts is null || Parts.Length == 0)
+            return;
+        for (int i = 0; i < Parts.Length; i++)
+        {
+            if (i > 0)
+                writer.Write('/');
+            writer.Write(CellText.Number(Parts[i].Value));
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+    {
+        if (Parts is null)
+            return;
+        foreach (var part in Parts)
+            fields.Add(new MarkoutField(CellText.LabelKey(part.Label, side), CellText.Number(part.Value)));
+    }
+}

--- a/src/Markout/Share.cs
+++ b/src/Markout/Share.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// A value together with its share of a (hidden) whole, rendered as <c>5056 (24%)</c>.
+/// With <see cref="MarkoutUnitAttribute"/> the value carries a unit suffix, e.g. <c>103s (93%)</c>.
+/// Decomposes into <c>value</c> and <c>pct</c> columns (prefixed with the comparison side when nested).
+/// </summary>
+/// <param name="Value">The value shown before the derived percent.</param>
+/// <param name="Whole">The whole the value is a share of. A zero renders the placeholder.</param>
+public readonly record struct Share(double Value, double Whole) : IMarkoutCell
+{
+    /// <inheritdoc/>
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+    {
+        writer.Write(CellText.Number(Value));
+        if (!string.IsNullOrEmpty(format.Unit))
+            writer.Write(format.Unit);
+        writer.Write(" (");
+        writer.Write(Whole == 0 ? CellText.Placeholder : CellText.Percent(Value / Whole * 100));
+        writer.Write(')');
+    }
+
+    /// <inheritdoc/>
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+    {
+        fields.Add(new MarkoutField(CellText.SideKey(side, "value"), CellText.Number(Value)));
+        fields.Add(new MarkoutField(
+            CellText.SideKey(side, "pct"),
+            Whole == 0 ? CellText.Placeholder : CellText.PercentNumber(Value / Whole * 100)));
+    }
+}

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -10,9 +10,13 @@ namespace Markout;
 /// Formatter for compact tabular output. It can render normalized TSV or a pretty
 /// space-padded table from the same row/column projection.
 /// </summary>
-public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter
+public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter, ICompositeCellFormatter
 {
     private const int ColumnGap = 2;
+
+    /// <summary>Structured output decomposes composite cells into typed columns.</summary>
+    bool ICompositeCellFormatter.DecomposesCompositeCells => true;
+
     private static readonly JsonWriterOptions JsonWriterOptions = new()
     {
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -255,14 +255,14 @@ public class UnicodeFormatter : IMarkoutFormatter,
 
         foreach (var item in items)
         {
-            int total = item.Segments.Sum(s => s.Count);
+            int total = item.Slices.Sum(s => s.Count);
             if (total <= 0)
                 continue;
 
             w.Write(item.Label.PadRight(15));
             w.Write(" ");
 
-            foreach (var segment in item.Segments)
+            foreach (var segment in item.Slices)
             {
                 double fraction = (double)segment.Count / total;
                 int width = (int)Math.Round(fraction * availableWidth);

--- a/tests/Markout.Tests/CompositeCellTests.cs
+++ b/tests/Markout.Tests/CompositeCellTests.cs
@@ -68,6 +68,34 @@ public partial class LinkedCompositeContext : MarkoutSerializerContext
 {
 }
 
+// A reference-type IMarkoutCell implementation (built-in shapes are value types) to verify
+// skip-null guarding and null-safe skip-default on the composite path.
+public sealed class TextCell(string text) : IMarkoutCell
+{
+    private readonly string _text = text;
+
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+        => writer.Write(_text);
+
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+        => fields.Add(new MarkoutField(side is null ? "text" : side + "_text", _text));
+}
+
+[MarkoutSerializable]
+public class RefCellCard
+{
+    [MarkoutPropertyName("score")]
+    public Change<long> Score { get; set; }
+
+    [MarkoutSkipNull]
+    public TextCell? Note { get; set; }
+}
+
+[MarkoutContext(typeof(RefCellCard))]
+public partial class RefCellContext : MarkoutSerializerContext
+{
+}
+
 public class CompositeCellTests
 {
     private static string Inline(IMarkoutCell cell, MarkoutCellFormat format = default)
@@ -491,5 +519,24 @@ public class CompositeCellTests
 
         Assert.Contains("[https://example.com](https://example.com)", output);
         Assert.Contains("| score | 10 \u2192 20 |", output);
+    }
+
+    [Fact]
+    public void Change_Scalar_LargeLong_AbsoluteDeltaIsExact()
+    {
+        // The absolute delta must be computed in long, not via double.
+        var cell = new Change<long>(9007199254740993L, 9007199254740994L);
+        Assert.Equal("1", Decompose(cell, new MarkoutCellFormat(Delta.Absolute))[2].Value);
+        Assert.Equal("9007199254740993 \u2192 9007199254740994 (+1)", Inline(cell, new MarkoutCellFormat(Delta.Absolute)));
+    }
+
+    [Fact]
+    public void Generated_ReferenceTypeCell_SkipNull_IsSkipped()
+    {
+        var withNote = new RefCellCard { Score = new Change<long>(1, 2), Note = new TextCell("hi") };
+        Assert.Contains("| Note | hi |", MarkoutSerializer.Serialize(withNote, RefCellContext.Default));
+
+        var withoutNote = new RefCellCard { Score = new Change<long>(1, 2), Note = null };
+        Assert.DoesNotContain("Note", MarkoutSerializer.Serialize(withoutNote, RefCellContext.Default));
     }
 }

--- a/tests/Markout.Tests/CompositeCellTests.cs
+++ b/tests/Markout.Tests/CompositeCellTests.cs
@@ -35,6 +35,22 @@ public partial class QualityCardContext : MarkoutSerializerContext
 {
 }
 
+// Nullable + skip guards on the composite path (regression: generated code must compile
+// under TreatWarningsAsErrors and must skip null composites instead of emitting blank rows).
+[MarkoutSerializable]
+public class NullableCompositeCard
+{
+    [MarkoutPropertyName("maybe"), MarkoutDelta(Delta.Percent)]
+    public Change<long>? Maybe { get; set; }
+
+    public string? Note { get; set; }
+}
+
+[MarkoutContext(typeof(NullableCompositeCard))]
+public partial class NullableCompositeContext : MarkoutSerializerContext
+{
+}
+
 public class CompositeCellTests
 {
     private static string Inline(IMarkoutCell cell, MarkoutCellFormat format = default)
@@ -326,5 +342,73 @@ public class CompositeCellTests
         Assert.Contains("web_before", headers);
         Assert.Contains("delta_pct", headers);
         Assert.Contains("value", headers);
+    }
+
+    // ── Regression: review findings ──
+
+    [Fact]
+    public void Generated_NullableComposite_Null_IsSkipped()
+    {
+        var card = new NullableCompositeCard { Maybe = null, Note = "n/a" };
+        var output = MarkoutSerializer.Serialize(card, NullableCompositeContext.Default);
+
+        Assert.DoesNotContain("maybe", output);
+        Assert.Contains("| Note | n/a |", output);
+    }
+
+    [Fact]
+    public void Generated_NullableComposite_Present_Renders()
+    {
+        var card = new NullableCompositeCard { Maybe = new Change<long>(100, 50), Note = "ok" };
+        var output = MarkoutSerializer.Serialize(card, NullableCompositeContext.Default);
+
+        Assert.Contains("| maybe | 100 \u2192 50 (-50%) |", output);
+    }
+
+    [Fact]
+    public void WriteCompositeTable_AppliesFieldProjection()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new MarkdownFormatter(),
+            new MarkoutWriterOptions { Projection = MarkoutProjection.WithFields("Verdict") });
+        writer.WriteCompositeTable(SampleRows());
+        var output = sw.ToString();
+
+        Assert.Contains("| Verdict | BETTER |", output);
+        Assert.DoesNotContain("Session IET", output);
+        Assert.DoesNotContain("tool calls", output);
+    }
+
+    [Fact]
+    public void WriteCompositeTable_Jsonl_DisambiguatesCollidingKeys()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        // "a b" and "a_b" both normalize to "a_b"; they must not silently merge into one key.
+        writer.WriteCompositeTable(
+            new MarkoutCompositeRow("segments", new Segments(new Segment("a b", 1), new Segment("a_b", 2))));
+
+        var line = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var root = JsonDocument.Parse(line).RootElement;
+
+        // Leading column + two distinct value columns, both values preserved.
+        var props = root.EnumerateObject().ToList();
+        Assert.Equal(3, props.Count);
+        var values = props.Where(p => p.Name != "field").Select(p => p.Value.GetString()).OrderBy(v => v).ToList();
+        Assert.Equal(["1", "2"], values);
+    }
+
+    [Fact]
+    public void Change_NestedInChange_ThreadsSideWithoutKeyCollision()
+    {
+        // Change<Change<int>> is an edge case, but its decomposed keys must stay distinct.
+        var cell = new Change<Change<int>>(new Change<int>(1, 2), new Change<int>(3, 4));
+        var fields = Decompose(cell);
+
+        var keys = fields.Select(f => f.Key).ToList();
+        Assert.Equal(keys.Count, keys.Distinct().Count());
+        Assert.Contains(new MarkoutField("before_before", "1"), fields);
+        Assert.Contains(new MarkoutField("after_after", "4"), fields);
     }
 }

--- a/tests/Markout.Tests/CompositeCellTests.cs
+++ b/tests/Markout.Tests/CompositeCellTests.cs
@@ -531,6 +531,17 @@ public class CompositeCellTests
     }
 
     [Fact]
+    public void Change_Scalar_ExtremeAbsoluteDelta_DoesNotOverflow()
+    {
+        // long endpoints must not wrap around, and decimal extremes must not throw.
+        var lng = new Change<long>(long.MinValue, long.MaxValue);
+        Assert.Equal("18446744073709551615", Decompose(lng, new MarkoutCellFormat(Delta.Absolute))[2].Value);
+
+        var dec = new Change<decimal>(decimal.MinValue, decimal.MaxValue);
+        Assert.Null(Record.Exception(() => Decompose(dec, new MarkoutCellFormat(Delta.Absolute))));
+    }
+
+    [Fact]
     public void Generated_ReferenceTypeCell_SkipNull_IsSkipped()
     {
         var withNote = new RefCellCard { Score = new Change<long>(1, 2), Note = new TextCell("hi") };

--- a/tests/Markout.Tests/CompositeCellTests.cs
+++ b/tests/Markout.Tests/CompositeCellTests.cs
@@ -1,0 +1,330 @@
+using System.Text.Json;
+using Markout;
+using Markout.Formatting;
+
+namespace Markout.Tests;
+
+// ── End-to-end model exercising composite cells through the source generator ──
+
+[MarkoutSerializable]
+public class QualityCard
+{
+    [MarkoutPropertyName("tasks correct")]
+    public Change<Fraction> TasksCorrect { get; set; }
+
+    [MarkoutPropertyName("tool calls: web / bash / other")]
+    public Change<Segments> ToolCalls { get; set; }
+
+    [MarkoutPropertyName("output tok (% of IET)")]
+    public Change<Share> OutputTok { get; set; }
+
+    [MarkoutPropertyName("tool-turn secs (% of turn time)"), MarkoutUnit("s")]
+    public Change<Share> ToolTurnSecs { get; set; }
+
+    [MarkoutPropertyName("tool-turn IET (% of turn IET)")]
+    public Change<Percent> ToolTurnIet { get; set; }
+
+    [MarkoutPropertyName("Session IET"), MarkoutDelta(Delta.Percent)]
+    public Change<long> SessionIet { get; set; }
+
+    public string? Verdict { get; set; }
+}
+
+[MarkoutContext(typeof(QualityCard))]
+public partial class QualityCardContext : MarkoutSerializerContext
+{
+}
+
+public class CompositeCellTests
+{
+    private static string Inline(IMarkoutCell cell, MarkoutCellFormat format = default)
+    {
+        var sw = new StringWriter();
+        cell.FormatInline(sw, format);
+        return sw.ToString();
+    }
+
+    private static List<MarkoutField> Decompose(IMarkoutCell cell, MarkoutCellFormat format = default)
+    {
+        var fields = new List<MarkoutField>();
+        cell.Decompose(fields, null, format);
+        return fields;
+    }
+
+    // ── Fraction ──
+
+    [Fact]
+    public void Fraction_RendersAndDecomposes()
+    {
+        var cell = new Fraction(24, 24);
+        Assert.Equal("24/24", Inline(cell));
+
+        var fields = Decompose(cell);
+        Assert.Equal([new("count", "24"), new("total", "24")], fields);
+    }
+
+    // ── Share ──
+
+    [Fact]
+    public void Share_RendersPercentAndDecomposes()
+    {
+        var cell = new Share(5056, 21067); // 24.0%
+        Assert.Equal("5056 (24%)", Inline(cell));
+
+        var fields = Decompose(cell);
+        Assert.Equal([new("value", "5056"), new("pct", "24")], fields);
+    }
+
+    [Fact]
+    public void Share_WithUnit_AddsSuffixToDenseValueOnly()
+    {
+        var cell = new Share(103, 110); // 93.6% -> 94%
+        Assert.Equal("103s (94%)", Inline(cell, new MarkoutCellFormat(Delta.None, "s")));
+
+        // Unit does not leak into the decomposed numeric value.
+        var fields = Decompose(cell, new MarkoutCellFormat(Delta.None, "s"));
+        Assert.Equal("103", fields[0].Value);
+    }
+
+    [Fact]
+    public void Share_ZeroWhole_RendersPlaceholder()
+    {
+        var cell = new Share(5, 0);
+        Assert.Equal("5 (\u2014)", Inline(cell));
+        Assert.Equal("\u2014", Decompose(cell)[1].Value);
+    }
+
+    // ── Percent ──
+
+    [Fact]
+    public void Percent_RendersAndDecomposes()
+    {
+        var cell = new Percent(93, 100);
+        Assert.Equal("93%", Inline(cell));
+        Assert.Equal([new("pct", "93")], Decompose(cell));
+    }
+
+    [Fact]
+    public void Percent_ZeroWhole_RendersPlaceholder()
+    {
+        var cell = new Percent(1, 0);
+        Assert.Equal("\u2014", Inline(cell));
+        Assert.Equal("\u2014", Decompose(cell)[0].Value);
+    }
+
+    // ── Segments ──
+
+    [Fact]
+    public void Segments_RendersSlashJoinedAndDecomposesByLabel()
+    {
+        var cell = new Segments(new Segment("web", 21), new Segment("bash", 171), new Segment("other", 236));
+        Assert.Equal("21/171/236", Inline(cell));
+
+        var fields = Decompose(cell);
+        Assert.Equal([new("web", "21"), new("bash", "171"), new("other", "236")], fields);
+    }
+
+    // ── Change (scalar) ──
+
+    [Fact]
+    public void Change_Scalar_WithPercentDelta()
+    {
+        var cell = new Change<long>(98555, 61190); // -37.9% -> -38%
+        Assert.Equal("98555 \u2192 61190 (-38%)", Inline(cell, new MarkoutCellFormat(Delta.Percent)));
+
+        var fields = Decompose(cell, new MarkoutCellFormat(Delta.Percent));
+        Assert.Equal([new("before", "98555"), new("after", "61190"), new("deltaPct", "-38")], fields);
+    }
+
+    [Fact]
+    public void Change_Scalar_WithAbsoluteDelta_UsesSignedDifference()
+    {
+        var cell = new Change<long>(10, 25);
+        Assert.Equal("10 \u2192 25 (+15)", Inline(cell, new MarkoutCellFormat(Delta.Absolute)));
+        Assert.Equal("15", Decompose(cell, new MarkoutCellFormat(Delta.Absolute))[2].Value);
+    }
+
+    [Fact]
+    public void Change_Scalar_NoDelta_OmitsSuffix()
+    {
+        var cell = new Change<long>(10, 25);
+        Assert.Equal("10 \u2192 25", Inline(cell));
+        Assert.Equal(2, Decompose(cell).Count);
+    }
+
+    [Fact]
+    public void Change_Scalar_ZeroBefore_RendersDeltaPlaceholder()
+    {
+        var cell = new Change<long>(0, 5);
+        Assert.Equal("0 \u2192 5 (\u2014)", Inline(cell, new MarkoutCellFormat(Delta.Percent)));
+        Assert.Equal("\u2014", Decompose(cell, new MarkoutCellFormat(Delta.Percent))[2].Value);
+    }
+
+    // ── Change (nested composites) ──
+
+    [Fact]
+    public void Change_NestedFraction_RendersAndDecomposesPerSide()
+    {
+        var cell = new Change<Fraction>(new Fraction(24, 24), new Fraction(20, 24));
+        Assert.Equal("24/24 \u2192 20/24", Inline(cell));
+
+        var fields = Decompose(cell);
+        Assert.Equal(
+            [new("before_count", "24"), new("before_total", "24"), new("after_count", "20"), new("after_total", "24")],
+            fields);
+    }
+
+    [Fact]
+    public void Change_NestedSegments_RendersAndDecomposesByLabelAndSide()
+    {
+        var cell = new Change<Segments>(
+            new Segments(new Segment("web", 21), new Segment("bash", 171), new Segment("other", 236)),
+            new Segments(new Segment("web", 0), new Segment("bash", 75), new Segment("other", 183)));
+        Assert.Equal("21/171/236 \u2192 0/75/183", Inline(cell));
+
+        var fields = Decompose(cell);
+        Assert.Equal(
+            [
+                new("web_before", "21"), new("bash_before", "171"), new("other_before", "236"),
+                new("web_after", "0"), new("bash_after", "75"), new("other_after", "183")
+            ],
+            fields);
+    }
+
+    [Fact]
+    public void Change_NestedShare_CarriesUnitToBothHalves()
+    {
+        var cell = new Change<Share>(new Share(103, 110), new Share(61, 68)); // 94%, 90%
+        Assert.Equal("103s (94%) \u2192 61s (90%)", Inline(cell, new MarkoutCellFormat(Delta.None, "s")));
+    }
+
+    // ── Writer: dense (document) vs decomposed (structured) ──
+
+    private static MarkoutCompositeRow[] SampleRows() =>
+    [
+        new("Session IET", new Change<long>(98555, 61190), new MarkoutCellFormat(Delta.Percent)),
+        new("tool calls", new Change<Segments>(
+            new Segments(new Segment("web", 21), new Segment("bash", 171), new Segment("other", 236)),
+            new Segments(new Segment("web", 0), new Segment("bash", 75), new Segment("other", 183)))),
+        MarkoutCompositeRow.Scalar("Verdict", "BETTER"),
+    ];
+
+    [Fact]
+    public void WriteCompositeTable_Markdown_RendersDenseFieldValueTable()
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteCompositeTable(SampleRows());
+        var output = writer.ToString();
+
+        Assert.Contains("| Field | Value |", output);
+        Assert.Contains("| Session IET | 98555 \u2192 61190 (-38%) |", output);
+        Assert.Contains("| tool calls | 21/171/236 \u2192 0/75/183 |", output);
+        Assert.Contains("| Verdict | BETTER |", output);
+    }
+
+    [Fact]
+    public void WriteCompositeTable_Tsv_DecomposesIntoUnionColumns()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv });
+        writer.WriteCompositeTable(SampleRows());
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var headers = lines[0].Split('\t');
+        Assert.Equal("field", headers[0]);
+        Assert.Contains("before", headers);
+        Assert.Contains("delta_pct", headers);
+        Assert.Contains("web_before", headers);
+
+        // Session IET row carries before/after/delta but no segment columns.
+        var sessionRow = lines[1].Split('\t');
+        Assert.Equal("Session IET", sessionRow[0]);
+        Assert.Contains("98555", sessionRow);
+        Assert.Contains("-38", sessionRow);
+    }
+
+    [Fact]
+    public void WriteCompositeTable_Jsonl_EmitsDecomposedRecords()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        writer.WriteCompositeTable(SampleRows());
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var session = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.Equal("Session IET", session.GetProperty("field").GetString());
+        Assert.Equal("98555", session.GetProperty("before").GetString());
+        Assert.Equal("61190", session.GetProperty("after").GetString());
+        Assert.Equal("-38", session.GetProperty("delta_pct").GetString());
+
+        var tools = JsonDocument.Parse(lines[1]).RootElement;
+        Assert.Equal("21", tools.GetProperty("web_before").GetString());
+        Assert.Equal("183", tools.GetProperty("other_after").GetString());
+    }
+
+    // ── End-to-end through the source generator ──
+
+    private static QualityCard SampleCard() => new()
+    {
+        TasksCorrect = new(new Fraction(24, 24), new Fraction(24, 24)),
+        ToolCalls = new(
+            new Segments(new Segment("web", 21), new Segment("bash", 171), new Segment("other", 236)),
+            new Segments(new Segment("web", 0), new Segment("bash", 75), new Segment("other", 183))),
+        OutputTok = new(new Share(5056, 21067), new Share(3129, 13037)),
+        ToolTurnSecs = new(new Share(103, 110), new Share(61, 68)),
+        ToolTurnIet = new(new Percent(93, 100), new Percent(91, 100)),
+        SessionIet = new(98555, 61190),
+        Verdict = "BETTER",
+    };
+
+    [Fact]
+    public void Generated_QualityCard_Markdown_IsDenseTable()
+    {
+        var output = MarkoutSerializer.Serialize(SampleCard(), QualityCardContext.Default);
+
+        Assert.Contains("| tasks correct | 24/24 \u2192 24/24 |", output);
+        Assert.Contains("| tool calls: web / bash / other | 21/171/236 \u2192 0/75/183 |", output);
+        Assert.Contains("| tool-turn secs (% of turn time) | 103s (94%) \u2192 61s (90%) |", output);
+        Assert.Contains("| tool-turn IET (% of turn IET) | 93% \u2192 91% |", output);
+        Assert.Contains("| Session IET | 98555 \u2192 61190 (-38%) |", output);
+        Assert.Contains("| Verdict | BETTER |", output);
+    }
+
+    [Fact]
+    public void Generated_QualityCard_Jsonl_Decomposes()
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(SampleCard(), sw, new TableFormatter(), QualityCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // One record per property/row, in declaration order.
+        var tasks = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.Equal("tasks correct", tasks.GetProperty("field").GetString());
+        Assert.Equal("24", tasks.GetProperty("before_count").GetString());
+
+        var session = JsonDocument.Parse(lines[5]).RootElement;
+        Assert.Equal("Session IET", session.GetProperty("field").GetString());
+        Assert.Equal("-38", session.GetProperty("delta_pct").GetString());
+
+        var verdict = JsonDocument.Parse(lines[6]).RootElement;
+        Assert.Equal("BETTER", verdict.GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public void Generated_QualityCard_Tsv_HasUnionColumns()
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(SampleCard(), sw, new TableFormatter(), QualityCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv });
+        var headers = sw.ToString().ReplaceLineEndings("\n").Split('\n')[0].Split('\t');
+
+        Assert.Equal("field", headers[0]);
+        Assert.Contains("before_count", headers);
+        Assert.Contains("web_before", headers);
+        Assert.Contains("delta_pct", headers);
+        Assert.Contains("value", headers);
+    }
+}

--- a/tests/Markout.Tests/CompositeCellTests.cs
+++ b/tests/Markout.Tests/CompositeCellTests.cs
@@ -51,6 +51,23 @@ public partial class NullableCompositeContext : MarkoutSerializerContext
 {
 }
 
+// Link formatting must survive the composite-card path (regression: EmitScalarCompositeRow
+// previously dropped [MarkoutLink]).
+[MarkoutSerializable]
+public class LinkedCompositeCard
+{
+    [MarkoutPropertyName("score")]
+    public Change<long> Score { get; set; }
+
+    [MarkoutLink]
+    public string? Url { get; set; }
+}
+
+[MarkoutContext(typeof(LinkedCompositeCard))]
+public partial class LinkedCompositeContext : MarkoutSerializerContext
+{
+}
+
 public class CompositeCellTests
 {
     private static string Inline(IMarkoutCell cell, MarkoutCellFormat format = default)
@@ -410,5 +427,69 @@ public class CompositeCellTests
         Assert.Equal(keys.Count, keys.Distinct().Count());
         Assert.Contains(new MarkoutField("before_before", "1"), fields);
         Assert.Contains(new MarkoutField("after_after", "4"), fields);
+    }
+
+    // ── Regression: second adversarial review (Gemini / GPT-5.5 / MAI) ──
+
+    [Fact]
+    public void Change_Scalar_NegativeBase_PercentUsesMagnitude()
+    {
+        // A rise from a negative base is a gain, not a loss: divide by |before|.
+        var cell = new Change<int>(-10, 10);
+        Assert.Equal("-10 \u2192 10 (+200%)", Inline(cell, new MarkoutCellFormat(Delta.Percent)));
+        Assert.Equal("200", Decompose(cell, new MarkoutCellFormat(Delta.Percent))[2].Value);
+    }
+
+    [Fact]
+    public void Change_Scalar_LargeLong_PreservesPrecision()
+    {
+        // Values beyond double's exact integer range must not be rounded.
+        var cell = new Change<long>(9007199254740993L, 9007199254740994L);
+        var fields = Decompose(cell);
+        Assert.Equal("9007199254740993", fields[0].Value);
+        Assert.Equal("9007199254740994", fields[1].Value);
+        Assert.Equal("9007199254740993 \u2192 9007199254740994", Inline(cell));
+    }
+
+    [Fact]
+    public void Change_NullableCompositeSide_RendersShapeNotStructDump()
+    {
+        var cell = new Change<Fraction?>(null, new Fraction(1, 2));
+        Assert.Equal(" \u2192 1/2", Inline(cell));
+
+        var fields = Decompose(cell);
+        Assert.Equal([new("after_count", "1"), new("after_total", "2")], fields);
+    }
+
+    [Fact]
+    public void WriteCompositeTable_Jsonl_HandlesEmptyAndNumericKeys()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        // "!!!" and "???" both normalize to empty; "2" is a bare digit — all must stay distinct.
+        writer.WriteCompositeTable(
+            new MarkoutCompositeRow("segments",
+                new Segments(new Segment("!!!", 1), new Segment("2", 2), new Segment("???", 3))));
+
+        var line = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var root = JsonDocument.Parse(line).RootElement;
+
+        var props = root.EnumerateObject().ToList();
+        Assert.Equal(4, props.Count); // field + 3 distinct value columns
+        Assert.Equal(props.Count, props.Select(p => p.Name).Distinct().Count());
+        Assert.All(props, p => Assert.False(string.IsNullOrEmpty(p.Name)));
+        var values = props.Where(p => p.Name != "field").Select(p => p.Value.GetString()).OrderBy(v => v).ToList();
+        Assert.Equal(["1", "2", "3"], values);
+    }
+
+    [Fact]
+    public void Generated_LinkedComposite_RendersLinkOnScalarRow()
+    {
+        var card = new LinkedCompositeCard { Score = new Change<long>(10, 20), Url = "https://example.com" };
+        var output = MarkoutSerializer.Serialize(card, LinkedCompositeContext.Default);
+
+        Assert.Contains("[https://example.com](https://example.com)", output);
+        Assert.Contains("| score | 10 \u2192 20 |", output);
     }
 }

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -222,7 +222,7 @@ public class MarkoutWriterTests
     public void MarkdownFormatter_WriteBreakdown_Renders()
     {
         var orch = MarkoutWriter.Create(new MarkdownFormatter());
-        var breakdown = new Breakdown("Test", [new Segment("Pass", 8), new Segment("Fail", 2)]);
+        var breakdown = new Breakdown("Test", [new Slice("Pass", 8), new Slice("Fail", 2)]);
         var result = orch.WriteBreakdown([breakdown]);
         Assert.True(result);
         var output = orch.ToString();
@@ -348,7 +348,7 @@ public class MarkoutWriterTests
     public void TableFormatter_WriteBreakdown_ReturnsFalse()
     {
         var orch = MarkoutWriter.Create(new TableFormatter());
-        var result = orch.WriteBreakdown([new Breakdown("X", [new Segment("A", 1)])]);
+        var result = orch.WriteBreakdown([new Breakdown("X", [new Slice("A", 1)])]);
         Assert.False(result);
     }
 
@@ -1108,7 +1108,7 @@ public class MarkoutWriterTests
         Assert.False(orch.WriteListItem("item"));
         Assert.False(orch.WriteCallout(CalloutSeverity.Note, "msg"));
         Assert.False(orch.WriteRule());
-        Assert.False(orch.WriteBreakdown([new Breakdown("X", [new Segment("A", 1)])]));
+        Assert.False(orch.WriteBreakdown([new Breakdown("X", [new Slice("A", 1)])]));
         Assert.False(orch.WriteMetrics([new Metric("M", 1)]));
         Assert.False(orch.WriteParagraph("text"));
         Assert.False(orch.WriteTreeNode("node"));
@@ -1361,7 +1361,7 @@ public class MarkoutWriterTests
         Assert.True(orch.WriteCodeEnd());
         Assert.True(orch.WriteCallout(CalloutSeverity.Note, "msg"));
         Assert.True(orch.WriteRule());
-        Assert.True(orch.WriteBreakdown([new Breakdown("test", [new Segment("a", 1)])]));
+        Assert.True(orch.WriteBreakdown([new Breakdown("test", [new Slice("a", 1)])]));
     }
 
     // ── Cascade field → streaming table ──

--- a/tests/Markout.Tests/UnicodeFormatterTests.cs
+++ b/tests/Markout.Tests/UnicodeFormatterTests.cs
@@ -315,14 +315,14 @@ public class UnicodeFormatterTests
         var orch = MarkoutWriter.Create(sw, new UnicodeFormatter());
         orch.WriteBreakdown([
             new Breakdown("Windows", [
-                new Segment("Critical", 10),
-                new Segment("High", 20),
-                new Segment("Medium", 30)
+                new Slice("Critical", 10),
+                new Slice("High", 20),
+                new Slice("Medium", 30)
             ]),
             new Breakdown("Linux", [
-                new Segment("Critical", 5),
-                new Segment("High", 15),
-                new Segment("Medium", 20)
+                new Slice("Critical", 5),
+                new Slice("High", 15),
+                new Slice("Medium", 20)
             ])
         ], maxBarWidth: 30);
         var output = sw.ToString();


### PR DESCRIPTION
Closes #122.

Adds data-only **composite-cell shapes** so one annotated model renders as a dense Markdown table **and** decomposes into typed columns/fields in TSV/JSONL — no pre-stringifying.

## What's here

- **Shapes** (namespace `Markout`): `Change<V>` (before→after), `Fraction`, `Share`, `Percent`, `Segments`/`Segment`.
  - `Change<V>` is named **`Change`, not `Comparison`**, to avoid a hard `CS0104` collision with `System.Comparison<T>` under `ImplicitUsings`.
- **Attributes**: `[MarkoutDelta(Delta)]` appends a derived change to a numeric `Change<V>`; `[MarkoutUnit(string)]` adds a unit suffix to a `Share`'s dense value.
- **`IMarkoutCell`** drives dense rendering (`FormatInline`) and structured decomposition (`Decompose`) at runtime; `Change<V>` lowers nested composites recursively (`Change<Fraction>`, `Change<Share>`, `Change<Percent>`, `Change<Segments>`). Zero denominators render `—`, never `NaN`/`Inf`.
- **`MarkoutWriter.WriteCompositeTable`** renders a dense `Field | Value` table for document formatters and decomposes into union columns for structured formatters (`ICompositeCellFormatter` opt-in; `TableFormatter` decomposes).
- **Source generator** recognizes `IMarkoutCell` properties on `[MarkoutSerializable]` models, reads the attributes, and emits the composite-card path (with nullable/skip guards).

## Breaking change (0.16.0)

The Breakdown element `Segment(Category, Count)` is renamed to **`Slice(Category, Count)`** (and `Breakdown.Segments` → `Breakdown.Slices`) to free `Segment` for the new independent-part shape. Two distinct concepts: a proportional *slice* of a shared whole vs. an independent *part*. Migration: `new Segment(...)` → `new Slice(...)`. Version bumped 0.15.0 → 0.16.0 with release notes.

## Design notes / deviations

Full rationale is in [the design comment on #122](https://github.com/richlander/markout/issues/122#issuecomment-4887465113). Deviations from the issue: leading structured column is `field` (not `metric`); JSON keys are snake_case per Markout's TSV/JSONL contract (`delta_pct`); TSV/JSONL use a uniform union of columns.

## Tracked follow-ups (from owner review, non-blocking)

- Typed (non-string) decomposed JSON values — broader `TableFormatter` change.
- Heterogeneous JSONL (omit absent keys) instead of the uniform union.

## Validation

- Full solution builds clean (0 warnings, `TreatWarningsAsErrors`).
- 859 tests green (25 new composite-cell tests: each shape × render/decompose, nesting, zero denominators, writer paths, end-to-end generated `QualityCard` across Markdown/TSV/JSONL, plus regressions for the review fixes).
- Two-model adversarial review (Opus + GPT); all findings addressed (nullable-composite guard, decomposed-key disambiguation, field projection on the composite path, nested-`Change` side threading).
- Grounding updated: `grounding/markout/AGENTS.md`, `skills/markout/SKILL.md`, `docs/design/shape-system.md`; markdownlint clean.
