### PR TITLE
First-class multi-source data cards (MetricChange<T> + MultiSourceRow) + Segments key-order flip (#128, #129)

### DIFF
--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -163,6 +163,15 @@ public readonly record struct Percent(double Part, double Whole);   // 93%
 public readonly record struct Segment(string Label, double Value);
 public readonly record struct Segments(params Segment[] Parts);     // 21/171/236
 
+// Card shapes — list-shapes that render as multi-format cards (Markdown table + typed JSONL/TSV).
+public readonly record struct MetricChange<T>(string Name, T Before, T After,
+    T? Target = null, string? TargetLabel = null,
+    GateStatus Status = GateStatus.Unknown, string? StatusLabel = null) where T : struct; // gated metric
+public readonly record struct Source(string Role, IMarkoutCell? Value, MarkoutCellFormat Format = default);
+public readonly struct MultiSourceRow(string label, params Source[] sources); // role matrix (roles → columns)
+public enum GateStatus { Unknown, Good, Neutral, Warning, Bad }    // verdict polarity
+public readonly record struct Verdict(GateStatus Status, string? Label = null); // first-class verdict cell
+
 // Hierarchy — a recursive node with children
 public class TreeNode { ... }
 

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -83,6 +83,26 @@ JSONL decomposition is **heterogeneous** (each record holds only its own keys); 
 column union (absent cells blank). Set `MarkoutWriterOptions.JsonTypedValues = true` to emit numeric
 columns as JSON numbers instead of strings.
 
+## Card shapes (declare a list; the generator picks the layout)
+
+Two list-shapes render as multi-format cards from a `[MarkoutSerializable]` model — Markdown table +
+flat typed JSONL/TSV — with no imperative writer calls:
+
+- `List<MetricChange<T>>` — a gated scalar metric per row. `MetricChange<T>(Name, Before, After,
+  Target? = null, TargetLabel? = null, Status = GateStatus.Unknown, StatusLabel? = null)` where
+  `T : struct`. Markdown = `Metric | Change | Target | Status`; JSONL = flat `before`/`after`/optional
+  `target`/`target_label`/`status`. `Status` is caller-supplied (Markout never derives it).
+- `List<MultiSourceRow>` — a role matrix: `MultiSourceRow(label, params Source[])`,
+  `Source(role, IMarkoutCell? value, format = default)`. Roles pivot to **columns** in Markdown
+  (caller-supplied order; absent role → `-`); JSONL emits one flat record per row with
+  `{role}_{side}_{field}` keys. Values are any `IMarkoutCell` incl. nested `Change<Share>` etc. Set
+  the label column header with `[MarkoutLabelHeader("Metric")]` (defaults to `Field`).
+- `Verdict(GateStatus Status, string? Label = null)` — a first-class verdict cell (typed polarity
+  `GateStatus` + optional caller label); use as a `Source` value for a verdict row.
+
+Decomposition keys are `snake_case_lower` (a fused role like `claude-opus-4.8` becomes
+`claude_opus_4_8_...`). Put `[MarkoutIgnoreInTable]` on these lists only when nested inside a table.
+
 ## Other output formats (still Markdown by default)
 
 Pass a formatter to change output: `new MarkdownFormatter()` (default), `PlainTextFormatter`,

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -98,8 +98,9 @@ flat typed JSONL/TSV — with no imperative writer calls:
   `Source(role, IMarkoutCell? value, format = default)`. Roles pivot to **columns** in Markdown
   (caller-supplied order; absent role → `-`); JSONL emits one flat record per row with
   `{role}_{side}_{field}` keys. Values are any `IMarkoutCell` incl. nested `Change<Share>` etc.;
-  **scalars work too** — `new Source("baseline", 2)` (int/long/double/decimal/string) decomposes to a
-  single `{role}` field. Set the label column header with `[MarkoutLabelHeader("Metric")]` (defaults to `Field`).
+  **scalars work too** — `new Source("baseline", 2)` (int/long/double/decimal) and `Source.Text(role, s)`
+  decompose to a single `{role}` field; `new Source(role, null)` is an absent cell. Set the label column
+  header with `[MarkoutLabelHeader("Metric")]` (defaults to `Field`).
 - `Verdict(GateStatus Status, string? Label = null)` — a first-class verdict cell (typed polarity
   `GateStatus` + optional caller label); use as a `Source` value for a verdict row (decomposes to `{role}`).
 

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -91,14 +91,17 @@ flat typed JSONL/TSV — with no imperative writer calls:
 - `List<MetricChange<T>>` — a gated scalar metric per row. `MetricChange<T>(Name, Before, After,
   Target? = null, TargetLabel? = null, Status = GateStatus.Unknown, StatusLabel? = null)` where
   `T : struct`. Markdown = `Metric | Change | Target | Status`; JSONL = flat `before`/`after`/optional
-  `target`/`target_label`/`status`. `Status` is caller-supplied (Markout never derives it).
+  `target`/`target_label`/`status`. `Status` is caller-supplied (Markout never derives it). `T` must be
+  a numeric scalar (int/long/double/decimal/...); a composite `T` (e.g. `Segments`) is a compile error
+  (`MARKOUT005`).
 - `List<MultiSourceRow>` — a role matrix: `MultiSourceRow(label, params Source[])`,
   `Source(role, IMarkoutCell? value, format = default)`. Roles pivot to **columns** in Markdown
   (caller-supplied order; absent role → `-`); JSONL emits one flat record per row with
-  `{role}_{side}_{field}` keys. Values are any `IMarkoutCell` incl. nested `Change<Share>` etc. Set
-  the label column header with `[MarkoutLabelHeader("Metric")]` (defaults to `Field`).
+  `{role}_{side}_{field}` keys. Values are any `IMarkoutCell` incl. nested `Change<Share>` etc.;
+  **scalars work too** — `new Source("baseline", 2)` (int/long/double/decimal/string) decomposes to a
+  single `{role}` field. Set the label column header with `[MarkoutLabelHeader("Metric")]` (defaults to `Field`).
 - `Verdict(GateStatus Status, string? Label = null)` — a first-class verdict cell (typed polarity
-  `GateStatus` + optional caller label); use as a `Source` value for a verdict row.
+  `GateStatus` + optional caller label); use as a `Source` value for a verdict row (decomposes to `{role}`).
 
 Decomposition keys are `snake_case_lower` (a fused role like `claude-opus-4.8` becomes
 `claude_opus_4_8_...`). Put `[MarkoutIgnoreInTable]` on these lists only when nested inside a table.

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -207,7 +207,7 @@ MarkoutSerializer.Serialize(card, Console.Out, QualityCardContext.Default);
 var jsonl = new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true };
 MarkoutSerializer.Serialize(card, Console.Out, new TableFormatter(), QualityCardContext.Default, jsonl);
 // {"field":"Session IET","before":98555,"after":61190,"delta_pct":-38}
-// {"field":"tool calls: web / bash / other","web_before":21,"bash_before":171,"other_before":236, ...}
+// {"field":"tool calls: web / bash / other","before_web":21,"before_bash":171,"before_other":236, ...}
 ```
 
 JSONL records are **heterogeneous** — each object contains only the keys its own cell produces.

--- a/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
+++ b/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
@@ -62,4 +62,17 @@ internal static class DiagnosticDescriptors
                      "Either add [MarkoutSection] to collection properties, or remove AutoFields=false."
     );
 
+    public static readonly DiagnosticDescriptor MetricChangeNonScalarType = new(
+        id: "MARKOUT005",
+        title: "MetricChange<T> requires a numeric scalar type argument",
+        messageFormat: "Property '{0}' uses MetricChange<{1}>, but T must be a numeric scalar type " +
+                       "(int, long, double, decimal, etc.). Composite shapes (e.g. Segments, Share) are not " +
+                       "supported here; keep them as ordinary rows or a plain metric.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "MetricChange<T> renders Before/After/Target as scalar values. A non-numeric type argument " +
+                     "renders incorrectly (e.g. a target prints the raw struct), so it is rejected at compile time."
+    );
+
 }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -653,6 +653,16 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}}}");
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
+        else if (prop.Kind == PropertyKind.MetricChange)
+        {
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+            sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess});");
+            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+            sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
+        }
         else if (prop.Kind == PropertyKind.CodeSection)
         {
             sb.AppendLine($"{indent}if ({propAccess}.Content != null)");
@@ -803,6 +813,11 @@ internal static class SerializerEmitter
             case PropertyKind.Breakdown:
                 sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
                 sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
+                break;
+
+            case PropertyKind.MetricChange:
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess});");
                 break;
 
             case PropertyKind.ComplexArray:
@@ -1012,6 +1027,8 @@ internal static class SerializerEmitter
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (code block)";
             if (prop.Kind == PropertyKind.Breakdown)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (distribution)";
+            if (prop.Kind == PropertyKind.MetricChange)
+                return $"H{prop.SectionLevel} Section \"{sectionName}\" (gated metrics)";
             return $"H{prop.SectionLevel} Section \"{sectionName}\"";
         }
 
@@ -1036,6 +1053,7 @@ internal static class SerializerEmitter
             PropertyKind.CodeSection => "Code",
             PropertyKind.Callout => "Callout",
             PropertyKind.Breakdown => "Breakdown",
+            PropertyKind.MetricChange => "MetricChange",
             _ => "Field"
         };
     }

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -655,7 +655,7 @@ internal static class SerializerEmitter
         }
         else if (prop.Kind == PropertyKind.MetricChange)
         {
-            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess});");
@@ -666,7 +666,7 @@ internal static class SerializerEmitter
         else if (prop.Kind == PropertyKind.MultiSource)
         {
             var labelHeader = EmitHelpers.EscapeString(prop.MultiSourceLabelHeader ?? "Field");
-            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
             sb.AppendLine($"{indent}    writer.WriteMultiSourceTable(\"{labelHeader}\", {propAccess});");
@@ -827,12 +827,12 @@ internal static class SerializerEmitter
                 break;
 
             case PropertyKind.MetricChange:
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0)");
                 sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess});");
                 break;
 
             case PropertyKind.MultiSource:
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0)");
                 sb.AppendLine($"{indent}    writer.WriteMultiSourceTable(\"{EmitHelpers.EscapeString(prop.MultiSourceLabelHeader ?? "Field")}\", {propAccess});");
                 break;
 

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -663,6 +663,17 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}}}");
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
+        else if (prop.Kind == PropertyKind.MultiSource)
+        {
+            var labelHeader = EmitHelpers.EscapeString(prop.MultiSourceLabelHeader ?? "Field");
+            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+            sb.AppendLine($"{indent}    writer.WriteMultiSourceTable(\"{labelHeader}\", {propAccess});");
+            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+            sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
+        }
         else if (prop.Kind == PropertyKind.CodeSection)
         {
             sb.AppendLine($"{indent}if ({propAccess}.Content != null)");
@@ -818,6 +829,11 @@ internal static class SerializerEmitter
             case PropertyKind.MetricChange:
                 sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
                 sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess});");
+                break;
+
+            case PropertyKind.MultiSource:
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}    writer.WriteMultiSourceTable(\"{EmitHelpers.EscapeString(prop.MultiSourceLabelHeader ?? "Field")}\", {propAccess});");
                 break;
 
             case PropertyKind.ComplexArray:
@@ -1029,6 +1045,8 @@ internal static class SerializerEmitter
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (distribution)";
             if (prop.Kind == PropertyKind.MetricChange)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (gated metrics)";
+            if (prop.Kind == PropertyKind.MultiSource)
+                return $"H{prop.SectionLevel} Section \"{sectionName}\" (multi-source)";
             return $"H{prop.SectionLevel} Section \"{sectionName}\"";
         }
 
@@ -1054,6 +1072,7 @@ internal static class SerializerEmitter
             PropertyKind.Callout => "Callout",
             PropertyKind.Breakdown => "Breakdown",
             PropertyKind.MetricChange => "MetricChange",
+            PropertyKind.MultiSource => "MultiSource",
             _ => "Field"
         };
     }

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -31,6 +31,9 @@ internal sealed class KnownTypeSymbols
     private INamedTypeSymbol? _breakdown;
     private bool _breakdownResolved;
 
+    private INamedTypeSymbol? _metricChange;
+    private bool _metricChangeResolved;
+
     private INamedTypeSymbol? _markoutCell;
     private bool _markoutCellResolved;
 
@@ -68,6 +71,7 @@ internal sealed class KnownTypeSymbols
     public INamedTypeSymbol? CodeSection => Resolve(ref _codeSection, ref _codeSectionResolved, "Markout.CodeSection");
     public INamedTypeSymbol? Callout => Resolve(ref _callout, ref _calloutResolved, "Markout.Callout");
     public INamedTypeSymbol? Breakdown => Resolve(ref _breakdown, ref _breakdownResolved, "Markout.Breakdown");
+    public INamedTypeSymbol? MetricChange => Resolve(ref _metricChange, ref _metricChangeResolved, "Markout.MetricChange`1");
     public INamedTypeSymbol? IMarkoutCell => Resolve(ref _markoutCell, ref _markoutCellResolved, "Markout.IMarkoutCell");
     public INamedTypeSymbol? MarkoutDeltaAttribute => Resolve(ref _markoutDeltaAttribute, ref _markoutDeltaAttributeResolved, "Markout.MarkoutDeltaAttribute");
     public INamedTypeSymbol? MarkoutUnitAttribute => Resolve(ref _markoutUnitAttribute, ref _markoutUnitAttributeResolved, "Markout.MarkoutUnitAttribute");

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -34,6 +34,9 @@ internal sealed class KnownTypeSymbols
     private INamedTypeSymbol? _metricChange;
     private bool _metricChangeResolved;
 
+    private INamedTypeSymbol? _multiSourceRow;
+    private bool _multiSourceRowResolved;
+
     private INamedTypeSymbol? _markoutCell;
     private bool _markoutCellResolved;
 
@@ -72,6 +75,7 @@ internal sealed class KnownTypeSymbols
     public INamedTypeSymbol? Callout => Resolve(ref _callout, ref _calloutResolved, "Markout.Callout");
     public INamedTypeSymbol? Breakdown => Resolve(ref _breakdown, ref _breakdownResolved, "Markout.Breakdown");
     public INamedTypeSymbol? MetricChange => Resolve(ref _metricChange, ref _metricChangeResolved, "Markout.MetricChange`1");
+    public INamedTypeSymbol? MultiSourceRow => Resolve(ref _multiSourceRow, ref _multiSourceRowResolved, "Markout.MultiSourceRow");
     public INamedTypeSymbol? IMarkoutCell => Resolve(ref _markoutCell, ref _markoutCellResolved, "Markout.IMarkoutCell");
     public INamedTypeSymbol? MarkoutDeltaAttribute => Resolve(ref _markoutDeltaAttribute, ref _markoutDeltaAttributeResolved, "Markout.MarkoutDeltaAttribute");
     public INamedTypeSymbol? MarkoutUnitAttribute => Resolve(ref _markoutUnitAttribute, ref _markoutUnitAttributeResolved, "Markout.MarkoutUnitAttribute");

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -183,6 +183,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public MarkoutDeltaKind DeltaMode { get; }
     public string? Unit { get; }
     public bool IsReferenceTypeCell { get; }
+    public string? MultiSourceLabelHeader { get; }
 
     public PropertyMetadata(
         string name,
@@ -232,7 +233,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? sectionEmptyText = null,
         MarkoutDeltaKind deltaMode = MarkoutDeltaKind.None,
         string? unit = null,
-        bool isReferenceTypeCell = false)
+        bool isReferenceTypeCell = false,
+        string? multiSourceLabelHeader = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -282,6 +284,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         DeltaMode = deltaMode;
         Unit = unit;
         IsReferenceTypeCell = isReferenceTypeCell;
+        MultiSourceLabelHeader = multiSourceLabelHeader;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -335,6 +338,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                DeltaMode == other.DeltaMode &&
                Unit == other.Unit &&
                IsReferenceTypeCell == other.IsReferenceTypeCell &&
+               MultiSourceLabelHeader == other.MultiSourceLabelHeader &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -373,6 +377,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (int)DeltaMode;
             hash = hash * 397 ^ (Unit?.GetHashCode() ?? 0);
             hash = hash * 397 ^ IsReferenceTypeCell.GetHashCode();
+            hash = hash * 397 ^ (MultiSourceLabelHeader?.GetHashCode() ?? 0);
             return hash;
         }
     }
@@ -474,6 +479,7 @@ internal enum PropertyKind
     Callout,
     Breakdown,
     MetricChange,
+    MultiSource,
     CompositeCell,
     Other
 }

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -473,6 +473,7 @@ internal enum PropertyKind
     CodeSection,
     Callout,
     Breakdown,
+    MetricChange,
     CompositeCell,
     Other
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -713,6 +713,22 @@ internal static class TypeParser
                         }
                     }
 
+                    // Check for IReadOnlyList<MetricChange<T>> / List<MetricChange<T>> - renders as a
+                    // gated-metric table (Metric | Change | Target | Status). MetricChange is generic,
+                    // so compare the element's original definition against the open generic symbol.
+                    if (knownTypes.MetricChange is not null &&
+                        elementType is INamedTypeSymbol metricChangeElement &&
+                        SymbolEqualityComparer.Default.Equals(metricChangeElement.OriginalDefinition, knownTypes.MetricChange))
+                    {
+                        var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
+                        if (typeDisplayString == "System.Collections.Generic.List<T>" ||
+                            typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>" ||
+                            typeDisplayString == "System.Collections.Generic.IList<T>")
+                        {
+                            return (PropertyKind.MetricChange, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+                        }
+                    }
+
                     if (elementType.SpecialType == SpecialType.System_String)
                         return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.Table, false);
 
@@ -753,6 +769,7 @@ internal static class TypeParser
              p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree ||
              p.Kind == PropertyKind.Description || p.Kind == PropertyKind.Metric ||
              p.Kind == PropertyKind.CodeSection || p.Kind == PropertyKind.Breakdown ||
+             p.Kind == PropertyKind.MetricChange ||
              (p.Kind == PropertyKind.StringArray && p.JoinSeparator == null)));
     }
 

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -734,8 +734,7 @@ internal static class TypeParser
                     {
                         var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
                         if (typeDisplayString == "System.Collections.Generic.List<T>" ||
-                            typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>" ||
-                            typeDisplayString == "System.Collections.Generic.IList<T>")
+                            typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>")
                         {
                             return (PropertyKind.MetricChange, null, null, false, null, null, true, FieldLayoutKind.Table, false);
                         }
@@ -747,8 +746,7 @@ internal static class TypeParser
                     {
                         var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
                         if (typeDisplayString == "System.Collections.Generic.List<T>" ||
-                            typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>" ||
-                            typeDisplayString == "System.Collections.Generic.IList<T>")
+                            typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>")
                         {
                             return (PropertyKind.MultiSource, null, null, false, null, null, true, FieldLayoutKind.Table, false);
                         }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -736,6 +736,17 @@ internal static class TypeParser
                         if (typeDisplayString == "System.Collections.Generic.List<T>" ||
                             typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>")
                         {
+                            // MetricChange<T> is scalar-only; the T:struct constraint can't exclude composite
+                            // shapes (Segments etc. are structs), so enforce a numeric allow-list here.
+                            var typeArg = metricChangeElement.TypeArguments.Length == 1 ? metricChangeElement.TypeArguments[0] : null;
+                            if (typeArg != null && !IsNumericScalarType(typeArg) && diagnostics != null && propertyName != null)
+                            {
+                                diagnostics.Add(new DiagnosticInfo(
+                                    DiagnosticDescriptors.MetricChangeNonScalarType,
+                                    propertyLocation,
+                                    propertyName,
+                                    typeArg.ToDisplayString()));
+                            }
                             return (PropertyKind.MetricChange, null, null, false, null, null, true, FieldLayoutKind.Table, false);
                         }
                     }
@@ -781,6 +792,15 @@ internal static class TypeParser
 
         return (PropertyKind.Other, null, null, false, null, null, true, FieldLayoutKind.Table, false);
     }
+
+    private static bool IsNumericScalarType(ITypeSymbol type) => type.SpecialType switch
+    {
+        SpecialType.System_Int32 or SpecialType.System_Int64 or SpecialType.System_Int16 or
+        SpecialType.System_Byte or SpecialType.System_SByte or SpecialType.System_UInt16 or
+        SpecialType.System_UInt32 or SpecialType.System_UInt64 or SpecialType.System_Double or
+        SpecialType.System_Single or SpecialType.System_Decimal => true,
+        _ => false
+    };
 
     private static bool HasNestedContent(IReadOnlyList<PropertyMetadata>? props)
     {

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -24,6 +24,7 @@ internal static class TypeParser
     private const string MarkoutSkipNullAttribute = "Markout.MarkoutSkipNullAttribute";
     private const string MarkoutDisplayFormatAttribute = "Markout.MarkoutDisplayFormatAttribute";
     private const string MarkoutMaxItemsAttribute = "Markout.MarkoutMaxItemsAttribute";
+    private const string MarkoutLabelHeaderAttribute = "Markout.MarkoutLabelHeaderAttribute";
     private const string MarkoutTableDisplayAttribute = "Markout.MarkoutTableDisplayAttribute";
     private const string MarkoutValueFormatterAttribute = "Markout.MarkoutValueFormatterAttribute";
     private const string MarkoutShowWhenAttribute = "Markout.MarkoutShowWhenAttribute";
@@ -462,6 +463,16 @@ internal static class TypeParser
             unit = unitValue;
         }
 
+        // Parse [MarkoutLabelHeader] — label/identity column header for a List<MultiSourceRow> card
+        string? multiSourceLabelHeader = null;
+        var labelHeaderAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutLabelHeaderAttribute);
+        if (labelHeaderAttr != null && labelHeaderAttr.ConstructorArguments.Length > 0 &&
+            labelHeaderAttr.ConstructorArguments[0].Value is string labelHeaderValue)
+        {
+            multiSourceLabelHeader = labelHeaderValue;
+        }
+
         // Detect nullable value types before determining property kind
         bool isNullableValueType = false;
         if (prop.Type is INamedTypeSymbol nullableCheck &&
@@ -541,7 +552,8 @@ internal static class TypeParser
             sectionEmptyText,
             deltaMode,
             unit,
-            isReferenceTypeCell);
+            isReferenceTypeCell,
+            multiSourceLabelHeader);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)
@@ -729,6 +741,19 @@ internal static class TypeParser
                         }
                     }
 
+                    // Check for IReadOnlyList<MultiSourceRow> / List<MultiSourceRow> - renders as a
+                    // pivoted multi-source table (roles become columns).
+                    if (SymbolEqualityComparer.Default.Equals(elementType, knownTypes.MultiSourceRow))
+                    {
+                        var typeDisplayString = namedType.OriginalDefinition.ToDisplayString();
+                        if (typeDisplayString == "System.Collections.Generic.List<T>" ||
+                            typeDisplayString == "System.Collections.Generic.IReadOnlyList<T>" ||
+                            typeDisplayString == "System.Collections.Generic.IList<T>")
+                        {
+                            return (PropertyKind.MultiSource, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+                        }
+                    }
+
                     if (elementType.SpecialType == SpecialType.System_String)
                         return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.Table, false);
 
@@ -769,7 +794,7 @@ internal static class TypeParser
              p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree ||
              p.Kind == PropertyKind.Description || p.Kind == PropertyKind.Metric ||
              p.Kind == PropertyKind.CodeSection || p.Kind == PropertyKind.Breakdown ||
-             p.Kind == PropertyKind.MetricChange ||
+             p.Kind == PropertyKind.MetricChange || p.Kind == PropertyKind.MultiSource ||
              (p.Kind == PropertyKind.StringArray && p.JoinSeparator == null)));
     }
 

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -617,6 +617,19 @@ internal static class TypeParser
             if (elementType.SpecialType == SpecialType.System_String)
                 return (PropertyKind.StringArray, null, null, false, null, null, true, FieldLayoutKind.Table, true);
 
+            // MetricChange<T>[] / MultiSourceRow[] — same card shapes as the List<T> forms (arrays
+            // satisfy IReadOnlyList<T>); IsArray=true so the emitter guards on .Length not .Count.
+            if (knownTypes.MetricChange is not null &&
+                elementType is INamedTypeSymbol metricChangeArrayElement &&
+                SymbolEqualityComparer.Default.Equals(metricChangeArrayElement.OriginalDefinition, knownTypes.MetricChange))
+            {
+                ReportIfNonScalarMetricChange(metricChangeArrayElement, diagnostics, propertyName, propertyLocation);
+                return (PropertyKind.MetricChange, null, null, false, null, null, true, FieldLayoutKind.Table, true);
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(elementType, knownTypes.MultiSourceRow))
+                return (PropertyKind.MultiSource, null, null, false, null, null, true, FieldLayoutKind.Table, true);
+
             var elementSettings = GetElementTypeSettings(elementType);
             var elementProps = GetTypeProperties(elementType, compilation, knownTypes, diagnostics, visitedTypes, elementSettings.NamingPolicy, elementSettings.SkipNullByDefault);
             var hasNested = HasNestedContent(elementProps);
@@ -738,15 +751,7 @@ internal static class TypeParser
                         {
                             // MetricChange<T> is scalar-only; the T:struct constraint can't exclude composite
                             // shapes (Segments etc. are structs), so enforce a numeric allow-list here.
-                            var typeArg = metricChangeElement.TypeArguments.Length == 1 ? metricChangeElement.TypeArguments[0] : null;
-                            if (typeArg != null && !IsNumericScalarType(typeArg) && diagnostics != null && propertyName != null)
-                            {
-                                diagnostics.Add(new DiagnosticInfo(
-                                    DiagnosticDescriptors.MetricChangeNonScalarType,
-                                    propertyLocation,
-                                    propertyName,
-                                    typeArg.ToDisplayString()));
-                            }
+                            ReportIfNonScalarMetricChange(metricChangeElement, diagnostics, propertyName, propertyLocation);
                             return (PropertyKind.MetricChange, null, null, false, null, null, true, FieldLayoutKind.Table, false);
                         }
                     }
@@ -801,6 +806,21 @@ internal static class TypeParser
         SpecialType.System_Single or SpecialType.System_Decimal => true,
         _ => false
     };
+
+    // Emits MARKOUT005 when a MetricChange<T> element has a non-numeric-scalar T (e.g. a composite shape).
+    private static void ReportIfNonScalarMetricChange(
+        INamedTypeSymbol metricChangeElement, List<DiagnosticInfo>? diagnostics, string? propertyName, Location? propertyLocation)
+    {
+        var typeArg = metricChangeElement.TypeArguments.Length == 1 ? metricChangeElement.TypeArguments[0] : null;
+        if (typeArg != null && !IsNumericScalarType(typeArg) && diagnostics != null && propertyName != null)
+        {
+            diagnostics.Add(new DiagnosticInfo(
+                DiagnosticDescriptors.MetricChangeNonScalarType,
+                propertyLocation,
+                propertyName,
+                typeArg.ToDisplayString()));
+        }
+    }
 
     private static bool HasNestedContent(IReadOnlyList<PropertyMetadata>? props)
     {

--- a/src/Markout/Attributes/MarkoutLabelHeaderAttribute.cs
+++ b/src/Markout/Attributes/MarkoutLabelHeaderAttribute.cs
@@ -1,0 +1,24 @@
+namespace Markout;
+
+/// <summary>
+/// Sets the label (identity) column header for a <c>List&lt;MultiSourceRow&gt;</c> multi-source
+/// card property (the leftmost column, e.g. <c>"Metric"</c>). When absent, the header defaults to
+/// <c>"Field"</c>.
+/// </summary>
+/// <example>
+///   <code>
+///   [MarkoutSection(Name = "Baseline comparison")]
+///   [MarkoutLabelHeader("Metric")]
+///   public List&lt;MultiSourceRow&gt; Rows { get; set; }
+///   </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutLabelHeaderAttribute : Attribute
+{
+    /// <summary>Initializes the attribute with the label-column header text.</summary>
+    /// <param name="header">The header for the leading label/identity column.</param>
+    public MarkoutLabelHeaderAttribute(string header) => Header = header;
+
+    /// <summary>The header for the leading label/identity column.</summary>
+    public string Header { get; }
+}

--- a/src/Markout/GateStatus.cs
+++ b/src/Markout/GateStatus.cs
@@ -26,3 +26,16 @@ public enum GateStatus
     /// <summary>A negative outcome (regression / violation / failure).</summary>
     Bad
 }
+
+/// <summary>Shared slug text for <see cref="GateStatus"/> polarity values.</summary>
+internal static class GateStatusText
+{
+    public static string Slug(GateStatus status) => status switch
+    {
+        GateStatus.Good => "good",
+        GateStatus.Neutral => "neutral",
+        GateStatus.Warning => "warning",
+        GateStatus.Bad => "bad",
+        _ => "unknown"
+    };
+}

--- a/src/Markout/GateStatus.cs
+++ b/src/Markout/GateStatus.cs
@@ -1,0 +1,28 @@
+namespace Markout;
+
+/// <summary>
+/// The polarity of a gate/verdict outcome. This is the neutral, domain-independent category a
+/// renderer uses to pick a badge/color; the exact domain word (<c>regression</c>, <c>BETTER</c>,
+/// <c>drift</c>, …) is carried by <see cref="Verdict.Label"/>.
+/// </summary>
+/// <remarks>
+/// The member set is provisional pending design sign-off (issue #128): it may become a curated
+/// domain vocabulary or stay a small polarity scale plus caller label.
+/// </remarks>
+public enum GateStatus
+{
+    /// <summary>No/unknown outcome.</summary>
+    Unknown,
+
+    /// <summary>A positive outcome (improvement / pass).</summary>
+    Good,
+
+    /// <summary>A neutral outcome (unchanged).</summary>
+    Neutral,
+
+    /// <summary>A cautionary outcome (drift / warning).</summary>
+    Warning,
+
+    /// <summary>A negative outcome (regression / violation / failure).</summary>
+    Bad
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.16.1</Version>
-    <PackageReleaseNotes>Composite-cell shapes (Change&lt;V&gt;, Fraction, Share, Percent, Segments) with [MarkoutDelta]/[MarkoutUnit] render as a dense Markdown table and decompose into typed JSONL/TSV columns. JSONL supports heterogeneous records (MarkoutWriterOptions.OmitEmptyJsonFields) and numeric/boolean values (MarkoutWriterOptions.JsonTypedValues). BREAKING (since 0.16.0): the Breakdown element type Segment(Category, Count) is renamed to Slice(Category, Count) and Breakdown.Segments to Breakdown.Slices; update `new Segment(...)` to `new Slice(...)`.</PackageReleaseNotes>
+    <Version>0.17.0</Version>
+    <PackageReleaseNotes>First-class multi-source data cards: MetricChange&lt;T&gt; renders as a Metric | Change | Target | Status table, and MultiSourceRow/Source pivot named roles into columns; both decompose to flat typed JSONL/TSV. GateStatus/Verdict is a first-class verdict cell; Source accepts scalars (new Source("baseline", 2)) and Source.Text(...); [MarkoutLabelHeader] sets the pivot label column; MARKOUT005 enforces MetricChange&lt;T&gt;'s numeric-scalar contract. BREAKING: nested Segments decomposition keys flip label-first to side-first (e.g. web_before becomes before_web) so multi-source keys are uniform as {role}_{side}_{field}; standalone Segments keys are unchanged.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -143,8 +143,4 @@ internal static class CellText
     /// <summary>Combines a decomposition <paramref name="side"/> with a sub-field name as <c>{side}_{sub}</c>.</summary>
     public static string SideKey(string? side, string sub)
         => side is null ? sub : side + "_" + sub;
-
-    /// <summary>Combines a segment <paramref name="label"/> with a decomposition side as <c>{label}_{side}</c>.</summary>
-    public static string LabelKey(string label, string? side)
-        => side is null ? label : label + "_" + side;
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -594,45 +594,43 @@ public class MarkoutWriter
             perRow[r] = tagged;
         }
 
-        // Guard against silent overwrite when two sources in the SAME row compose the same flat key
-        // (e.g. role "a" + field "b_c" vs role "a_b" + field "c" → both "a_b_c"). Disambiguate the
-        // later collision deterministically so no value is dropped.
-        foreach (var tagged in perRow)
-        {
-            var seenInRow = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var (_, fields) in tagged)
-            {
-                for (int i = 0; i < fields.Count; i++)
-                {
-                    var key = fields[i].Key;
-                    if (!seenInRow.Add(key))
-                    {
-                        int suffix = 2;
-                        string candidate;
-                        do { candidate = key + "_" + suffix++; } while (!seenInRow.Add(candidate));
-                        fields[i] = new MarkoutField(candidate, fields[i].Value);
-                    }
-                }
-            }
-        }
-
+        // Assign every distinct (role, composed-field-key) a unique output column, deterministically
+        // by global role order (roleOrder) then first-seen field order — so the same source maps to
+        // the same column in EVERY row regardless of per-row source order or presence. Colliding
+        // composed keys (role "a"+"b_c" vs role "a_b"+"c" → both "a_b_c") get a deterministic "_N"
+        // suffix on the later role, applied globally rather than per row.
+        var columnOf = new Dictionary<(string Role, string Field), string>();
+        var takenColumns = new HashSet<string>(StringComparer.Ordinal);
         var keyOrder = new List<string>();
-        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
         foreach (var role in roleOrder)
             foreach (var tagged in perRow)
                 foreach (var (owner, fields) in tagged)
                     if (owner == role)
                         foreach (var field in fields)
-                            if (seenKeys.Add(field.Key))
-                                keyOrder.Add(field.Key);
+                        {
+                            var id = (role, field.Key);
+                            if (columnOf.ContainsKey(id))
+                                continue;
+                            var column = field.Key;
+                            if (!takenColumns.Add(column))
+                            {
+                                int suffix = 2;
+                                string candidate;
+                                do { candidate = field.Key + "_" + suffix++; } while (!takenColumns.Add(candidate));
+                                column = candidate;
+                            }
+                            columnOf[id] = column;
+                            keyOrder.Add(column);
+                        }
 
-        // Flatten the role-tagged fields into one list per row for the shared emitter.
+        // Flatten each row into (column, value) using the global map.
         var perRowFlat = new List<MarkoutField>[perRow.Length];
         for (int r = 0; r < perRow.Length; r++)
         {
             var flat = new List<MarkoutField>();
-            foreach (var (_, fields) in perRow[r])
-                flat.AddRange(fields);
+            foreach (var (role, fields) in perRow[r])
+                foreach (var field in fields)
+                    flat.Add(new MarkoutField(columnOf[(role, field.Key)], field.Value));
             perRowFlat[r] = flat;
         }
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -503,9 +503,9 @@ public class MarkoutWriter
     /// <param name="labelHeader">The header/identity-column name for the row labels.</param>
     /// <param name="rows">The multi-source rows.</param>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteMultiSourceTable(string labelHeader, params ReadOnlySpan<MultiSourceRow> rows)
+    public bool WriteMultiSourceTable(string labelHeader, IReadOnlyList<MultiSourceRow> rows)
     {
-        if (_sectionExcluded || rows.Length == 0)
+        if (_sectionExcluded || rows.Count == 0)
             return true;
 
         if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
@@ -534,14 +534,14 @@ public class MarkoutWriter
 
     // Document formatters: one column per role; each cell the dense render of that role's value.
     private bool WriteDenseMultiSourceTable(
-        string labelHeader, ReadOnlySpan<MultiSourceRow> rows, List<string> roleOrder, Dictionary<string, int> roleIndex)
+        string labelHeader, IReadOnlyList<MultiSourceRow> rows, List<string> roleOrder, Dictionary<string, int> roleIndex)
     {
         var headers = new string[roleOrder.Count + 1];
         headers[0] = labelHeader;
         for (int i = 0; i < roleOrder.Count; i++)
             headers[i + 1] = roleOrder[i];
 
-        var outRows = new List<string[]>(rows.Length);
+        var outRows = new List<string[]>(rows.Count);
         foreach (var row in rows)
         {
             var values = new string[roleOrder.Count + 1];
@@ -569,13 +569,13 @@ public class MarkoutWriter
 
     // Decomposing formatters (TSV/JSONL): one flat record per row, {role}_{field} columns.
     private bool WriteDecomposedMultiSourceTable(
-        string labelHeader, ReadOnlySpan<MultiSourceRow> rows, List<string> roleOrder)
+        string labelHeader, IReadOnlyList<MultiSourceRow> rows, List<string> roleOrder)
     {
         // Decompose each source with side = role, tagging fields with their owning role so the
         // column union can be ordered role-major (caller role order), then field order within a role.
-        var perRow = new List<(string Role, List<MarkoutField> Fields)>[rows.Length];
-        var labels = new string[rows.Length];
-        for (int r = 0; r < rows.Length; r++)
+        var perRow = new List<(string Role, List<MarkoutField> Fields)>[rows.Count];
+        var labels = new string[rows.Count];
+        for (int r = 0; r < rows.Count; r++)
         {
             var row = rows[r];
             labels[r] = row.Label;
@@ -685,9 +685,9 @@ public class MarkoutWriter
     /// structured output.
     /// </summary>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteMetricChangeTable<T>(params ReadOnlySpan<MetricChange<T>> rows) where T : struct
+    public bool WriteMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows) where T : struct
     {
-        if (_sectionExcluded || rows.Length == 0)
+        if (_sectionExcluded || rows.Count == 0)
             return true;
 
         if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
@@ -696,21 +696,21 @@ public class MarkoutWriter
         if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
             return WriteDecomposedMetricChangeTable(rows);
 
-        var outRows = new List<string[]>(rows.Length);
+        var outRows = new List<string[]>(rows.Count);
         foreach (var metric in rows)
             outRows.Add([metric.Name, ChangeText(metric), TargetText(metric), StatusText(metric)]);
 
         return WriteTable(["Metric", "Change", "Target", "Status"], outRows);
     }
 
-    private bool WriteDecomposedMetricChangeTable<T>(ReadOnlySpan<MetricChange<T>> rows) where T : struct
+    private bool WriteDecomposedMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows) where T : struct
     {
-        var labels = new string[rows.Length];
-        var perRow = new List<MarkoutField>[rows.Length];
+        var labels = new string[rows.Count];
+        var perRow = new List<MarkoutField>[rows.Count];
         var keyOrder = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
-        for (int r = 0; r < rows.Length; r++)
+        for (int r = 0; r < rows.Count; r++)
         {
             var metric = rows[r];
             labels[r] = metric.Name;

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -594,6 +594,28 @@ public class MarkoutWriter
             perRow[r] = tagged;
         }
 
+        // Guard against silent overwrite when two sources in the SAME row compose the same flat key
+        // (e.g. role "a" + field "b_c" vs role "a_b" + field "c" → both "a_b_c"). Disambiguate the
+        // later collision deterministically so no value is dropped.
+        foreach (var tagged in perRow)
+        {
+            var seenInRow = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var (_, fields) in tagged)
+            {
+                for (int i = 0; i < fields.Count; i++)
+                {
+                    var key = fields[i].Key;
+                    if (!seenInRow.Add(key))
+                    {
+                        int suffix = 2;
+                        string candidate;
+                        do { candidate = key + "_" + suffix++; } while (!seenInRow.Add(candidate));
+                        fields[i] = new MarkoutField(candidate, fields[i].Value);
+                    }
+                }
+            }
+        }
+
         var keyOrder = new List<string>();
         var seenKeys = new HashSet<string>(StringComparer.Ordinal);
         foreach (var role in roleOrder)

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -493,6 +493,170 @@ public class MarkoutWriter
     }
 
     /// <summary>
+    /// Writes a multi-source pivot table: each <see cref="MultiSourceRow"/> carries named-role
+    /// cells. Formatters that decompose composites (<see cref="Formatting.ICompositeCellFormatter"/>,
+    /// i.e. TSV/JSONL) emit one flat record per row with <c>{role}_{field}</c> columns (each cell
+    /// decomposed with its role as the side); all others render a wide table with one column per
+    /// role — caller-supplied role order (first appearance across rows), a role absent from a row
+    /// rendered as <c>-</c>, and each cell the dense render of that role's value.
+    /// </summary>
+    /// <param name="labelHeader">The header/identity-column name for the row labels.</param>
+    /// <param name="rows">The multi-source rows.</param>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
+    public bool WriteMultiSourceTable(string labelHeader, params ReadOnlySpan<MultiSourceRow> rows)
+    {
+        if (_sectionExcluded || rows.Length == 0)
+            return true;
+
+        if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
+            return false;
+
+        // Column axis = roles in caller (first-appearance) order across the whole row collection.
+        var roleOrder = new List<string>();
+        var roleIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            if (row.Sources is null)
+                continue;
+            foreach (var source in row.Sources)
+                if (source.Role is not null && roleIndex.TryAdd(source.Role, roleOrder.Count))
+                    roleOrder.Add(source.Role);
+        }
+
+        if (roleOrder.Count == 0)
+            return true;
+
+        if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
+            return WriteDecomposedMultiSourceTable(labelHeader, rows, roleOrder);
+
+        return WriteDenseMultiSourceTable(labelHeader, rows, roleOrder, roleIndex);
+    }
+
+    // Document formatters: one column per role; each cell the dense render of that role's value.
+    private bool WriteDenseMultiSourceTable(
+        string labelHeader, ReadOnlySpan<MultiSourceRow> rows, List<string> roleOrder, Dictionary<string, int> roleIndex)
+    {
+        var headers = new string[roleOrder.Count + 1];
+        headers[0] = labelHeader;
+        for (int i = 0; i < roleOrder.Count; i++)
+            headers[i + 1] = roleOrder[i];
+
+        var outRows = new List<string[]>(rows.Length);
+        foreach (var row in rows)
+        {
+            var values = new string[roleOrder.Count + 1];
+            values[0] = row.Label;
+            for (int i = 1; i < values.Length; i++)
+                values[i] = "-";
+
+            if (row.Sources is not null)
+            {
+                foreach (var source in row.Sources)
+                {
+                    if (source.Role is null || source.Value is null || !roleIndex.TryGetValue(source.Role, out var idx))
+                        continue;
+                    var sw = new StringWriter();
+                    source.Value.FormatInline(sw, source.Format);
+                    values[idx + 1] = sw.ToString();
+                }
+            }
+
+            outRows.Add(values);
+        }
+
+        return WriteTable(headers, outRows);
+    }
+
+    // Decomposing formatters (TSV/JSONL): one flat record per row, {role}_{field} columns.
+    private bool WriteDecomposedMultiSourceTable(
+        string labelHeader, ReadOnlySpan<MultiSourceRow> rows, List<string> roleOrder)
+    {
+        // Decompose each source with side = role, tagging fields with their owning role so the
+        // column union can be ordered role-major (caller role order), then field order within a role.
+        var perRow = new List<(string Role, List<MarkoutField> Fields)>[rows.Length];
+        var labels = new string[rows.Length];
+        for (int r = 0; r < rows.Length; r++)
+        {
+            var row = rows[r];
+            labels[r] = row.Label;
+            var tagged = new List<(string, List<MarkoutField>)>();
+            if (row.Sources is not null)
+            {
+                foreach (var source in row.Sources)
+                {
+                    if (source.Role is null || source.Value is null)
+                        continue;
+                    var fields = new List<MarkoutField>();
+                    source.Value.Decompose(fields, source.Role, source.Format);
+                    tagged.Add((source.Role, fields));
+                }
+            }
+            perRow[r] = tagged;
+        }
+
+        var keyOrder = new List<string>();
+        var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var role in roleOrder)
+            foreach (var tagged in perRow)
+                foreach (var (owner, fields) in tagged)
+                    if (owner == role)
+                        foreach (var field in fields)
+                            if (keyIndex.TryAdd(field.Key, keyOrder.Count))
+                                keyOrder.Add(field.Key);
+
+        // Leading identity column (from labelHeader) + one column per union key. Stable header
+        // names are snake-cased and de-duped, mirroring WriteDecomposedCompositeTable, because
+        // TableWriter re-applies ToSnakeCase to header keys for TSV/JSONL.
+        var headers = new string[keyOrder.Count + 1];
+        var headerNames = new string[keyOrder.Count + 1];
+        headers[0] = labelHeader;
+        var labelKey = Formatting.FormatHelper.ToSnakeCase(labelHeader);
+        if (string.IsNullOrEmpty(labelKey))
+            labelKey = "field";
+        headerNames[0] = labelKey;
+        var usedStableKeys = new HashSet<string>(StringComparer.Ordinal) { labelKey };
+
+        for (int i = 0; i < keyOrder.Count; i++)
+        {
+            headers[i + 1] = keyOrder[i];
+            var stable = Formatting.FormatHelper.ToSnakeCase(keyOrder[i]);
+            if (string.IsNullOrEmpty(stable))
+                stable = "column";
+            if (!usedStableKeys.Add(stable))
+            {
+                int suffix = 2;
+                string candidate;
+                do { candidate = stable + "_" + suffix++; } while (!usedStableKeys.Add(candidate));
+                stable = candidate;
+            }
+            headerNames[i + 1] = stable;
+        }
+
+        var outRows = new List<string[]>(perRow.Length);
+        for (int r = 0; r < perRow.Length; r++)
+        {
+            var values = new string[keyOrder.Count + 1];
+            values[0] = labels[r];
+            for (int i = 1; i < values.Length; i++)
+                values[i] = "";
+            foreach (var (_, fields) in perRow[r])
+                foreach (var field in fields)
+                    values[keyIndex[field.Key] + 1] = field.Value;
+            outRows.Add(values);
+        }
+
+        _pendingJsonIdentityColumns = 1;
+        try
+        {
+            return WriteTable(headers, headerNames, outRows);
+        }
+        finally
+        {
+            _pendingJsonIdentityColumns = 0;
+        }
+    }
+
+    /// <summary>
     /// Writes a single bullet list item.
     /// </summary>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support lists.</returns>

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -595,18 +595,39 @@ public class MarkoutWriter
         }
 
         var keyOrder = new List<string>();
-        var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
         foreach (var role in roleOrder)
             foreach (var tagged in perRow)
                 foreach (var (owner, fields) in tagged)
                     if (owner == role)
                         foreach (var field in fields)
-                            if (keyIndex.TryAdd(field.Key, keyOrder.Count))
+                            if (seenKeys.Add(field.Key))
                                 keyOrder.Add(field.Key);
 
-        // Leading identity column (from labelHeader) + one column per union key. Stable header
-        // names are snake-cased and de-duped, mirroring WriteDecomposedCompositeTable, because
-        // TableWriter re-applies ToSnakeCase to header keys for TSV/JSONL.
+        // Flatten the role-tagged fields into one list per row for the shared emitter.
+        var perRowFlat = new List<MarkoutField>[perRow.Length];
+        for (int r = 0; r < perRow.Length; r++)
+        {
+            var flat = new List<MarkoutField>();
+            foreach (var (_, fields) in perRow[r])
+                flat.AddRange(fields);
+            perRowFlat[r] = flat;
+        }
+
+        return WriteDecomposedFieldTable(labelHeader, labels, perRowFlat, keyOrder);
+    }
+
+    // Shared emitter for flat decomposed record tables (multi-source, metric-change): a leading
+    // identity column (from labelHeader) plus one column per key in keyOrder. Stable header names
+    // are snake-cased and de-duped because TableWriter re-applies ToSnakeCase to header keys for
+    // TSV/JSONL; the leading identity column stays a JSON string.
+    private bool WriteDecomposedFieldTable(
+        string labelHeader, IReadOnlyList<string> labels, IReadOnlyList<List<MarkoutField>> perRowFields, IReadOnlyList<string> keyOrder)
+    {
+        var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int i = 0; i < keyOrder.Count; i++)
+            keyIndex[keyOrder[i]] = i;
+
         var headers = new string[keyOrder.Count + 1];
         var headerNames = new string[keyOrder.Count + 1];
         headers[0] = labelHeader;
@@ -632,16 +653,16 @@ public class MarkoutWriter
             headerNames[i + 1] = stable;
         }
 
-        var outRows = new List<string[]>(perRow.Length);
-        for (int r = 0; r < perRow.Length; r++)
+        var outRows = new List<string[]>(perRowFields.Count);
+        for (int r = 0; r < perRowFields.Count; r++)
         {
             var values = new string[keyOrder.Count + 1];
             values[0] = labels[r];
             for (int i = 1; i < values.Length; i++)
                 values[i] = "";
-            foreach (var (_, fields) in perRow[r])
-                foreach (var field in fields)
-                    values[keyIndex[field.Key] + 1] = field.Value;
+            foreach (var field in perRowFields[r])
+                if (keyIndex.TryGetValue(field.Key, out var idx))
+                    values[idx + 1] = field.Value;
             outRows.Add(values);
         }
 
@@ -654,6 +675,81 @@ public class MarkoutWriter
         {
             _pendingJsonIdentityColumns = 0;
         }
+    }
+
+    /// <summary>
+    /// Writes a gated-metric table from <see cref="MetricChange{T}"/> rows: document formatters
+    /// render fixed <c>Metric | Change | Target | Status</c> columns; decomposing formatters
+    /// (TSV/JSONL) emit flat typed fields (<c>before</c>, <c>after</c>, optional <c>target</c>/
+    /// <c>target_label</c>, <c>status</c>). Absent targets render <c>-</c> and are omitted from
+    /// structured output.
+    /// </summary>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
+    public bool WriteMetricChangeTable<T>(params ReadOnlySpan<MetricChange<T>> rows) where T : struct
+    {
+        if (_sectionExcluded || rows.Length == 0)
+            return true;
+
+        if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
+            return false;
+
+        if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
+            return WriteDecomposedMetricChangeTable(rows);
+
+        var outRows = new List<string[]>(rows.Length);
+        foreach (var metric in rows)
+            outRows.Add([metric.Name, ChangeText(metric), TargetText(metric), StatusText(metric)]);
+
+        return WriteTable(["Metric", "Change", "Target", "Status"], outRows);
+    }
+
+    private bool WriteDecomposedMetricChangeTable<T>(ReadOnlySpan<MetricChange<T>> rows) where T : struct
+    {
+        var labels = new string[rows.Length];
+        var perRow = new List<MarkoutField>[rows.Length];
+        var keyOrder = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        for (int r = 0; r < rows.Length; r++)
+        {
+            var metric = rows[r];
+            labels[r] = metric.Name;
+            var fields = new List<MarkoutField>();
+            new Change<T>(metric.Before, metric.After).Decompose(fields, null, default);
+            if (metric.Target is not null)
+            {
+                fields.Add(new MarkoutField("target", CellText.Scalar(metric.Target.Value)));
+                if (!string.IsNullOrEmpty(metric.TargetLabel))
+                    fields.Add(new MarkoutField("targetLabel", metric.TargetLabel!));
+            }
+            if (metric.Status != GateStatus.Unknown || !string.IsNullOrEmpty(metric.StatusLabel))
+                fields.Add(new MarkoutField("status", StatusText(metric)));
+
+            perRow[r] = fields;
+            foreach (var field in fields)
+                if (seen.Add(field.Key))
+                    keyOrder.Add(field.Key);
+        }
+
+        return WriteDecomposedFieldTable("Metric", labels, perRow, keyOrder);
+    }
+
+    private static string ChangeText<T>(in MetricChange<T> metric) where T : struct
+        => MarkoutCell.ToInlineString(new Change<T>(metric.Before, metric.After));
+
+    private static string TargetText<T>(in MetricChange<T> metric) where T : struct
+    {
+        if (metric.Target is null)
+            return "-";
+        var value = CellText.Scalar(metric.Target.Value);
+        return string.IsNullOrEmpty(metric.TargetLabel) ? value : metric.TargetLabel + ": " + value;
+    }
+
+    private static string StatusText<T>(in MetricChange<T> metric) where T : struct
+    {
+        if (!string.IsNullOrEmpty(metric.StatusLabel))
+            return metric.StatusLabel!;
+        return metric.Status == GateStatus.Unknown ? "-" : GateStatusText.Slug(metric.Status);
     }
 
     /// <summary>

--- a/src/Markout/MetricChange.cs
+++ b/src/Markout/MetricChange.cs
@@ -1,0 +1,30 @@
+namespace Markout;
+
+/// <summary>
+/// A gated scalar metric change: a <c>Before → After</c> value with an optional target/threshold
+/// and a caller-supplied status. The ergonomic specialization of a multi-source row for the common
+/// baseline-delta case; a collection renders as a <c>Metric | Change | Target | Status</c> table
+/// and decomposes to flat typed fields (<c>before</c>, <c>after</c>, optional <c>target</c>/
+/// <c>target_label</c>, <c>status</c>).
+/// </summary>
+/// <remarks>
+/// Restricted to <c>struct</c> scalar values; the source generator further limits <typeparamref name="T"/>
+/// to the renderable numeric scalars (composite shapes like <see cref="Segments"/> stay ordinary rows).
+/// <see cref="Status"/> is caller-supplied — Markout never derives regression/drift from the values.
+/// </remarks>
+/// <param name="Name">The metric name (leading identity column).</param>
+/// <param name="Before">The value before.</param>
+/// <param name="After">The value after.</param>
+/// <param name="Target">An optional target/threshold; <c>null</c> for an ungated metric.</param>
+/// <param name="TargetLabel">An optional domain label for the target (e.g. <c>"allowed failures"</c>).</param>
+/// <param name="Status">The caller-supplied outcome polarity.</param>
+/// <param name="StatusLabel">An optional caller display word for the status (e.g. <c>"regression"</c>).</param>
+public readonly record struct MetricChange<T>(
+    string Name,
+    T Before,
+    T After,
+    T? Target = null,
+    string? TargetLabel = null,
+    GateStatus Status = GateStatus.Unknown,
+    string? StatusLabel = null)
+    where T : struct;

--- a/src/Markout/MultiSourceRow.cs
+++ b/src/Markout/MultiSourceRow.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// One row of a multi-source card: a label plus named-role cells (<see cref="Source"/>). A
+/// collection of these renders as a <em>pivoted</em> wide table — one column per role, each cell
+/// the dense render of that role's value — in document formatters, and decomposes to one flat
+/// <c>{role}_{field}</c> record per row in structured formatters (TSV/JSONL).
+/// </summary>
+/// <remarks>
+/// Rows may be <b>heterogeneous</b>: different rows can carry different roles and different cell
+/// types (e.g. metric rows hold <see cref="Change{V}"/> cells while a verdict row holds
+/// <see cref="Verdict"/> cells). Column order is the caller-supplied role order (first appearance
+/// across the row collection); a role absent from a given row renders as <c>-</c>.
+/// </remarks>
+public readonly struct MultiSourceRow
+{
+    /// <summary>Creates a row from a label and its named-role cells.</summary>
+    /// <param name="label">The row label (the leading identity column / cell).</param>
+    /// <param name="sources">The named-role cells, in caller-supplied column order.</param>
+    public MultiSourceRow(string label, params Source[] sources)
+    {
+        Label = label;
+        Sources = sources ?? [];
+    }
+
+    /// <summary>The row label (leading identity column).</summary>
+    public string Label { get; }
+
+    /// <summary>The named-role cells for this row, in caller-supplied order.</summary>
+    public IReadOnlyList<Source> Sources { get; }
+}

--- a/src/Markout/Segments.cs
+++ b/src/Markout/Segments.cs
@@ -11,7 +11,7 @@ public readonly record struct Segment(string Label, double Value);
 /// <summary>
 /// A set of independent labeled parts with no shared denominator, rendered slash-joined as
 /// <c>21/171/236</c>. Each label becomes a decomposed field (as <c>{label}</c>, or
-/// <c>{label}_{side}</c> when nested in a <see cref="Change{V}"/>).
+/// <c>{side}_{label}</c> when nested in a <see cref="Change{V}"/>).
 /// </summary>
 /// <param name="Parts">The labeled parts, rendered left-to-right in order.</param>
 public readonly record struct Segments(params Segment[] Parts) : IMarkoutCell
@@ -35,6 +35,6 @@ public readonly record struct Segments(params Segment[] Parts) : IMarkoutCell
         if (Parts is null)
             return;
         foreach (var part in Parts)
-            fields.Add(new MarkoutField(CellText.LabelKey(part.Label, side), CellText.Number(part.Value)));
+            fields.Add(new MarkoutField(CellText.SideKey(side, part.Label), CellText.Number(part.Value)));
     }
 }

--- a/src/Markout/Source.cs
+++ b/src/Markout/Source.cs
@@ -1,0 +1,12 @@
+namespace Markout;
+
+/// <summary>
+/// One named source within a <see cref="MultiSourceRow"/>. The <paramref name="Role"/> names the
+/// column in the pivoted Markdown table and the decomposition prefix in structured output; the
+/// <paramref name="Value"/> is any composite cell (a scalar cell, a nested <see cref="Change{V}"/>,
+/// a <see cref="Verdict"/>, etc.). A <c>null</c> value renders as an empty/absent cell.
+/// </summary>
+/// <param name="Role">The source role (e.g. a model name, or <c>baseline</c>/<c>current</c>).</param>
+/// <param name="Value">The cell for this role.</param>
+/// <param name="Format">Render-time derivation/format options for this cell.</param>
+public readonly record struct Source(string Role, IMarkoutCell? Value, MarkoutCellFormat Format = default);

--- a/src/Markout/Source.cs
+++ b/src/Markout/Source.cs
@@ -9,4 +9,35 @@ namespace Markout;
 /// <param name="Role">The source role (e.g. a model name, or <c>baseline</c>/<c>current</c>).</param>
 /// <param name="Value">The cell for this role.</param>
 /// <param name="Format">Render-time derivation/format options for this cell.</param>
-public readonly record struct Source(string Role, IMarkoutCell? Value, MarkoutCellFormat Format = default);
+public readonly record struct Source(string Role, IMarkoutCell? Value, MarkoutCellFormat Format = default)
+{
+    /// <summary>Creates a source with an integral scalar value (decomposes to a single <c>{role}</c> field).</summary>
+    public Source(string role, long value, MarkoutCellFormat format = default)
+        : this(role, new ScalarSourceCell(value), format) { }
+
+    /// <summary>Creates a source with a floating-point scalar value (decomposes to a single <c>{role}</c> field).</summary>
+    public Source(string role, double value, MarkoutCellFormat format = default)
+        : this(role, new ScalarSourceCell(value), format) { }
+
+    /// <summary>Creates a source with a decimal scalar value (decomposes to a single <c>{role}</c> field).</summary>
+    public Source(string role, decimal value, MarkoutCellFormat format = default)
+        : this(role, new ScalarSourceCell(value), format) { }
+
+    /// <summary>Creates a source with a text scalar value (decomposes to a single <c>{role}</c> field).</summary>
+    public Source(string role, string value, MarkoutCellFormat format = default)
+        : this(role, new ScalarSourceCell(value), format) { }
+}
+
+/// <summary>
+/// Wraps a plain scalar as an <see cref="IMarkoutCell"/> for use as a <see cref="Source"/> value:
+/// renders verbatim and decomposes to a single field keyed by the enclosing role (<c>{role}</c>),
+/// so a card can mix scalar role cells with composite ones.
+/// </summary>
+internal sealed class ScalarSourceCell(object? value) : IMarkoutCell
+{
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+        => writer.Write(CellText.Scalar(value));
+
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+        => fields.Add(new MarkoutField(side ?? "value", CellText.Scalar(value)));
+}

--- a/src/Markout/Source.cs
+++ b/src/Markout/Source.cs
@@ -23,9 +23,13 @@ public readonly record struct Source(string Role, IMarkoutCell? Value, MarkoutCe
     public Source(string role, decimal value, MarkoutCellFormat format = default)
         : this(role, new ScalarSourceCell(value), format) { }
 
-    /// <summary>Creates a source with a text scalar value (decomposes to a single <c>{role}</c> field).</summary>
-    public Source(string role, string value, MarkoutCellFormat format = default)
-        : this(role, new ScalarSourceCell(value), format) { }
+    /// <summary>
+    /// Creates a source with a text scalar value (decomposes to a single <c>{role}</c> field). A static
+    /// factory rather than a constructor so a <c>string</c> overload does not make <c>new Source(role, null)</c>
+    /// ambiguous with the primary <see cref="IMarkoutCell"/> constructor.
+    /// </summary>
+    public static Source Text(string role, string value, MarkoutCellFormat format = default)
+        => new(role, new ScalarSourceCell(value), format);
 }
 
 /// <summary>

--- a/src/Markout/Verdict.cs
+++ b/src/Markout/Verdict.cs
@@ -18,14 +18,5 @@ public readonly record struct Verdict(GateStatus Status, string? Label = null) :
     public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
         => fields.Add(new MarkoutField(CellText.SideKey(side, "status"), Text));
 
-    private string Text => string.IsNullOrEmpty(Label) ? Slug(Status) : Label!;
-
-    private static string Slug(GateStatus status) => status switch
-    {
-        GateStatus.Good => "good",
-        GateStatus.Neutral => "neutral",
-        GateStatus.Warning => "warning",
-        GateStatus.Bad => "bad",
-        _ => "unknown"
-    };
+    private string Text => string.IsNullOrEmpty(Label) ? GateStatusText.Slug(Status) : Label!;
 }

--- a/src/Markout/Verdict.cs
+++ b/src/Markout/Verdict.cs
@@ -16,7 +16,7 @@ public readonly record struct Verdict(GateStatus Status, string? Label = null) :
 
     /// <inheritdoc/>
     public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
-        => fields.Add(new MarkoutField(CellText.SideKey(side, "status"), Text));
+        => fields.Add(new MarkoutField(side ?? "status", Text));
 
     private string Text => string.IsNullOrEmpty(Label) ? GateStatusText.Slug(Status) : Label!;
 }

--- a/src/Markout/Verdict.cs
+++ b/src/Markout/Verdict.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// A first-class gate/verdict cell: a typed <see cref="GateStatus"/> polarity plus an optional
+/// caller display label (e.g. <c>"regression"</c>, <c>"BETTER"</c>). The label — or, when absent,
+/// the polarity slug — renders densely; structured output decomposes to a <c>status</c> field.
+/// Lets a card carry a verdict as typed data instead of a caller-formatted string.
+/// </summary>
+/// <param name="Status">The outcome polarity (drives badge/color in capable renderers).</param>
+/// <param name="Label">An optional caller display word; overrides the polarity slug.</param>
+public readonly record struct Verdict(GateStatus Status, string? Label = null) : IMarkoutCell
+{
+    /// <inheritdoc/>
+    public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
+        => writer.Write(Text);
+
+    /// <inheritdoc/>
+    public void Decompose(ICollection<MarkoutField> fields, string? side, in MarkoutCellFormat format)
+        => fields.Add(new MarkoutField(CellText.SideKey(side, "status"), Text));
+
+    private string Text => string.IsNullOrEmpty(Label) ? Slug(Status) : Label!;
+
+    private static string Slug(GateStatus status) => status switch
+    {
+        GateStatus.Good => "good",
+        GateStatus.Neutral => "neutral",
+        GateStatus.Warning => "warning",
+        GateStatus.Bad => "bad",
+        _ => "unknown"
+    };
+}

--- a/tests/Markout.Tests/CompositeCellTests.cs
+++ b/tests/Markout.Tests/CompositeCellTests.cs
@@ -236,7 +236,7 @@ public class CompositeCellTests
     }
 
     [Fact]
-    public void Change_NestedSegments_RendersAndDecomposesByLabelAndSide()
+    public void Change_NestedSegments_RendersAndDecomposesBySideAndLabel()
     {
         var cell = new Change<Segments>(
             new Segments(new Segment("web", 21), new Segment("bash", 171), new Segment("other", 236)),
@@ -246,8 +246,8 @@ public class CompositeCellTests
         var fields = Decompose(cell);
         Assert.Equal(
             [
-                new("web_before", "21"), new("bash_before", "171"), new("other_before", "236"),
-                new("web_after", "0"), new("bash_after", "75"), new("other_after", "183")
+                new("before_web", "21"), new("before_bash", "171"), new("before_other", "236"),
+                new("after_web", "0"), new("after_bash", "75"), new("after_other", "183")
             ],
             fields);
     }
@@ -296,7 +296,7 @@ public class CompositeCellTests
         Assert.Equal("field", headers[0]);
         Assert.Contains("before", headers);
         Assert.Contains("delta_pct", headers);
-        Assert.Contains("web_before", headers);
+        Assert.Contains("before_web", headers);
 
         // Session IET row carries before/after/delta but no segment columns.
         var sessionRow = lines[1].Split('\t');
@@ -321,8 +321,8 @@ public class CompositeCellTests
         Assert.Equal("-38", session.GetProperty("delta_pct").GetString());
 
         var tools = JsonDocument.Parse(lines[1]).RootElement;
-        Assert.Equal("21", tools.GetProperty("web_before").GetString());
-        Assert.Equal("183", tools.GetProperty("other_after").GetString());
+        Assert.Equal("21", tools.GetProperty("before_web").GetString());
+        Assert.Equal("183", tools.GetProperty("after_other").GetString());
     }
 
     // ── End-to-end through the source generator ──
@@ -384,7 +384,7 @@ public class CompositeCellTests
 
         Assert.Equal("field", headers[0]);
         Assert.Contains("before_count", headers);
-        Assert.Contains("web_before", headers);
+        Assert.Contains("before_web", headers);
         Assert.Contains("delta_pct", headers);
         Assert.Contains("value", headers);
     }
@@ -565,10 +565,10 @@ public class CompositeCellTests
         // Each record carries only its own keys — a scalar Change row has no segment columns.
         var session = JsonDocument.Parse(lines[0]).RootElement;
         Assert.True(session.TryGetProperty("before", out _));
-        Assert.False(session.TryGetProperty("web_before", out _));
+        Assert.False(session.TryGetProperty("before_web", out _));
 
         var tools = JsonDocument.Parse(lines[1]).RootElement;
-        Assert.True(tools.TryGetProperty("web_before", out _));
+        Assert.True(tools.TryGetProperty("before_web", out _));
         Assert.False(tools.TryGetProperty("before", out _));
 
         var verdict = JsonDocument.Parse(lines[2]).RootElement;

--- a/tests/Markout.Tests/GeneratedMetricChangeTests.cs
+++ b/tests/Markout.Tests/GeneratedMetricChangeTests.cs
@@ -58,3 +58,33 @@ public class GeneratedMetricChangeTests
         Assert.Equal("regression", failures.GetProperty("status").GetString());
     }
 }
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class GeneratedArrayCard
+{
+    [MarkoutIgnore] public string Title => "Arr";
+
+    [MarkoutSection(Name = "Metrics")]
+    public MetricChange<int>[] Metrics { get; set; } = [];
+}
+
+[MarkoutContext(typeof(GeneratedArrayCard))]
+public partial class GeneratedArrayCardContext : MarkoutSerializerContext
+{
+}
+
+public class GeneratedMetricChangeArrayTests
+{
+    [Fact]
+    public void Generated_MetricChangeArray_RendersCardNotComplexArray()
+    {
+        var card = new GeneratedArrayCard
+        {
+            Metrics = [new("Failures", 0, 7, 0, "allowed failures", GateStatus.Bad, "regression")],
+        };
+        var md = MarkoutSerializer.Serialize(card, GeneratedArrayCardContext.Default);
+
+        Assert.Contains("| Metric | Change | Target | Status |", md);
+        Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", md);
+    }
+}

--- a/tests/Markout.Tests/GeneratedMetricChangeTests.cs
+++ b/tests/Markout.Tests/GeneratedMetricChangeTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using Markout;
+
+namespace Markout.Tests;
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class GeneratedIlDiffCard
+{
+    [MarkoutIgnore] public string Title { get; set; } = "IL Diff";
+
+    [MarkoutSection(Name = "Baseline comparison")]
+    public List<MetricChange<int>> Metrics { get; set; } = new();
+}
+
+[MarkoutContext(typeof(GeneratedIlDiffCard))]
+public partial class GeneratedIlDiffCardContext : MarkoutSerializerContext
+{
+}
+
+public class GeneratedMetricChangeTests
+{
+    private static GeneratedIlDiffCard Card() => new()
+    {
+        Metrics =
+        [
+            new("Failures", 0, 7, 0, "allowed failures", GateStatus.Bad, "regression"),
+            new("Changed bodies", 45, 46, Status: GateStatus.Warning, StatusLabel: "drift"),
+        ],
+    };
+
+    [Fact]
+    public void Generated_MetricChangeSection_RendersFixedColumnTable()
+    {
+        var md = MarkoutSerializer.Serialize(Card(), GeneratedIlDiffCardContext.Default);
+
+        Assert.Contains("## Baseline comparison", md);
+        Assert.Contains("| Metric | Change | Target | Status |", md);
+        Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", md);
+        Assert.Contains("| Changed bodies | 45 \u2192 46 | - | drift |", md);
+    }
+
+    [Fact]
+    public void Generated_MetricChangeSection_Jsonl_DecomposesToFlatFields()
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(Card(), sw, new TableFormatter(), GeneratedIlDiffCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+
+        var failures = sw.ToString().ReplaceLineEndings("\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => JsonDocument.Parse(l).RootElement)
+            .First(e => e.TryGetProperty("metric", out var m) && m.GetString() == "Failures");
+
+        Assert.Equal("0", failures.GetProperty("before").GetString());
+        Assert.Equal("7", failures.GetProperty("after").GetString());
+        Assert.Equal("0", failures.GetProperty("target").GetString());
+        Assert.Equal("allowed failures", failures.GetProperty("target_label").GetString());
+        Assert.Equal("regression", failures.GetProperty("status").GetString());
+    }
+}

--- a/tests/Markout.Tests/GeneratedMultiSourceTests.cs
+++ b/tests/Markout.Tests/GeneratedMultiSourceTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using Markout;
+
+namespace Markout.Tests;
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class GeneratedMultiSourceCard
+{
+    [MarkoutIgnore] public string Title { get; set; } = "Quality";
+
+    [MarkoutSection(Name = "Baseline comparison")]
+    [MarkoutLabelHeader("Metric")]
+    public List<MultiSourceRow> Rows { get; set; } = new();
+}
+
+[MarkoutContext(typeof(GeneratedMultiSourceCard))]
+public partial class GeneratedMultiSourceCardContext : MarkoutSerializerContext
+{
+}
+
+public class GeneratedMultiSourceTests
+{
+    private static GeneratedMultiSourceCard Card() => new()
+    {
+        Rows =
+        [
+            new("output tok",
+                new Source("opus", new Change<Share>(new Share(5056, 21067), new Share(3129, 13037))),
+                new Source("gpt5", new Change<Share>(new Share(6100, 21800), new Share(3500, 14000)))),
+            new("verdict",
+                new Source("opus", new Verdict(GateStatus.Good, "BETTER")),
+                new Source("gpt5", new Verdict(GateStatus.Good, "BETTER"))),
+        ],
+    };
+
+    [Fact]
+    public void Generated_MultiSource_PivotsRolesIntoColumns_WithLabelHeader()
+    {
+        var md = MarkoutSerializer.Serialize(Card(), GeneratedMultiSourceCardContext.Default);
+
+        Assert.Contains("## Baseline comparison", md);
+        Assert.Contains("| Metric | opus | gpt5 |", md);
+        Assert.Contains("| output tok | 5056 (24%) \u2192 3129 (24%) | 6100 (28%) \u2192 3500 (25%) |", md);
+        Assert.Contains("| verdict | BETTER | BETTER |", md);
+    }
+
+    [Fact]
+    public void Generated_MultiSource_Jsonl_DecomposesRolePrefixedKeys()
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(Card(), sw, new TableFormatter(), GeneratedMultiSourceCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+
+        var tok = sw.ToString().ReplaceLineEndings("\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => JsonDocument.Parse(l).RootElement)
+            .First(e => e.TryGetProperty("metric", out var m) && m.GetString() == "output tok");
+
+        Assert.Equal("5056", tok.GetProperty("opus_before_value").GetString());
+        Assert.Equal("24", tok.GetProperty("opus_before_pct").GetString());
+        Assert.Equal("3500", tok.GetProperty("gpt5_after_value").GetString());
+    }
+}

--- a/tests/Markout.Tests/MetricChangeTableTests.cs
+++ b/tests/Markout.Tests/MetricChangeTableTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using Markout;
+
+namespace Markout.Tests;
+
+public class MetricChangeTableTests
+{
+    private static MetricChange<int>[] Rows() =>
+    [
+        new("Failures", 0, 7, 0, "allowed failures", GateStatus.Bad, "regression"),
+        new("Changed bodies", 45, 46, Status: GateStatus.Warning, StatusLabel: "drift"),
+        new("Compared bodies", 78, 78), // ungated, no status
+    ];
+
+    [Fact]
+    public void Markdown_RendersMetricChangeTargetStatusColumns()
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMetricChangeTable(Rows());
+        var output = writer.ToString();
+
+        Assert.Contains("| Metric | Change | Target | Status |", output);
+        Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", output);
+        Assert.Contains("| Changed bodies | 45 \u2192 46 | - | drift |", output);
+        Assert.Contains("| Compared bodies | 78 \u2192 78 | - | - |", output);
+    }
+
+    [Fact]
+    public void Jsonl_EmitsFlatTypedFields_OmittingAbsentTargetAndStatus()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMetricChangeTable(Rows());
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var failures = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.Equal("Failures", failures.GetProperty("metric").GetString());
+        Assert.Equal("0", failures.GetProperty("before").GetString());
+        Assert.Equal("7", failures.GetProperty("after").GetString());
+        Assert.Equal("0", failures.GetProperty("target").GetString());
+        Assert.Equal("allowed failures", failures.GetProperty("target_label").GetString());
+        Assert.Equal("regression", failures.GetProperty("status").GetString());
+
+        // Ungated row: target / target_label omitted; status present.
+        var changed = JsonDocument.Parse(lines[1]).RootElement;
+        Assert.Equal("45", changed.GetProperty("before").GetString());
+        Assert.False(changed.TryGetProperty("target", out _));
+        Assert.False(changed.TryGetProperty("target_label", out _));
+        Assert.Equal("drift", changed.GetProperty("status").GetString());
+
+        // No target, no status.
+        var compared = JsonDocument.Parse(lines[2]).RootElement;
+        Assert.Equal("78", compared.GetProperty("before").GetString());
+        Assert.False(compared.TryGetProperty("target", out _));
+        Assert.False(compared.TryGetProperty("status", out _));
+    }
+
+    [Fact]
+    public void Jsonl_TypedValues_EmitsNumericFields()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        writer.WriteMetricChangeTable(Rows());
+        var line0 = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var failures = JsonDocument.Parse(line0).RootElement;
+
+        Assert.Equal(JsonValueKind.Number, failures.GetProperty("before").ValueKind);
+        Assert.Equal(7, failures.GetProperty("after").GetInt32());
+        // Identity + status stay strings.
+        Assert.Equal(JsonValueKind.String, failures.GetProperty("metric").ValueKind);
+        Assert.Equal("regression", failures.GetProperty("status").GetString());
+    }
+}

--- a/tests/Markout.Tests/MultiSourceTableTests.cs
+++ b/tests/Markout.Tests/MultiSourceTableTests.cs
@@ -177,4 +177,28 @@ public class MultiSourceTableTests
         Assert.Equal(0, rec.GetProperty("budget").GetInt32());
         Assert.Equal("REGRESSION", rec.GetProperty("verdict").GetString());
     }
+
+    // ── Colliding composed keys are disambiguated (no silent data loss) ──
+
+    [Fact]
+    public void Jsonl_CollidingComposedKeys_AreDisambiguated()
+    {
+        // role "a" + segment "b_c" and role "a_b" + segment "c" both compose to "a_b_c".
+        MultiSourceRow[] rows =
+        [
+            new("row",
+                new Source("a", new Segments(new Segment("b_c", 1))),
+                new Source("a_b", new Segments(new Segment("c", 2)))),
+        ];
+
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        writer.WriteMultiSourceTable("Metric", rows);
+        var rec = JsonDocument.Parse(sw.ToString().ReplaceLineEndings("\n").Trim()).RootElement;
+
+        // Both values survive; the second colliding key is disambiguated.
+        Assert.Equal("1", rec.GetProperty("a_b_c").GetString());
+        Assert.Equal("2", rec.GetProperty("a_b_c_2").GetString());
+    }
 }

--- a/tests/Markout.Tests/MultiSourceTableTests.cs
+++ b/tests/Markout.Tests/MultiSourceTableTests.cs
@@ -99,10 +99,10 @@ public class MultiSourceTableTests
         Assert.Equal("75", tools.GetProperty("opus_after_bash").GetString());
         Assert.Equal("5", tools.GetProperty("gpt5_after_web").GetString());
 
-        // Row 2: Verdict -> {role}_status
+        // Row 2: Verdict -> {role} (flat, no _status suffix)
         var verdict = JsonDocument.Parse(lines[2]).RootElement;
-        Assert.Equal("BETTER", verdict.GetProperty("opus_status").GetString());
-        Assert.Equal("BETTER", verdict.GetProperty("gpt5_status").GetString());
+        Assert.Equal("BETTER", verdict.GetProperty("opus").GetString());
+        Assert.Equal("BETTER", verdict.GetProperty("gpt5").GetString());
     }
 
     [Fact]
@@ -143,6 +143,38 @@ public class MultiSourceTableTests
         Assert.Equal("metric", headers[0]);
         Assert.Contains("opus_before_value", headers);
         Assert.Contains("gpt5_before_web", headers);
-        Assert.Contains("opus_status", headers);
+        Assert.Contains("opus", headers);
+    }
+
+    // ── Scalar role values (leak-triage shape): baseline/current/budget + verdict ──
+
+    [Fact]
+    public void ScalarSources_RenderAndDecomposeByRole()
+    {
+        MultiSourceRow[] rows =
+        [
+            new("arraypool-rent-not-returned",
+                new Source("baseline", 2),
+                new Source("current", 5),
+                new Source("budget", 0),
+                new Source("verdict", new Verdict(GateStatus.Bad, "REGRESSION"))),
+        ];
+
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMultiSourceTable("Metric", rows);
+        Assert.Contains("| Metric | baseline | current | budget | verdict |", writer.ToString());
+        Assert.Contains("| arraypool-rent-not-returned | 2 | 5 | 0 | REGRESSION |", writer.ToString());
+
+        var sw = new StringWriter();
+        var jsonl = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        jsonl.WriteMultiSourceTable("Metric", rows);
+        var rec = JsonDocument.Parse(sw.ToString().ReplaceLineEndings("\n").Trim()).RootElement;
+
+        Assert.Equal("arraypool-rent-not-returned", rec.GetProperty("metric").GetString());
+        Assert.Equal(2, rec.GetProperty("baseline").GetInt32());   // typed number
+        Assert.Equal(5, rec.GetProperty("current").GetInt32());
+        Assert.Equal(0, rec.GetProperty("budget").GetInt32());
+        Assert.Equal("REGRESSION", rec.GetProperty("verdict").GetString());
     }
 }

--- a/tests/Markout.Tests/MultiSourceTableTests.cs
+++ b/tests/Markout.Tests/MultiSourceTableTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using Markout;
+
+namespace Markout.Tests;
+
+public class MultiSourceTableTests
+{
+    // Roles are model names; each metric cell is a nested baseline -> current Change<Shape>.
+    private static MultiSourceRow[] MatrixRows() =>
+    [
+        new("output tok",
+            new Source("opus", new Change<Share>(new Share(5056, 21067), new Share(3129, 13037))),
+            new Source("gpt5", new Change<Share>(new Share(6100, 21800), new Share(3500, 14000)))),
+        new("tool calls",
+            new Source("opus", new Change<Segments>(
+                new Segments(new Segment("web", 21), new Segment("bash", 171)),
+                new Segments(new Segment("web", 0), new Segment("bash", 75)))),
+            new Source("gpt5", new Change<Segments>(
+                new Segments(new Segment("web", 30), new Segment("bash", 150)),
+                new Segments(new Segment("web", 5), new Segment("bash", 80))))),
+        new("verdict",
+            new Source("opus", new Verdict(GateStatus.Good, "BETTER")),
+            new Source("gpt5", new Verdict(GateStatus.Good, "BETTER"))),
+    ];
+
+    // ── Dense Markdown pivot: roles become columns ──
+
+    [Fact]
+    public void Markdown_PivotsRolesIntoColumns()
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMultiSourceTable("Metric", MatrixRows());
+        var output = writer.ToString();
+
+        Assert.Contains("| Metric | opus | gpt5 |", output);
+        Assert.Contains("| output tok | 5056 (24%) \u2192 3129 (24%) | 6100 (28%) \u2192 3500 (25%) |", output);
+        Assert.Contains("| tool calls | 21/171 \u2192 0/75 | 30/150 \u2192 5/80 |", output);
+        Assert.Contains("| verdict | BETTER | BETTER |", output);
+    }
+
+    [Fact]
+    public void Markdown_AbsentRoleRendersDash()
+    {
+        MultiSourceRow[] rows =
+        [
+            new("full", new Source("opus", new Change<long>(1, 2)), new Source("gpt5", new Change<long>(3, 4))),
+            new("opus only", new Source("opus", new Change<long>(5, 6))),
+        ];
+
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMultiSourceTable("Metric", rows);
+        var output = writer.ToString();
+
+        Assert.Contains("| opus only | 5 \u2192 6 | - |", output);
+    }
+
+    // ── Caller-controlled column order (insertion order, not sorted, not first-row-only) ──
+
+    [Fact]
+    public void ColumnOrder_IsCallerInsertionOrder_NotSorted()
+    {
+        MultiSourceRow[] rows =
+        [
+            new("m1", new Source("zebra", new Change<long>(1, 2))),
+            new("m2", new Source("zebra", new Change<long>(3, 4)), new Source("alpha", new Change<long>(5, 6))),
+        ];
+
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMultiSourceTable("Metric", rows);
+        var output = writer.ToString();
+
+        // "zebra" first (first appearance), "alpha" appended when it first appears in row 2.
+        Assert.Contains("| Metric | zebra | alpha |", output);
+        // m1 has no "alpha" -> dash.
+        Assert.Contains("| m1 | 1 \u2192 2 | - |", output);
+    }
+
+    // ── Decomposed JSONL: one flat record per row, {role}_{side}_{field} keys ──
+
+    [Fact]
+    public void Jsonl_DecomposesToRolePrefixedKeys()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMultiSourceTable("Metric", MatrixRows());
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        // Row 0: Change<Share> -> {role}_{side}_{value|pct}
+        var tok = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.Equal("output tok", tok.GetProperty("metric").GetString());
+        Assert.Equal("5056", tok.GetProperty("opus_before_value").GetString());
+        Assert.Equal("24", tok.GetProperty("opus_before_pct").GetString());
+        Assert.Equal("3500", tok.GetProperty("gpt5_after_value").GetString());
+
+        // Row 1: Change<Segments> -> side-first labels (post-#129 flip): {role}_{side}_{label}
+        var tools = JsonDocument.Parse(lines[1]).RootElement;
+        Assert.Equal("21", tools.GetProperty("opus_before_web").GetString());
+        Assert.Equal("75", tools.GetProperty("opus_after_bash").GetString());
+        Assert.Equal("5", tools.GetProperty("gpt5_after_web").GetString());
+
+        // Row 2: Verdict -> {role}_status
+        var verdict = JsonDocument.Parse(lines[2]).RootElement;
+        Assert.Equal("BETTER", verdict.GetProperty("opus_status").GetString());
+        Assert.Equal("BETTER", verdict.GetProperty("gpt5_status").GetString());
+    }
+
+    [Fact]
+    public void Jsonl_Heterogeneous_OmitsAbsentRoleKeys()
+    {
+        MultiSourceRow[] rows =
+        [
+            new("m1", new Source("opus", new Change<long>(1, 2))),
+            new("m2", new Source("opus", new Change<long>(3, 4)), new Source("gpt5", new Change<long>(5, 6))),
+        ];
+
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMultiSourceTable("Metric", rows);
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var m1 = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.True(m1.TryGetProperty("opus_before", out _));
+        Assert.False(m1.TryGetProperty("gpt5_before", out _)); // absent role omitted
+
+        var m2 = JsonDocument.Parse(lines[1]).RootElement;
+        Assert.True(m2.TryGetProperty("gpt5_before", out _));
+    }
+
+    // ── TSV keeps a uniform column union ──
+
+    [Fact]
+    public void Tsv_KeepsUniformColumnUnion()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv });
+        writer.WriteMultiSourceTable("Metric", MatrixRows());
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var headers = lines[0].Split('\t');
+        Assert.Equal("metric", headers[0]);
+        Assert.Contains("opus_before_value", headers);
+        Assert.Contains("gpt5_before_web", headers);
+        Assert.Contains("opus_status", headers);
+    }
+}

--- a/tests/Markout.Tests/MultiSourceTableTests.cs
+++ b/tests/Markout.Tests/MultiSourceTableTests.cs
@@ -178,27 +178,50 @@ public class MultiSourceTableTests
         Assert.Equal("REGRESSION", rec.GetProperty("verdict").GetString());
     }
 
-    // ── Colliding composed keys are disambiguated (no silent data loss) ──
+    // ── Null source value is unambiguous and renders as an absent cell ──
 
     [Fact]
-    public void Jsonl_CollidingComposedKeys_AreDisambiguated()
+    public void NullSourceValue_CompilesAndRendersDash()
+    {
+        // Regression: the scalar ctor overloads must not make `new Source(role, null)` ambiguous.
+        MultiSourceRow[] rows = [new("m", new Source("a", null), new Source("b", 5))];
+
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMultiSourceTable("Metric", rows);
+
+        Assert.Contains("| m | - | 5 |", writer.ToString());
+    }
+
+    // ── Colliding composed keys are disambiguated consistently across rows (no data mixing) ──
+
+    [Fact]
+    public void Jsonl_CollidingComposedKeys_AreDisambiguatedConsistentlyAcrossRows()
     {
         // role "a" + segment "b_c" and role "a_b" + segment "c" both compose to "a_b_c".
+        // The two rows present the colliding sources in DIFFERENT orders; a given role must map to
+        // the same column in every row (no data landing in the wrong column).
         MultiSourceRow[] rows =
         [
-            new("row",
+            new("row1",
                 new Source("a", new Segments(new Segment("b_c", 1))),
                 new Source("a_b", new Segments(new Segment("c", 2)))),
+            new("row2",
+                new Source("a_b", new Segments(new Segment("c", 3))),
+                new Source("a", new Segments(new Segment("b_c", 4)))),
         ];
 
         var sw = new StringWriter();
         var writer = MarkoutWriter.Create(sw, new TableFormatter(),
             new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
         writer.WriteMultiSourceTable("Metric", rows);
-        var rec = JsonDocument.Parse(sw.ToString().ReplaceLineEndings("\n").Trim()).RootElement;
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var r1 = JsonDocument.Parse(lines[0]).RootElement;
+        var r2 = JsonDocument.Parse(lines[1]).RootElement;
 
-        // Both values survive; the second colliding key is disambiguated.
-        Assert.Equal("1", rec.GetProperty("a_b_c").GetString());
-        Assert.Equal("2", rec.GetProperty("a_b_c_2").GetString());
+        // Role "a" is always column "a_b_c"; role "a_b" is always column "a_b_c_2".
+        Assert.Equal("1", r1.GetProperty("a_b_c").GetString());
+        Assert.Equal("2", r1.GetProperty("a_b_c_2").GetString());
+        Assert.Equal("4", r2.GetProperty("a_b_c").GetString());
+        Assert.Equal("3", r2.GetProperty("a_b_c_2").GetString());
     }
 }


### PR DESCRIPTION
## Summary

First-class **multi-source data cards** for Markout (issue #128), plus the **#129** `Segments` key-order breaking change. Targets **0.17.0**.

Lets a tool declare a card once and get both a dense human Markdown table and typed, decomposed JSON/JSONL/TSV — for cards whose rows have **more than two related sources** (baseline/current/budget/verdict, or a model-by-metric matrix), which the existing two-source `Change<T>` couldn't express. Motivated and validated by three consumers: `dotnet-inspect` IL-Diff, `dotnet-inspect` leak-triage, and `dotnet-package-grounding`'s multi-model quality card.

## New shapes

- **`MetricChange<T>`** — a gated scalar metric row. Rendered as `Metric | Change | Target | Status`; decomposes to flat typed `before`/`after`/optional `target`/`target_label`/`status`. `Status` is caller-supplied (never derived).
  ```csharp
  new MetricChange<int>("Failures", 0, 7, Target: 0, TargetLabel: "allowed failures",
                        Status: GateStatus.Bad, StatusLabel: "regression");
  ```
- **`MultiSourceRow`** / **`Source`** — a role matrix. Roles pivot to **columns** in Markdown (caller-supplied order; absent role → `-`); JSONL emits one flat record per row with `{role}_{side}_{field}` keys. Values are any `IMarkoutCell` (incl. nested `Change<Share>`), plus **scalar** convenience (`new Source("baseline", 2)`, `Source.Text(...)`) and `new Source(role, null)` for an absent cell.
- **`GateStatus`** + **`Verdict(GateStatus, string? Label)`** — a first-class typed verdict cell (polarity + optional caller word), not a caller-formatted string.

## Generator + attributes

- Source-generator recognition for `List`/`IReadOnlyList`/`T[]` of `MetricChange<T>` and `MultiSourceRow`, emitting `WriteMetricChangeTable` / `WriteMultiSourceTable` — declare on a `[MarkoutSerializable]` model, no imperative writer calls.
- **`[MarkoutLabelHeader("Metric")]`** sets the pivot's label-column header (default `Field`).
- **`MARKOUT005`** compile error enforces `MetricChange<T>`'s numeric-scalar contract (the `T:struct` constraint can't exclude composite structs like `Segments`).

## Breaking change (#129)

`Segments` decomposition keys flip **label-first → side-first** when nested (`web_before` → `before_web`), making multi-source keys uniform as `{role}_{side}_{field}`. **Standalone `Segments` keys are unchanged**; only nested `Change<Segments>` structured output is affected. Details in #129.

## Testing

- **604 tests** (green), including end-to-end generator tests, the role-pivot layout (caller order, absent-role, heterogeneous rows), three-level decomposition keys, scalar/null sources, the `MARKOUT005` diagnostic, arrays, and cross-row key-collision consistency.
- **Two-model adversarial review to two cleans** (GPT-5.5 + Gemini 3.1 Pro, 3 rounds). Round 1 fixed an `IList<T>` recognition compile bug; round 2 fixed a cross-row key-collision misalignment and a `Source` null-overload ambiguity; round 3 both reviewers clean.
- Proven end-to-end in a `dotnet-inspect` worktree via a local project-ref (the `MetricChange` card renders `Metric | Change | Target | Status` + typed JSONL against real data).

## Follow-ups (not in this PR)

- Evidence/list cell + display-cap `MarkoutCellFormat` flag (deferred).
- Consumer adoption after 0.17.0 is published: switch `dotnet-inspect` / `dotnet-package-grounding` from the project-ref to the package and port the real cards.

Closes #128. Closes #129.
