### PR TITLE
Section-aware structured rows for card list-shapes (#131)

### DIFF
--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -94,6 +94,9 @@ flat typed JSONL/TSV — with no imperative writer calls:
   `target`/`target_label`/`status`. `Status` is caller-supplied (Markout never derives it). `T` must be
   a numeric scalar (int/long/double/decimal/...); a composite `T` (e.g. `Segments`) is a compile error
   (`MARKOUT005`).
+- `[MarkoutSection(Name = "...", IncludeSectionInStructuredRows = true)]` on a `List<MetricChange<T>>`
+  or `List<MultiSourceRow>` section prepends a leading `section` column (the section name) to TSV/JSONL
+  rows — for multiplexing several sectioned card shapes into one structured stream. Markdown is unchanged.
 - `List<MultiSourceRow>` — a role matrix: `MultiSourceRow(label, params Source[])`,
   `Source(role, IMarkoutCell? value, format = default)`. Roles pivot to **columns** in Markdown
   (caller-supplied order; absent role → `-`); JSONL emits one flat record per row with

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -655,10 +655,11 @@ internal static class SerializerEmitter
         }
         else if (prop.Kind == PropertyKind.MetricChange)
         {
+            var sectionArg = prop.SectionIncludeInStructuredRows ? $", \"{EmitHelpers.EscapeString(sectionName)}\"" : "";
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
-            sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess});");
+            sb.AppendLine($"{indent}    writer.WriteMetricChangeTable({propAccess}{sectionArg});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
@@ -666,10 +667,11 @@ internal static class SerializerEmitter
         else if (prop.Kind == PropertyKind.MultiSource)
         {
             var labelHeader = EmitHelpers.EscapeString(prop.MultiSourceLabelHeader ?? "Field");
+            var sectionArg = prop.SectionIncludeInStructuredRows ? $", \"{EmitHelpers.EscapeString(sectionName)}\"" : "";
             sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.{(prop.IsArray ? "Length" : "Count")} > 0)");
             sb.AppendLine($"{indent}{{");
             sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
-            sb.AppendLine($"{indent}    writer.WriteMultiSourceTable(\"{labelHeader}\", {propAccess});");
+            sb.AppendLine($"{indent}    writer.WriteMultiSourceTable(\"{labelHeader}\", {propAccess}{sectionArg});");
             sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
             sb.AppendLine($"{indent}}}");
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -152,6 +152,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? SectionShowWhenProperty { get; }
     public string? SectionGroupByProperty { get; }
     public bool SectionHeadless { get; }
+    public bool SectionIncludeInStructuredRows { get; }
     public MarkoutFieldOrderKind SectionFieldOrder { get; }
     public IReadOnlyList<(string MethodName, string ColumnName)>? SectionIgnoreColumnWhen { get; }
     public string? ElementTypeName { get; }
@@ -203,6 +204,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? sectionShowWhenProperty = null,
         string? sectionGroupByProperty = null,
         bool sectionHeadless = false,
+        bool sectionIncludeInStructuredRows = false,
         MarkoutFieldOrderKind sectionFieldOrder = MarkoutFieldOrderKind.Input,
         IReadOnlyList<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null,
         string? elementTypeName = null,
@@ -253,6 +255,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         SectionShowWhenProperty = sectionShowWhenProperty;
         SectionGroupByProperty = sectionGroupByProperty;
         SectionHeadless = sectionHeadless;
+        SectionIncludeInStructuredRows = sectionIncludeInStructuredRows;
         SectionFieldOrder = sectionFieldOrder;
         SectionIgnoreColumnWhen = sectionIgnoreColumnWhen;
         ElementTypeName = elementTypeName;
@@ -308,6 +311,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                SectionShowWhenProperty == other.SectionShowWhenProperty &&
                SectionGroupByProperty == other.SectionGroupByProperty &&
                SectionHeadless == other.SectionHeadless &&
+               SectionIncludeInStructuredRows == other.SectionIncludeInStructuredRows &&
                SectionFieldOrder == other.SectionFieldOrder &&
                IgnoreColumnWhenEqual(SectionIgnoreColumnWhen, other.SectionIgnoreColumnWhen) &&
                ElementTypeName == other.ElementTypeName &&
@@ -365,6 +369,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionShowWhenProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (SectionGroupByProperty?.GetHashCode() ?? 0);
             hash = hash * 397 ^ SectionHeadless.GetHashCode();
+            hash = hash * 397 ^ SectionIncludeInStructuredRows.GetHashCode();
             hash = hash * 397 ^ (int)SectionFieldOrder;
             hash = hash * 397 ^ (SectionIgnoreColumnWhen?.Count ?? 0);
             hash = hash * 397 ^ (ValueFormatterTypeName?.GetHashCode() ?? 0);

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -243,6 +243,7 @@ internal static class TypeParser
         string? sectionShowWhenProperty = null;
         string? sectionGroupByProperty = null;
         bool sectionHeadless = false;
+        bool sectionIncludeInStructuredRows = false;
         MarkoutFieldOrderKind sectionFieldOrder = MarkoutFieldOrderKind.Input;
         string? sectionEmptyText = null;
         List<(string MethodName, string ColumnName)>? sectionIgnoreColumnWhen = null;
@@ -273,6 +274,8 @@ internal static class TypeParser
                         sectionGroupByProperty = gb;
                     else if (named.Key == "Headless" && named.Value.Value is bool hl)
                         sectionHeadless = hl;
+                    else if (named.Key == "IncludeSectionInStructuredRows" && named.Value.Value is bool isr)
+                        sectionIncludeInStructuredRows = isr;
                     else if (named.Key == "FieldOrder" && named.Value.Value is int fo)
                         sectionFieldOrder = (MarkoutFieldOrderKind)fo;
                     else if (named.Key == "EmptyText" && named.Value.Value is string et)
@@ -522,6 +525,7 @@ internal static class TypeParser
             sectionShowWhenProperty,
             sectionGroupByProperty,
             sectionHeadless,
+            sectionIncludeInStructuredRows,
             sectionFieldOrder,
             sectionIgnoreColumnWhen,
             elementTypeName,

--- a/src/Markout/Attributes/MarkoutSectionAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSectionAttribute.cs
@@ -61,6 +61,15 @@ public sealed class MarkoutSectionAttribute : Attribute
     /// </summary>
     public bool Headless { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether decomposed (TSV/JSONL) rows for this section include a leading
+    /// <c>section</c> column carrying the section <see cref="Name"/>. Lets a tool multiplex several
+    /// sectioned card shapes into one structured stream and route rows by section. Off by default;
+    /// Markdown output is unaffected (the section is already its heading). Applies to list shapes that
+    /// decompose to typed rows (<c>List&lt;MetricChange&lt;T&gt;&gt;</c>, <c>List&lt;MultiSourceRow&gt;</c>).
+    /// </summary>
+    public bool IncludeSectionInStructuredRows { get; set; }
+
     /// Gets or sets fallback text rendered as a paragraph when the section's collection is
     /// non-null but empty. The section heading is still emitted, followed by this text in place
     /// of the table or list. When the collection is null the section is omitted entirely, so the

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.17.0</Version>
-    <PackageReleaseNotes>First-class multi-source data cards: MetricChange&lt;T&gt; renders as a Metric | Change | Target | Status table, and MultiSourceRow/Source pivot named roles into columns; both decompose to flat typed JSONL/TSV. GateStatus/Verdict is a first-class verdict cell; Source accepts scalars (new Source("baseline", 2)) and Source.Text(...); [MarkoutLabelHeader] sets the pivot label column; MARKOUT005 enforces MetricChange&lt;T&gt;'s numeric-scalar contract. BREAKING: nested Segments decomposition keys flip label-first to side-first (e.g. web_before becomes before_web) so multi-source keys are uniform as {role}_{side}_{field}; standalone Segments keys are unchanged.</PackageReleaseNotes>
+    <Version>0.18.0</Version>
+    <PackageReleaseNotes>Section-aware structured rows: [MarkoutSection(IncludeSectionInStructuredRows = true)] on a List&lt;MetricChange&lt;T&gt;&gt; or List&lt;MultiSourceRow&gt; section prepends a leading "section" column (the section name) to decomposed TSV/JSONL rows, so a tool can multiplex several sectioned card shapes into one structured stream and route by section. Markdown output is unchanged.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -503,7 +503,7 @@ public class MarkoutWriter
     /// <param name="labelHeader">The header/identity-column name for the row labels.</param>
     /// <param name="rows">The multi-source rows.</param>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteMultiSourceTable(string labelHeader, IReadOnlyList<MultiSourceRow> rows)
+    public bool WriteMultiSourceTable(string labelHeader, IReadOnlyList<MultiSourceRow> rows, string? structuredSection = null)
     {
         if (_sectionExcluded || rows.Count == 0)
             return true;
@@ -527,7 +527,7 @@ public class MarkoutWriter
             return true;
 
         if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
-            return WriteDecomposedMultiSourceTable(labelHeader, rows, roleOrder);
+            return WriteDecomposedMultiSourceTable(labelHeader, rows, roleOrder, structuredSection);
 
         return WriteDenseMultiSourceTable(labelHeader, rows, roleOrder, roleIndex);
     }
@@ -569,7 +569,7 @@ public class MarkoutWriter
 
     // Decomposing formatters (TSV/JSONL): one flat record per row, {role}_{field} columns.
     private bool WriteDecomposedMultiSourceTable(
-        string labelHeader, IReadOnlyList<MultiSourceRow> rows, List<string> roleOrder)
+        string labelHeader, IReadOnlyList<MultiSourceRow> rows, List<string> roleOrder, string? structuredSection)
     {
         // Decompose each source with side = role, tagging fields with their owning role so the
         // column union can be ordered role-major (caller role order), then field order within a role.
@@ -634,7 +634,7 @@ public class MarkoutWriter
             perRowFlat[r] = flat;
         }
 
-        return WriteDecomposedFieldTable(labelHeader, labels, perRowFlat, keyOrder);
+        return WriteDecomposedFieldTable(labelHeader, labels, perRowFlat, keyOrder, structuredSection);
     }
 
     // Shared emitter for flat decomposed record tables (multi-source, metric-change): a leading
@@ -642,51 +642,71 @@ public class MarkoutWriter
     // are snake-cased and de-duped because TableWriter re-applies ToSnakeCase to header keys for
     // TSV/JSONL; the leading identity column stays a JSON string.
     private bool WriteDecomposedFieldTable(
-        string labelHeader, IReadOnlyList<string> labels, IReadOnlyList<List<MarkoutField>> perRowFields, IReadOnlyList<string> keyOrder)
+        string labelHeader, IReadOnlyList<string> labels, IReadOnlyList<List<MarkoutField>> perRowFields, IReadOnlyList<string> keyOrder,
+        string? structuredSection = null)
     {
         var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
         for (int i = 0; i < keyOrder.Count; i++)
             keyIndex[keyOrder[i]] = i;
 
-        var headers = new string[keyOrder.Count + 1];
-        var headerNames = new string[keyOrder.Count + 1];
-        headers[0] = labelHeader;
+        // Leading identity columns: an optional "section" discriminator (for multiplexed structured
+        // streams), then the row label. Both stay JSON strings (never coerced under JsonTypedValues).
+        int lead = structuredSection is null ? 1 : 2;
+        var headers = new string[keyOrder.Count + lead];
+        var headerNames = new string[keyOrder.Count + lead];
+        var usedStableKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        string Dedupe(string stable)
+        {
+            if (usedStableKeys.Add(stable))
+                return stable;
+            int suffix = 2;
+            string candidate;
+            do { candidate = stable + "_" + suffix++; } while (!usedStableKeys.Add(candidate));
+            return candidate;
+        }
+
+        int col = 0;
+        if (structuredSection is not null)
+        {
+            headers[col] = "section";
+            headerNames[col] = Dedupe("section");
+            col++;
+        }
+        headers[col] = labelHeader;
         var labelKey = Formatting.FormatHelper.ToSnakeCase(labelHeader);
         if (string.IsNullOrEmpty(labelKey))
             labelKey = "field";
-        headerNames[0] = labelKey;
-        var usedStableKeys = new HashSet<string>(StringComparer.Ordinal) { labelKey };
+        headerNames[col] = Dedupe(labelKey);
+        col++;
 
         for (int i = 0; i < keyOrder.Count; i++)
         {
-            headers[i + 1] = keyOrder[i];
+            headers[col] = keyOrder[i];
             var stable = Formatting.FormatHelper.ToSnakeCase(keyOrder[i]);
             if (string.IsNullOrEmpty(stable))
                 stable = "column";
-            if (!usedStableKeys.Add(stable))
-            {
-                int suffix = 2;
-                string candidate;
-                do { candidate = stable + "_" + suffix++; } while (!usedStableKeys.Add(candidate));
-                stable = candidate;
-            }
-            headerNames[i + 1] = stable;
+            headerNames[col] = Dedupe(stable);
+            col++;
         }
 
         var outRows = new List<string[]>(perRowFields.Count);
         for (int r = 0; r < perRowFields.Count; r++)
         {
-            var values = new string[keyOrder.Count + 1];
-            values[0] = labels[r];
-            for (int i = 1; i < values.Length; i++)
+            var values = new string[keyOrder.Count + lead];
+            for (int i = 0; i < values.Length; i++)
                 values[i] = "";
+            int c = 0;
+            if (structuredSection is not null)
+                values[c++] = structuredSection;
+            values[c] = labels[r];
             foreach (var field in perRowFields[r])
                 if (keyIndex.TryGetValue(field.Key, out var idx))
-                    values[idx + 1] = field.Value;
+                    values[lead + idx] = field.Value;
             outRows.Add(values);
         }
 
-        _pendingJsonIdentityColumns = 1;
+        _pendingJsonIdentityColumns = lead;
         try
         {
             return WriteTable(headers, headerNames, outRows);
@@ -705,7 +725,7 @@ public class MarkoutWriter
     /// structured output.
     /// </summary>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows) where T : struct
+    public bool WriteMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows, string? structuredSection = null) where T : struct
     {
         if (_sectionExcluded || rows.Count == 0)
             return true;
@@ -714,7 +734,7 @@ public class MarkoutWriter
             return false;
 
         if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
-            return WriteDecomposedMetricChangeTable(rows);
+            return WriteDecomposedMetricChangeTable(rows, structuredSection);
 
         var outRows = new List<string[]>(rows.Count);
         foreach (var metric in rows)
@@ -723,7 +743,7 @@ public class MarkoutWriter
         return WriteTable(["Metric", "Change", "Target", "Status"], outRows);
     }
 
-    private bool WriteDecomposedMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows) where T : struct
+    private bool WriteDecomposedMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows, string? structuredSection) where T : struct
     {
         var labels = new string[rows.Count];
         var perRow = new List<MarkoutField>[rows.Count];
@@ -751,7 +771,7 @@ public class MarkoutWriter
                     keyOrder.Add(field.Key);
         }
 
-        return WriteDecomposedFieldTable("Metric", labels, perRow, keyOrder);
+        return WriteDecomposedFieldTable("Metric", labels, perRow, keyOrder, structuredSection);
     }
 
     private static string ChangeText<T>(in MetricChange<T> metric) where T : struct

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -503,7 +503,19 @@ public class MarkoutWriter
     /// <param name="labelHeader">The header/identity-column name for the row labels.</param>
     /// <param name="rows">The multi-source rows.</param>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteMultiSourceTable(string labelHeader, IReadOnlyList<MultiSourceRow> rows, string? structuredSection = null)
+    public bool WriteMultiSourceTable(string labelHeader, IReadOnlyList<MultiSourceRow> rows)
+        => WriteMultiSourceTable(labelHeader, rows, null);
+
+    /// <summary>
+    /// As <see cref="WriteMultiSourceTable(string, IReadOnlyList{MultiSourceRow})"/>, plus an optional
+    /// <paramref name="structuredSection"/>: when non-null, decomposed (TSV/JSONL) rows gain a leading
+    /// <c>section</c> column carrying that value. Markdown/dense output is unaffected.
+    /// </summary>
+    /// <param name="labelHeader">The header/identity-column name for the row labels.</param>
+    /// <param name="rows">The multi-source rows.</param>
+    /// <param name="structuredSection">A section discriminator prepended to decomposed rows, or <c>null</c>.</param>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
+    public bool WriteMultiSourceTable(string labelHeader, IReadOnlyList<MultiSourceRow> rows, string? structuredSection)
     {
         if (_sectionExcluded || rows.Count == 0)
             return true;
@@ -725,7 +737,18 @@ public class MarkoutWriter
     /// structured output.
     /// </summary>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows, string? structuredSection = null) where T : struct
+    public bool WriteMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows) where T : struct
+        => WriteMetricChangeTable(rows, null);
+
+    /// <summary>
+    /// As <see cref="WriteMetricChangeTable{T}(IReadOnlyList{MetricChange{T}})"/>, plus an optional
+    /// <paramref name="structuredSection"/>: when non-null, decomposed (TSV/JSONL) rows gain a leading
+    /// <c>section</c> column carrying that value. Markdown output is unaffected.
+    /// </summary>
+    /// <param name="rows">The gated-metric rows.</param>
+    /// <param name="structuredSection">A section discriminator prepended to decomposed rows, or <c>null</c>.</param>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
+    public bool WriteMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows, string? structuredSection) where T : struct
     {
         if (_sectionExcluded || rows.Count == 0)
             return true;

--- a/tests/Markout.Tests/GeneratedMetricChangeTests.cs
+++ b/tests/Markout.Tests/GeneratedMetricChangeTests.cs
@@ -88,3 +88,53 @@ public class GeneratedMetricChangeArrayTests
         Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", md);
     }
 }
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class GeneratedSectionRowsCard
+{
+    [MarkoutIgnore] public string Title => "IL Diff";
+
+    [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
+    public List<MetricChange<int>> Baseline { get; set; } = new();
+
+    [MarkoutSection(Name = "Plain metrics")]
+    public List<MetricChange<int>> Plain { get; set; } = new();
+}
+
+[MarkoutContext(typeof(GeneratedSectionRowsCard))]
+public partial class GeneratedSectionRowsCardContext : MarkoutSerializerContext
+{
+}
+
+public class GeneratedSectionRowsTests
+{
+    [Fact]
+    public void Generated_IncludeSectionInStructuredRows_AddsSectionOnlyToFlaggedSection()
+    {
+        var card = new GeneratedSectionRowsCard
+        {
+            Baseline = [new("Failures", 0, 7, 0, "max failures", GateStatus.Bad, "regression")],
+            Plain = [new("Changed bodies", 45, 46, Status: GateStatus.Warning, StatusLabel: "drift")],
+        };
+
+        // Markdown is unaffected — the section is the heading, no section column in the table.
+        var md = MarkoutSerializer.Serialize(card, GeneratedSectionRowsCardContext.Default);
+        Assert.Contains("## Baseline metric changes", md);
+        Assert.DoesNotContain("| section |", md);
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), GeneratedSectionRowsCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var records = sw.ToString().ReplaceLineEndings("\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => JsonDocument.Parse(l).RootElement)
+            .ToList();
+
+        var failures = records.First(e => e.GetProperty("metric").GetString() == "Failures");
+        Assert.Equal("Baseline metric changes", failures.GetProperty("section").GetString());
+
+        // The un-flagged section's rows carry no section discriminator.
+        var changed = records.First(e => e.GetProperty("metric").GetString() == "Changed bodies");
+        Assert.False(changed.TryGetProperty("section", out _));
+    }
+}

--- a/tests/Markout.Tests/MetricChangeTableTests.cs
+++ b/tests/Markout.Tests/MetricChangeTableTests.cs
@@ -72,4 +72,21 @@ public class MetricChangeTableTests
         Assert.Equal(JsonValueKind.String, failures.GetProperty("metric").ValueKind);
         Assert.Equal("regression", failures.GetProperty("status").GetString());
     }
+
+    [Fact]
+    public void Jsonl_StructuredSection_PrependsSectionColumn()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        writer.WriteMetricChangeTable(Rows(), structuredSection: "Baseline metric changes");
+        var line0 = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+
+        // Leading, stable section column; identity columns stay strings; typed numbers still work.
+        Assert.StartsWith("{\"section\":\"Baseline metric changes\",\"metric\":\"Failures\"", line0);
+        var rec = JsonDocument.Parse(line0).RootElement;
+        Assert.Equal(JsonValueKind.String, rec.GetProperty("section").ValueKind);
+        Assert.Equal(JsonValueKind.String, rec.GetProperty("metric").ValueKind);
+        Assert.Equal(7, rec.GetProperty("after").GetInt32());
+    }
 }

--- a/tests/Markout.Tests/MultiSourceTableTests.cs
+++ b/tests/Markout.Tests/MultiSourceTableTests.cs
@@ -224,4 +224,22 @@ public class MultiSourceTableTests
         Assert.Equal("4", r2.GetProperty("a_b_c").GetString());
         Assert.Equal("3", r2.GetProperty("a_b_c_2").GetString());
     }
+
+    // ── Structured-section discriminator (issue #131) ──
+
+    [Fact]
+    public void Jsonl_StructuredSection_ComposesWithLabelColumn()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        writer.WriteMultiSourceTable("Metric", MatrixRows(), structuredSection: "grounding");
+        var line0 = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+
+        // section + the multi-source label column ("metric") both lead, both stay strings.
+        Assert.StartsWith("{\"section\":\"grounding\",\"metric\":\"output tok\"", line0);
+        var rec = JsonDocument.Parse(line0).RootElement;
+        Assert.Equal("grounding", rec.GetProperty("section").GetString());
+        Assert.Equal(JsonValueKind.String, rec.GetProperty("metric").ValueKind);
+    }
 }


### PR DESCRIPTION
## Summary

Implements [#131](https://github.com/richlander/markout/issues/131): an opt-in **`section` discriminator** on decomposed (TSV/JSONL) rows for the card list-shapes, so a tool can multiplex several sectioned card shapes into one structured stream and route rows by section. Targets **0.18.0** (additive, non-breaking).

```csharp
[MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
public List<MetricChange<int>> BaselineMetrics { get; init; } = [];
```

## Behavior

Markdown is unchanged (the section is already its `## heading`):

```md
## Baseline metric changes

| Metric | Change | Target | Status |
| Failures | 0 → 7 | max failures: 0 | regression |
```

JSONL/TSV rows gain a leading, stable `section` column:

```jsonl
{"section":"Baseline metric changes","metric":"Failures","before":0,"after":7,"target":0,"target_label":"max failures","status":"regression"}
```

## How

The section name is a **compile-time constant the generator already has** (it emits `WriteSectionStart(level, "…")`), so it's injected as an argument — no runtime section-tracking:

- New `bool IncludeSectionInStructuredRows` on `MarkoutSectionAttribute`, threaded through `PropertyMetadata` (incl. equality, for incremental-generator caching).
- The generator, for a flagged `List<MetricChange<T>>` / `List<MultiSourceRow>` section, emits `writer.WriteMetricChangeTable(prop, "Baseline metric changes")` (and the `WriteMultiSourceTable` equivalent).
- The writer methods gain an optional `string? structuredSection = null`; the shared `WriteDecomposedFieldTable` prepends a `section` **string identity column** (never coerced under `JsonTypedValues`), composing with the shape's existing label/identity column — so `MetricChange` gets `section` + `metric`, and a multi-source card gets `section` + its `[MarkoutLabelHeader]` column. `_pendingJsonIdentityColumns` becomes 2.

## Scope

- Applies to the shapes that decompose to typed rows (`List<MetricChange<T>>`, `List<MultiSourceRow>`); a no-op for shapes that don't (e.g. `List<Metric>`/`List<Breakdown>`), and extends automatically to any future decomposing list shape.
- `section` is the fixed v1 field name (matches the harness convention); a follow-up could make it configurable.
- Not needed to unblock `dotnet-inspect` PR #2399 (a local wrapper works); this removes the need for parallel sectioned DTOs.

## Testing

- **607 tests** (+3): direct-writer `MetricChange`/`MultiSource` section prepend (order + string identity + typed numbers preserved), and an end-to-end generator test proving the flagged section gets `section` while an un-flagged sibling section does not, with Markdown unaffected.

Closes #131.
