### PR TITLE
Goal-aware cells: derived direction + polarity (#133, 0.19.0)

### DIFF
--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -155,13 +155,19 @@ public readonly record struct Slice(string Category, int Count);
 public readonly record struct Breakdown(string Label, Slice[] Slices);
 
 // Composite cells — data-only cells that render densely and decompose into typed columns.
-// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit] configure derivation/format.
+// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit]/[MarkoutGoal] configure derivation/format.
 public readonly record struct Change<V>(V Before, V After);        // before → after (+ derived delta)
 public readonly record struct Fraction(double Count, double Total); // 24/24
 public readonly record struct Share(double Value, double Whole);    // 5056 (24%)
 public readonly record struct Percent(double Part, double Whole);   // 93%
 public readonly record struct Segment(string Label, double Value);
 public readonly record struct Segments(params Segment[] Parts);     // 21/171/236
+
+// Goal-aware derivation — [MarkoutGoal] (or a Goal on MetricChange<T>/MarkoutCellFormat) derives a
+// structural Direction and a goal-applied GateStatus polarity from a numeric Change<V>, as separate
+// direction/status fields. A caller-supplied Status overrides the derived polarity.
+public enum Goal { Context, Higher, Lower }                         // which direction is "good"
+public enum Direction { Unchanged, Increased, Decreased, Introduced, Resolved }; // structural, goal-neutral
 
 // Card shapes — list-shapes that render as multi-format cards (Markdown table + typed JSONL/TSV).
 public readonly record struct MetricChange<T>(string Name, T Before, T After,

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -165,9 +165,11 @@ public readonly record struct Segments(params Segment[] Parts);     // 21/171/23
 
 // Goal-aware derivation — [MarkoutGoal] (or a Goal on MetricChange<T>/MarkoutCellFormat) derives a
 // structural Direction and a goal-applied GateStatus polarity from a numeric Change<V>, as separate
-// direction/status fields. A caller-supplied Status overrides the derived polarity.
+// direction/status fields. A caller-supplied Status overrides the derived polarity. Composite
+// Change<Share|Percent|Fraction> derive from IGoalMagnitude (Share→Value, Percent/Fraction→ratio).
 public enum Goal { Context, Higher, Lower }                         // which direction is "good"
 public enum Direction { Unchanged, Increased, Decreased, Introduced, Resolved }; // structural, goal-neutral
+public interface IGoalMagnitude { double GoalMagnitude { get; } }   // composite cell's comparable magnitude
 
 // Card shapes — list-shapes that render as multi-format cards (Markdown table + typed JSONL/TSV).
 public readonly record struct MetricChange<T>(string Name, T Before, T After,

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -77,7 +77,9 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
   (`increased`/`decreased`/`introduced` (0→N)/`resolved` (N→0)/`unchanged`) and a goal-applied polarity
   `status` (`good`/`bad`/`neutral`) — instead of the caller hand-coding ceiling/floor/drift. Optional
   noise, `[MarkoutGoal(Goal.Higher, 0.001)]`, treats sub-threshold movement as `unchanged`. `Goal.Context`
-  (default) derives nothing.
+  (default) derives nothing. Composite `Change<Share|Percent|Fraction>` also derive `direction`/`status`
+  from a single comparable magnitude (`Share` → raw `Value`; `Percent`/`Fraction` → their ratio);
+  `Change<Segments>` has no single magnitude, so it derives nothing.
 - `Fraction(count, total)` → `24/24`; `Share(value, whole)` → `5056 (24%)`
   (`[MarkoutUnit("s")]` → `103s (93%)`); `Percent(part, whole)` → `93%`;
   `Segments(new Segment(label, value), ...)` → `21/171/236` (labels become column names).

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -72,6 +72,12 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
 - `Change<V>` — a `before → after` change (NOT `Comparison`, which collides with `System.Comparison<T>`).
   `[MarkoutDelta(Delta.Percent)]` on a numeric `Change<V>` appends the signed change, e.g.
   `98555 → 61190 (−38%)`; `Delta.Absolute` appends the signed difference.
+  `[MarkoutGoal(Goal.Higher)]` / `[MarkoutGoal(Goal.Lower)]` on a numeric `Change<V>` makes Markout
+  derive two decomposed fields — a structural `direction`
+  (`increased`/`decreased`/`introduced` (0→N)/`resolved` (N→0)/`unchanged`) and a goal-applied polarity
+  `status` (`good`/`bad`/`neutral`) — instead of the caller hand-coding ceiling/floor/drift. Optional
+  noise, `[MarkoutGoal(Goal.Higher, 0.001)]`, treats sub-threshold movement as `unchanged`. `Goal.Context`
+  (default) derives nothing.
 - `Fraction(count, total)` → `24/24`; `Share(value, whole)` → `5056 (24%)`
   (`[MarkoutUnit("s")]` → `103s (93%)`); `Percent(part, whole)` → `93%`;
   `Segments(new Segment(label, value), ...)` → `21/171/236` (labels become column names).
@@ -91,9 +97,11 @@ flat typed JSONL/TSV — with no imperative writer calls:
 - `List<MetricChange<T>>` — a gated scalar metric per row. `MetricChange<T>(Name, Before, After,
   Target? = null, TargetLabel? = null, Status = GateStatus.Unknown, StatusLabel? = null)` where
   `T : struct`. Markdown = `Metric | Change | Target | Status`; JSONL = flat `before`/`after`/optional
-  `target`/`target_label`/`status`. `Status` is caller-supplied (Markout never derives it). `T` must be
-  a numeric scalar (int/long/double/decimal/...); a composite `T` (e.g. `Segments`) is a compile error
-  (`MARKOUT005`).
+  `target`/`target_label`/`status`. `Status` is caller-supplied. Set `{ Goal = Goal.Higher|Lower }`
+  (init property; optionally `Noise`) to derive the `direction`/`status` axes from `Before → After` —
+  the derived polarity fills the `Status` column and a `direction` field, and a caller-supplied `Status`
+  still overrides it. `T` must be a numeric scalar (int/long/double/decimal/...); a composite `T` (e.g.
+  `Segments`) is a compile error (`MARKOUT005`).
 - `[MarkoutSection(Name = "...", IncludeSectionInStructuredRows = true)]` on a `List<MetricChange<T>>`
   or `List<MultiSourceRow>` section prepends a leading `section` column (the section name) to TSV/JSONL
   rows — for multiplexing several sectioned card shapes into one structured stream. Markdown is unchanged.

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -356,6 +356,18 @@ internal static class EmitHelpers
     public static string UnitLiteral(PropertyMetadata prop)
         => prop.Unit == null ? "null" : $"\"{EscapeString(prop.Unit)}\"";
 
+    /// <summary>Emits the runtime Markout.Goal enum literal for a composite cell property.</summary>
+    public static string GoalLiteral(PropertyMetadata prop) => prop.Goal switch
+    {
+        MarkoutGoalKind.Higher => "global::Markout.Goal.Higher",
+        MarkoutGoalKind.Lower => "global::Markout.Goal.Lower",
+        _ => "global::Markout.Goal.Context"
+    };
+
+    /// <summary>Emits the noise-tolerance double literal for a composite cell property.</summary>
+    public static string NoiseLiteral(PropertyMetadata prop)
+        => prop.Noise.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+
     public static bool IsScalarKind(PropertyKind kind)
     {
         return kind is

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -366,7 +366,16 @@ internal static class EmitHelpers
 
     /// <summary>Emits the noise-tolerance double literal for a composite cell property.</summary>
     public static string NoiseLiteral(PropertyMetadata prop)
-        => prop.Noise.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+    {
+        var noise = prop.Noise;
+        if (double.IsNaN(noise))
+            return "global::System.Double.NaN";
+        if (double.IsPositiveInfinity(noise))
+            return "global::System.Double.PositiveInfinity";
+        if (double.IsNegativeInfinity(noise))
+            return "global::System.Double.NegativeInfinity";
+        return noise.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+    }
 
     public static bool IsScalarKind(PropertyKind kind)
     {

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -348,7 +348,7 @@ internal static class FieldEmitter
         string rowsVar,
         string indent)
     {
-        var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)})";
+        var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)}, {EmitHelpers.GoalLiteral(prop)}, {EmitHelpers.NoiseLiteral(prop)})";
 
         string RowAdd(string cellExpr) =>
             $"{rowsVar}.Add(new global::Markout.MarkoutCompositeRow(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {cellExpr}, {format}));";

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -348,7 +348,7 @@ internal static class FieldEmitter
         string rowsVar,
         string indent)
     {
-        var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)}, {EmitHelpers.GoalLiteral(prop)}, {EmitHelpers.NoiseLiteral(prop)})";
+        var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)}) {{ Goal = {EmitHelpers.GoalLiteral(prop)}, Noise = {EmitHelpers.NoiseLiteral(prop)} }}";
 
         string RowAdd(string cellExpr) =>
             $"{rowsVar}.Add(new global::Markout.MarkoutCompositeRow(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {cellExpr}, {format}));";

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -183,6 +183,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? SectionEmptyText { get; }
     public MarkoutDeltaKind DeltaMode { get; }
     public string? Unit { get; }
+    public MarkoutGoalKind Goal { get; }
+    public double Noise { get; }
     public bool IsReferenceTypeCell { get; }
     public string? MultiSourceLabelHeader { get; }
 
@@ -236,7 +238,9 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         MarkoutDeltaKind deltaMode = MarkoutDeltaKind.None,
         string? unit = null,
         bool isReferenceTypeCell = false,
-        string? multiSourceLabelHeader = null)
+        string? multiSourceLabelHeader = null,
+        MarkoutGoalKind goal = MarkoutGoalKind.Context,
+        double noise = 0)
     {
         Name = name;
         DisplayName = displayName;
@@ -286,6 +290,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         SectionEmptyText = sectionEmptyText;
         DeltaMode = deltaMode;
         Unit = unit;
+        Goal = goal;
+        Noise = noise;
         IsReferenceTypeCell = isReferenceTypeCell;
         MultiSourceLabelHeader = multiSourceLabelHeader;
     }
@@ -341,6 +347,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                SectionEmptyText == other.SectionEmptyText &&
                DeltaMode == other.DeltaMode &&
                Unit == other.Unit &&
+               Goal == other.Goal &&
+               Noise.Equals(other.Noise) &&
                IsReferenceTypeCell == other.IsReferenceTypeCell &&
                MultiSourceLabelHeader == other.MultiSourceLabelHeader &&
                SequenceEqual(ElementProperties, other.ElementProperties);
@@ -381,6 +389,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (SectionEmptyText?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (int)DeltaMode;
             hash = hash * 397 ^ (Unit?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ (int)Goal;
+            hash = hash * 397 ^ Noise.GetHashCode();
             hash = hash * 397 ^ IsReferenceTypeCell.GetHashCode();
             hash = hash * 397 ^ (MultiSourceLabelHeader?.GetHashCode() ?? 0);
             return hash;
@@ -497,4 +507,14 @@ internal enum MarkoutDeltaKind
     None = 0,
     Percent = 1,
     Absolute = 2
+}
+
+/// <summary>
+/// Internal representation of Markout.Goal. Values mirror the runtime enum.
+/// </summary>
+internal enum MarkoutGoalKind
+{
+    Context = 0,
+    Higher = 1,
+    Lower = 2
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -34,6 +34,7 @@ internal static class TypeParser
     private const string MarkoutIgnoreColumnWhenAttribute = "Markout.MarkoutIgnoreColumnWhenAttribute";
     private const string MarkoutDeltaAttribute = "Markout.MarkoutDeltaAttribute";
     private const string MarkoutUnitAttribute = "Markout.MarkoutUnitAttribute";
+    private const string MarkoutGoalAttribute = "Markout.MarkoutGoalAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -466,6 +467,22 @@ internal static class TypeParser
             unit = unitValue;
         }
 
+        // Parse [MarkoutGoal] — optimization goal (+ optional noise) for a numeric Change<> cell
+        MarkoutGoalKind goal = MarkoutGoalKind.Context;
+        double noise = 0;
+        var goalAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutGoalAttribute);
+        if (goalAttr != null && goalAttr.ConstructorArguments.Length > 0 &&
+            goalAttr.ConstructorArguments[0].Value is int goalValue)
+        {
+            goal = (MarkoutGoalKind)goalValue;
+            if (goalAttr.ConstructorArguments.Length > 1 &&
+                goalAttr.ConstructorArguments[1].Value is double noiseValue)
+            {
+                noise = noiseValue;
+            }
+        }
+
         // Parse [MarkoutLabelHeader] — label/identity column header for a List<MultiSourceRow> card
         string? multiSourceLabelHeader = null;
         var labelHeaderAttr = prop.GetAttributes()
@@ -557,7 +574,9 @@ internal static class TypeParser
             deltaMode,
             unit,
             isReferenceTypeCell,
-            multiSourceLabelHeader);
+            multiSourceLabelHeader,
+            goal,
+            noise);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutGoalAttribute.cs
+++ b/src/Markout/Attributes/MarkoutGoalAttribute.cs
@@ -1,0 +1,21 @@
+namespace Markout;
+
+/// <summary>
+/// Declares the optimization <see cref="Markout.Goal"/> for a numeric <see cref="Change{V}"/> property.
+/// When the goal is not <see cref="Markout.Goal.Context"/>, structured output gains a derived
+/// <c>direction</c> (structural) and <c>status</c> (goal-applied polarity) field. An optional
+/// <paramref name="noise"/> tolerance treats sub-threshold movement as <see cref="Direction.Unchanged"/>.
+/// Extends the same property-format mechanism as <see cref="MarkoutDeltaAttribute"/> and
+/// <see cref="MarkoutUnitAttribute"/>.
+/// </summary>
+/// <param name="goal">The optimization goal (which direction of movement is good).</param>
+/// <param name="noise">The tolerance (inclusive) under which a change is <see cref="Direction.Unchanged"/>.</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutGoalAttribute(Goal goal, double noise = 0) : Attribute
+{
+    /// <summary>The optimization goal.</summary>
+    public Goal Goal { get; } = goal;
+
+    /// <summary>The noise tolerance under which a change counts as unchanged.</summary>
+    public double Noise { get; } = noise;
+}

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -53,6 +53,13 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             fields.Add(new MarkoutField(CellText.SideKey(side, "deltaPct"), DeltaValue(Delta.Percent)));
         else if (format.Delta == Delta.Absolute)
             fields.Add(new MarkoutField(CellText.SideKey(side, "deltaAbs"), DeltaValue(Delta.Absolute)));
+
+        if (format.Goal != Goal.Context &&
+            GoalDerivation.TryDerive(Before, After, format.Goal, format.Noise, out var direction, out var status))
+        {
+            fields.Add(new MarkoutField(CellText.SideKey(side, "direction"), DirectionText.Slug(direction)));
+            fields.Add(new MarkoutField(CellText.SideKey(side, "status"), GateStatusText.Slug(status)));
+        }
     }
 
     private string DeltaSuffix(Delta mode)

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -43,6 +43,15 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         {
             (Before as IMarkoutCell)?.Decompose(fields, CellText.SideKey(side, "before"), format);
             (After as IMarkoutCell)?.Decompose(fields, CellText.SideKey(side, "after"), format);
+
+            // Composite shapes derive goal direction/status from their comparable magnitude
+            // (a scalar Change<T> does this in the branch below).
+            if (format.Goal != Goal.Context && Before is IGoalMagnitude beforeMag && After is IGoalMagnitude afterMag &&
+                GoalDerivation.TryDerive(beforeMag.GoalMagnitude, afterMag.GoalMagnitude, format.Goal, format.Noise, out var compositeDir, out var compositeStatus))
+            {
+                fields.Add(new MarkoutField(CellText.SideKey(side, "direction"), DirectionText.Slug(compositeDir)));
+                fields.Add(new MarkoutField(CellText.SideKey(side, "status"), GateStatusText.Slug(compositeStatus)));
+            }
             return;
         }
 

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -1,0 +1,94 @@
+namespace Markout;
+
+/// <summary>
+/// The <b>structural, goal-neutral</b> category of a numeric <c>Before → After</c> movement. It states
+/// only <em>how</em> a value moved, never whether that is good or bad — the good/bad polarity is the
+/// separate <see cref="GateStatus"/> axis, derived by applying a <see cref="Goal"/> to this direction.
+/// Structured output carries both a <c>direction</c> (this) and a <c>status</c> (polarity) field.
+/// </summary>
+public enum Direction
+{
+    /// <summary>No net movement (within the declared noise tolerance).</summary>
+    Unchanged,
+
+    /// <summary>The value rose (both sides non-zero).</summary>
+    Increased,
+
+    /// <summary>The value fell (both sides non-zero).</summary>
+    Decreased,
+
+    /// <summary>The value appeared: <c>0 → N</c>. Rendered as "New" by some cards.</summary>
+    Introduced,
+
+    /// <summary>The value cleared: <c>N → 0</c>.</summary>
+    Resolved
+}
+
+/// <summary>Shared slug text for <see cref="Direction"/> values (the stable structured token).</summary>
+internal static class DirectionText
+{
+    public static string Slug(Direction direction) => direction switch
+    {
+        Direction.Increased => "increased",
+        Direction.Decreased => "decreased",
+        Direction.Introduced => "introduced",
+        Direction.Resolved => "resolved",
+        _ => "unchanged"
+    };
+}
+
+/// <summary>
+/// Derives a structural <see cref="Direction"/> from a numeric change and the goal-applied
+/// <see cref="GateStatus"/> polarity. Keeps the two axes separate so a <see cref="Goal.Context"/>
+/// metric can report movement with a <see cref="GateStatus.Neutral"/> polarity, and a zero-crossing
+/// can flip polarity by goal without changing its structural category.
+/// </summary>
+internal static class GoalDerivation
+{
+    /// <summary>
+    /// Classifies the movement from <paramref name="before"/> to <paramref name="after"/>. A movement
+    /// whose magnitude is within <paramref name="noise"/> (inclusive) is <see cref="Direction.Unchanged"/>.
+    /// </summary>
+    public static Direction Classify(double before, double after, double noise = 0)
+    {
+        var delta = after - before;
+        if (Math.Abs(delta) <= noise)
+            return Direction.Unchanged;
+        if (before == 0)
+            return Direction.Introduced;
+        if (after == 0)
+            return Direction.Resolved;
+        return delta > 0 ? Direction.Increased : Direction.Decreased;
+    }
+
+    /// <summary>
+    /// Applies <paramref name="goal"/> to a structural <paramref name="direction"/> to get the good/bad
+    /// polarity. <see cref="Goal.Context"/> and <see cref="Direction.Unchanged"/> are always
+    /// <see cref="GateStatus.Neutral"/>.
+    /// </summary>
+    public static GateStatus Polarity(Direction direction, Goal goal)
+    {
+        if (goal == Goal.Context || direction == Direction.Unchanged)
+            return GateStatus.Neutral;
+
+        var rose = direction is Direction.Increased or Direction.Introduced;
+        return goal == Goal.Higher
+            ? (rose ? GateStatus.Good : GateStatus.Bad)
+            : (rose ? GateStatus.Bad : GateStatus.Good);
+    }
+
+    /// <summary>
+    /// Convenience: classify a change and return both axes. Returns <c>false</c> when either side is not
+    /// a numeric scalar (goal derivation does not apply), leaving both outputs at their neutral defaults.
+    /// </summary>
+    public static bool TryDerive(object? before, object? after, Goal goal, double noise, out Direction direction, out GateStatus status)
+    {
+        direction = Direction.Unchanged;
+        status = GateStatus.Neutral;
+        if (!CellText.TryScalarDouble(before, out var b) || !CellText.TryScalarDouble(after, out var a))
+            return false;
+        direction = Classify(b, a, noise);
+        status = Polarity(direction, goal);
+        return true;
+    }
+}

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -46,17 +46,26 @@ internal static class DirectionText
 internal static class GoalDerivation
 {
     /// <summary>
-    /// Classifies the movement from <paramref name="before"/> to <paramref name="after"/>. A movement
-    /// whose magnitude is within <paramref name="noise"/> (inclusive) is <see cref="Direction.Unchanged"/>.
+    /// Classifies the movement from <paramref name="before"/> to <paramref name="after"/> (both assumed
+    /// finite). A movement whose magnitude is within <paramref name="noise"/> (inclusive) is
+    /// <see cref="Direction.Unchanged"/>. The zero-crossing categories are restricted to
+    /// <em>non-negative</em> counts — <c>0 → +N</c> is <see cref="Direction.Introduced"/> and
+    /// <c>+N → 0</c> is <see cref="Direction.Resolved"/> — so a crossing that involves a negative value
+    /// (e.g. <c>0 → -5</c>) falls through to sign-based <see cref="Direction.Increased"/>/<see cref="Direction.Decreased"/>,
+    /// keeping <see cref="Polarity"/> algebraically correct.
     /// </summary>
     public static Direction Classify(double before, double after, double noise = 0)
     {
+        // A NaN or negative tolerance is meaningless; treat it as exact (0).
+        if (!(noise >= 0))
+            noise = 0;
+
         var delta = after - before;
         if (Math.Abs(delta) <= noise)
             return Direction.Unchanged;
-        if (before == 0)
+        if (before == 0 && after > 0)
             return Direction.Introduced;
-        if (after == 0)
+        if (after == 0 && before > 0)
             return Direction.Resolved;
         return delta > 0 ? Direction.Increased : Direction.Decreased;
     }
@@ -64,7 +73,8 @@ internal static class GoalDerivation
     /// <summary>
     /// Applies <paramref name="goal"/> to a structural <paramref name="direction"/> to get the good/bad
     /// polarity. <see cref="Goal.Context"/> and <see cref="Direction.Unchanged"/> are always
-    /// <see cref="GateStatus.Neutral"/>.
+    /// <see cref="GateStatus.Neutral"/>. Relies on <see cref="Classify"/> restricting
+    /// <see cref="Direction.Introduced"/> to rises and <see cref="Direction.Resolved"/> to falls.
     /// </summary>
     public static GateStatus Polarity(Direction direction, Goal goal)
     {
@@ -78,8 +88,24 @@ internal static class GoalDerivation
     }
 
     /// <summary>
-    /// Convenience: classify a change and return both axes. Returns <c>false</c> when either side is not
-    /// a numeric scalar (goal derivation does not apply), leaving both outputs at their neutral defaults.
+    /// Derives both axes from finite scalar magnitudes. Returns <c>false</c> when either side is not a
+    /// finite number (NaN/Infinity), so callers omit <c>direction</c>/<c>status</c> — matching the
+    /// <c>—</c> placeholder a non-finite value renders.
+    /// </summary>
+    public static bool TryDerive(double before, double after, Goal goal, double noise, out Direction direction, out GateStatus status)
+    {
+        direction = Direction.Unchanged;
+        status = GateStatus.Neutral;
+        if (!double.IsFinite(before) || !double.IsFinite(after))
+            return false;
+        direction = Classify(before, after, noise);
+        status = Polarity(direction, goal);
+        return true;
+    }
+
+    /// <summary>
+    /// Convenience: derive both axes from boxed scalars. Returns <c>false</c> when either side is not a
+    /// (finite) numeric scalar, leaving both outputs at their neutral defaults.
     /// </summary>
     public static bool TryDerive(object? before, object? after, Goal goal, double noise, out Direction direction, out GateStatus status)
     {
@@ -87,8 +113,6 @@ internal static class GoalDerivation
         status = GateStatus.Neutral;
         if (!CellText.TryScalarDouble(before, out var b) || !CellText.TryScalarDouble(after, out var a))
             return false;
-        direction = Classify(b, a, noise);
-        status = Polarity(direction, goal);
-        return true;
+        return TryDerive(b, a, goal, noise, out direction, out status);
     }
 }

--- a/src/Markout/Fraction.cs
+++ b/src/Markout/Fraction.cs
@@ -6,8 +6,11 @@ namespace Markout;
 /// </summary>
 /// <param name="Count">The numerator.</param>
 /// <param name="Total">The denominator.</param>
-public readonly record struct Fraction(double Count, double Total) : IMarkoutCell
+public readonly record struct Fraction(double Count, double Total) : IMarkoutCell, IGoalMagnitude
 {
+    /// <summary>The count-over-total rate drives goal derivation (not the raw count).</summary>
+    double IGoalMagnitude.GoalMagnitude => Total == 0 ? 0 : Count / Total;
+
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
     {

--- a/src/Markout/Fraction.cs
+++ b/src/Markout/Fraction.cs
@@ -8,8 +8,9 @@ namespace Markout;
 /// <param name="Total">The denominator.</param>
 public readonly record struct Fraction(double Count, double Total) : IMarkoutCell, IGoalMagnitude
 {
-    /// <summary>The count-over-total rate drives goal derivation (not the raw count).</summary>
-    double IGoalMagnitude.GoalMagnitude => Total == 0 ? 0 : Count / Total;
+    /// <summary>The count-over-total rate drives goal derivation (not the raw count); an undefined rate
+    /// (zero total) yields <see cref="double.NaN"/> so no direction is derived.</summary>
+    double IGoalMagnitude.GoalMagnitude => Total == 0 ? double.NaN : Count / Total;
 
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)

--- a/src/Markout/Goal.cs
+++ b/src/Markout/Goal.cs
@@ -1,0 +1,22 @@
+namespace Markout;
+
+/// <summary>
+/// The optimization goal for a numeric metric: which direction of movement is "good". A goal lets
+/// Markout derive a structural <see cref="Markout.Direction"/> and a polarity <see cref="GateStatus"/>
+/// from a <c>Before → After</c> change, replacing hand-coded ceiling/floor/drift helpers in callers.
+/// </summary>
+/// <remarks>
+/// v1 ships the three unambiguous goals below. A numeric-target goal (reach/approach a specific value)
+/// is deferred pending its own design (exact vs distance vs ceiling/floor).
+/// </remarks>
+public enum Goal
+{
+    /// <summary>Informational: the metric has no good/bad polarity; movement is drift.</summary>
+    Context,
+
+    /// <summary>Higher is better (e.g. <c>Fully raised</c>): an increase is <see cref="GateStatus.Good"/>.</summary>
+    Higher,
+
+    /// <summary>Lower is better (e.g. <c>Pass bugs</c>): a decrease is <see cref="GateStatus.Good"/>.</summary>
+    Lower
+}

--- a/src/Markout/IGoalMagnitude.cs
+++ b/src/Markout/IGoalMagnitude.cs
@@ -1,0 +1,17 @@
+namespace Markout;
+
+/// <summary>
+/// Implemented by composite cell shapes that expose a single comparable magnitude, so a
+/// <see cref="Change{V}"/> over that shape can derive a goal <c>direction</c>/<c>status</c> the same
+/// way a scalar <see cref="Change{V}"/> does. Shapes without one meaningful magnitude (e.g.
+/// <see cref="Segments"/>) do not implement this and get no derived direction. A custom
+/// <see cref="IMarkoutCell"/> can opt into goal derivation by implementing it.
+/// </summary>
+public interface IGoalMagnitude
+{
+    /// <summary>
+    /// The single numeric magnitude used to classify goal direction (compared before vs after). Only
+    /// the relative order/sign matters, so any monotonic magnitude (raw value or ratio) is valid.
+    /// </summary>
+    double GoalMagnitude { get; }
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.18.0</Version>
-    <PackageReleaseNotes>Section-aware structured rows: [MarkoutSection(IncludeSectionInStructuredRows = true)] on a List&lt;MetricChange&lt;T&gt;&gt; or List&lt;MultiSourceRow&gt; section prepends a leading "section" column (the section name) to decomposed TSV/JSONL rows, so a tool can multiplex several sectioned card shapes into one structured stream and route by section. Markdown output is unchanged.</PackageReleaseNotes>
+    <Version>0.19.0</Version>
+    <PackageReleaseNotes>Goal-aware cells: [MarkoutGoal(Goal.Higher|Lower)] on a numeric Change&lt;T&gt; property (and a Goal on MetricChange&lt;T&gt; / MarkoutCellFormat for runtime rows) makes Markout derive a structural "direction" (increased/decreased/introduced/resolved/unchanged) and a goal-applied polarity "status" (good/bad/neutral), replacing hand-coded ceiling/floor/drift helpers. The two axes decompose as separate direction/status fields; a caller-supplied Status still overrides the derived polarity. An optional noise tolerance treats sub-threshold movement as unchanged. Goal.Context (default) leaves behavior unchanged.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -2,17 +2,24 @@ namespace Markout;
 
 /// <summary>
 /// Render-time configuration for a composite cell, sourced from property attributes
-/// (<see cref="MarkoutDeltaAttribute"/>, <see cref="MarkoutUnitAttribute"/>).
+/// (<see cref="MarkoutDeltaAttribute"/>, <see cref="MarkoutUnitAttribute"/>, <see cref="MarkoutGoalAttribute"/>).
 /// Shapes are data-only; derivation/formatting options travel through this struct.
 /// </summary>
 /// <param name="Delta">The derived change mode for a numeric <see cref="Change{V}"/>.</param>
 /// <param name="Unit">An optional unit suffix (e.g. <c>"s"</c>) for a <see cref="Share"/> value.</param>
-/// <param name="Goal">The optimization goal; when not <see cref="Markout.Goal.Context"/>, a numeric
-/// <see cref="Change{V}"/> derives a structural <c>direction</c> and a polarity <c>status</c>.</param>
-/// <param name="Noise">The tolerance (inclusive) under which a change counts as
-/// <see cref="Direction.Unchanged"/>; defaults to <c>0</c> (exact).</param>
-public readonly record struct MarkoutCellFormat(
-    Delta Delta = Delta.None,
-    string? Unit = null,
-    Goal Goal = Goal.Context,
-    double Noise = 0);
+public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string? Unit = null)
+{
+    /// <summary>
+    /// The optimization goal; when not <see cref="Markout.Goal.Context"/>, a numeric
+    /// <see cref="Change{V}"/> derives a structural <c>direction</c> and a polarity <c>status</c>.
+    /// Added as an <c>init</c> property (not a constructor parameter) so the shipped two-arg
+    /// constructor stays binary-compatible.
+    /// </summary>
+    public Goal Goal { get; init; }
+
+    /// <summary>
+    /// The tolerance (inclusive) under which a change counts as <see cref="Direction.Unchanged"/>;
+    /// defaults to <c>0</c> (exact).
+    /// </summary>
+    public double Noise { get; init; }
+}

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -7,4 +7,12 @@ namespace Markout;
 /// </summary>
 /// <param name="Delta">The derived change mode for a numeric <see cref="Change{V}"/>.</param>
 /// <param name="Unit">An optional unit suffix (e.g. <c>"s"</c>) for a <see cref="Share"/> value.</param>
-public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string? Unit = null);
+/// <param name="Goal">The optimization goal; when not <see cref="Markout.Goal.Context"/>, a numeric
+/// <see cref="Change{V}"/> derives a structural <c>direction</c> and a polarity <c>status</c>.</param>
+/// <param name="Noise">The tolerance (inclusive) under which a change counts as
+/// <see cref="Direction.Unchanged"/>; defaults to <c>0</c> (exact).</param>
+public readonly record struct MarkoutCellFormat(
+    Delta Delta = Delta.None,
+    string? Unit = null,
+    Goal Goal = Goal.Context,
+    double Noise = 0);

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -785,8 +785,11 @@ public class MarkoutWriter
                 if (!string.IsNullOrEmpty(metric.TargetLabel))
                     fields.Add(new MarkoutField("targetLabel", metric.TargetLabel!));
             }
-            if (metric.Status != GateStatus.Unknown || !string.IsNullOrEmpty(metric.StatusLabel))
-                fields.Add(new MarkoutField("status", StatusText(metric)));
+            var (direction, status) = Resolve(metric);
+            if (direction is not null)
+                fields.Add(new MarkoutField("direction", direction));
+            if (status is not null)
+                fields.Add(new MarkoutField("status", status));
 
             perRow[r] = fields;
             foreach (var field in fields)
@@ -809,10 +812,32 @@ public class MarkoutWriter
     }
 
     private static string StatusText<T>(in MetricChange<T> metric) where T : struct
+        => Resolve(metric).Status ?? "-";
+
+    /// <summary>
+    /// Resolves the row's <c>direction</c> (structural) and <c>status</c> (polarity) text. A
+    /// caller-supplied <see cref="MetricChange{T}.StatusLabel"/> or <see cref="MetricChange{T}.Status"/>
+    /// overrides the derived polarity; direction is derived whenever a goal is set.
+    /// </summary>
+    private static (string? Direction, string? Status) Resolve<T>(in MetricChange<T> metric) where T : struct
     {
+        Direction? direction = null;
+        var derived = GateStatus.Neutral;
+        if (metric.Goal != Goal.Context &&
+            GoalDerivation.TryDerive(metric.Before, metric.After, metric.Goal, metric.Noise, out var d, out derived))
+            direction = d;
+
+        string? status;
         if (!string.IsNullOrEmpty(metric.StatusLabel))
-            return metric.StatusLabel!;
-        return metric.Status == GateStatus.Unknown ? "-" : GateStatusText.Slug(metric.Status);
+            status = metric.StatusLabel;
+        else if (metric.Status != GateStatus.Unknown)
+            status = GateStatusText.Slug(metric.Status);
+        else if (direction is not null)
+            status = GateStatusText.Slug(derived);
+        else
+            status = null;
+
+        return (direction is null ? null : DirectionText.Slug(direction.Value), status);
     }
 
     /// <summary>

--- a/src/Markout/MetricChange.cs
+++ b/src/Markout/MetricChange.cs
@@ -27,4 +27,16 @@ public readonly record struct MetricChange<T>(
     string? TargetLabel = null,
     GateStatus Status = GateStatus.Unknown,
     string? StatusLabel = null)
-    where T : struct;
+    where T : struct
+{
+    /// <summary>
+    /// The optimization goal. When not <see cref="Goal.Context"/> and <see cref="Status"/> is
+    /// caller-unset, Markout derives a structural <c>direction</c> and a polarity <c>status</c> from
+    /// <see cref="Before"/> → <see cref="After"/>. Set via object initializer to preserve the shipped
+    /// constructor, e.g. <c>new MetricChange&lt;int&gt;("Failures", b, a) { Goal = Goal.Lower }</c>.
+    /// </summary>
+    public Goal Goal { get; init; } = Goal.Context;
+
+    /// <summary>The tolerance (inclusive) under which a change is <see cref="Direction.Unchanged"/>; default exact.</summary>
+    public double Noise { get; init; }
+}

--- a/src/Markout/Percent.cs
+++ b/src/Markout/Percent.cs
@@ -9,8 +9,9 @@ namespace Markout;
 /// <param name="Whole">The whole. A zero renders the placeholder.</param>
 public readonly record struct Percent(double Part, double Whole) : IMarkoutCell, IGoalMagnitude
 {
-    /// <summary>The part-over-whole ratio drives goal derivation.</summary>
-    double IGoalMagnitude.GoalMagnitude => Whole == 0 ? 0 : Part / Whole;
+    /// <summary>The part-over-whole ratio drives goal derivation; an undefined ratio (zero whole,
+    /// which renders as the placeholder) yields <see cref="double.NaN"/> so no direction is derived.</summary>
+    double IGoalMagnitude.GoalMagnitude => Whole == 0 ? double.NaN : Part / Whole;
 
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)

--- a/src/Markout/Percent.cs
+++ b/src/Markout/Percent.cs
@@ -7,8 +7,11 @@ namespace Markout;
 /// </summary>
 /// <param name="Part">The part.</param>
 /// <param name="Whole">The whole. A zero renders the placeholder.</param>
-public readonly record struct Percent(double Part, double Whole) : IMarkoutCell
+public readonly record struct Percent(double Part, double Whole) : IMarkoutCell, IGoalMagnitude
 {
+    /// <summary>The part-over-whole ratio drives goal derivation.</summary>
+    double IGoalMagnitude.GoalMagnitude => Whole == 0 ? 0 : Part / Whole;
+
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
         => writer.Write(Whole == 0 ? CellText.Placeholder : CellText.Percent(Part / Whole * 100));

--- a/src/Markout/Share.cs
+++ b/src/Markout/Share.cs
@@ -7,8 +7,11 @@ namespace Markout;
 /// </summary>
 /// <param name="Value">The value shown before the derived percent.</param>
 /// <param name="Whole">The whole the value is a share of. A zero renders the placeholder.</param>
-public readonly record struct Share(double Value, double Whole) : IMarkoutCell
+public readonly record struct Share(double Value, double Whole) : IMarkoutCell, IGoalMagnitude
 {
+    /// <summary>The raw value drives goal derivation (the share percent is secondary context).</summary>
+    double IGoalMagnitude.GoalMagnitude => Value;
+
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
     {

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -54,7 +54,7 @@ public class GoalAwareCellTests
     [InlineData(5, 5, "higher", "unchanged", "neutral")]
     public void Change_WithGoal_DerivesDirectionAndPolarity(int before, int after, string goal, string direction, string status)
     {
-        var format = new MarkoutCellFormat(Goal: goal == "lower" ? Goal.Lower : Goal.Higher);
+        var format = new MarkoutCellFormat { Goal = goal == "lower" ? Goal.Lower : Goal.Higher };
         var fields = Decompose(new Change<long>(before, after), format);
 
         Assert.Equal(direction, fields.Single(f => f.Key == "direction").Value);
@@ -64,7 +64,7 @@ public class GoalAwareCellTests
     [Fact]
     public void Change_ContextGoal_EmitsNeitherDirectionNorStatus()
     {
-        var fields = Decompose(new Change<long>(45, 46), new MarkoutCellFormat(Goal: Goal.Context));
+        var fields = Decompose(new Change<long>(45, 46), new MarkoutCellFormat { Goal = Goal.Context });
         Assert.DoesNotContain(fields, f => f.Key is "direction" or "status");
     }
 
@@ -72,7 +72,7 @@ public class GoalAwareCellTests
     public void Change_NoiseTolerance_ClassifiesSubThresholdAsUnchanged()
     {
         // 87.30% -> 87.31% with a 0.001 tolerance is within noise -> unchanged/neutral.
-        var format = new MarkoutCellFormat(Goal: Goal.Higher, Noise: 0.001);
+        var format = new MarkoutCellFormat { Goal = Goal.Higher, Noise = 0.001 };
         var fields = Decompose(new Change<double>(0.8730, 0.8731), format);
 
         Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
@@ -82,7 +82,7 @@ public class GoalAwareCellTests
     [Fact]
     public void Change_GoalAndDelta_EmitBothDerivedAxesAndDelta()
     {
-        var format = new MarkoutCellFormat(Delta.Absolute, Goal: Goal.Lower);
+        var format = new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower };
         var fields = Decompose(new Change<long>(10, 3), format);
 
         Assert.Equal("10", fields[0].Value); // before

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -52,6 +52,13 @@ public class GoalAwareCellTests
     // Unchanged is always neutral regardless of goal
     [InlineData(5, 5, "lower", "unchanged", "neutral")]
     [InlineData(5, 5, "higher", "unchanged", "neutral")]
+    // Negative-involved crossings fall through to sign-based direction (polarity stays algebraic)
+    [InlineData(0, -5, "higher", "decreased", "bad")]
+    [InlineData(0, -5, "lower", "decreased", "good")]
+    [InlineData(-5, 0, "higher", "increased", "good")]
+    [InlineData(-5, 0, "lower", "increased", "bad")]
+    [InlineData(-3, -5, "lower", "decreased", "good")]
+    [InlineData(-5, -3, "higher", "increased", "good")]
     public void Change_WithGoal_DerivesDirectionAndPolarity(int before, int after, string goal, string direction, string status)
     {
         var format = new MarkoutCellFormat { Goal = goal == "lower" ? Goal.Lower : Goal.Higher };
@@ -171,6 +178,81 @@ public class GoalAwareCellTests
 
         Assert.Equal("decreased", row.GetProperty("direction").GetString()); // still derived
         Assert.Equal("near-threshold", row.GetProperty("status").GetString()); // caller override wins
+    }
+
+    [Fact]
+    public void Change_NonFiniteInput_EmitsNoDirectionOrStatus()
+    {
+        // NaN/Infinity render as the — placeholder; goal derivation is omitted rather than guessed.
+        Assert.DoesNotContain(Decompose(new Change<double>(double.NaN, 5), new MarkoutCellFormat { Goal = Goal.Higher }),
+            f => f.Key is "direction" or "status");
+        Assert.DoesNotContain(Decompose(new Change<double>(5, double.PositiveInfinity), new MarkoutCellFormat { Goal = Goal.Lower }),
+            f => f.Key is "direction" or "status");
+    }
+
+    // --- Composite cells derive from a comparable magnitude (runtime Source path) ---
+
+    [Fact]
+    public void MultiSourceRow_CompositeCells_DeriveDirectionAndStatusFromMagnitude()
+    {
+        var rows = new[]
+        {
+            // Share magnitude = raw Value: 5056 -> 3129 tokens, Lower -> good.
+            new MultiSourceRow("output tok",
+                new Source("opus", new Change<Share>(new Share(5056, 21067), new Share(3129, 13037)),
+                    new MarkoutCellFormat { Goal = Goal.Lower })),
+            // Fraction magnitude = Count/Total rate: 20/24 -> 24/24 rate up, Higher -> good.
+            new MultiSourceRow("tasks correct",
+                new Source("opus", new Change<Fraction>(new Fraction(20, 24), new Fraction(24, 24)),
+                    new MarkoutCellFormat { Goal = Goal.Higher })),
+            // Percent magnitude = Part/Whole: 80% -> 95%, Higher -> good.
+            new MultiSourceRow("read grounding",
+                new Source("opus", new Change<Percent>(new Percent(80, 100), new Percent(95, 100)),
+                    new MarkoutCellFormat { Goal = Goal.Higher })),
+        };
+
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMultiSourceTable("Metric", rows);
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var tok = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.Equal("decreased", tok.GetProperty("opus_direction").GetString());
+        Assert.Equal("good", tok.GetProperty("opus_status").GetString());
+        // The composite's own decomposed fields are still present.
+        Assert.Equal("5056", tok.GetProperty("opus_before_value").GetString());
+
+        var tasks = JsonDocument.Parse(lines[1]).RootElement;
+        Assert.Equal("increased", tasks.GetProperty("opus_direction").GetString());
+        Assert.Equal("good", tasks.GetProperty("opus_status").GetString());
+
+        var read = JsonDocument.Parse(lines[2]).RootElement;
+        Assert.Equal("increased", read.GetProperty("opus_direction").GetString());
+        Assert.Equal("good", read.GetProperty("opus_status").GetString());
+    }
+
+    [Fact]
+    public void MultiSourceRow_SegmentsCell_NoDerivedDirection_EvenWithGoal()
+    {
+        // Segments has no single comparable magnitude (no IGoalMagnitude) -> no direction/status.
+        var rows = new[]
+        {
+            new MultiSourceRow("tool calls",
+                new Source("opus", new Change<Segments>(
+                    new Segments(new Segment("web", 21), new Segment("other", 171)),
+                    new Segments(new Segment("web", 10), new Segment("other", 183))),
+                    new MarkoutCellFormat { Goal = Goal.Lower })),
+        };
+
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMultiSourceTable("Metric", rows);
+        var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
+
+        Assert.False(row.TryGetProperty("opus_direction", out _));
+        Assert.False(row.TryGetProperty("opus_status", out _));
     }
 
     // --- Attribute path (source generator) ---

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -1,0 +1,213 @@
+using System.Text.Json;
+using Markout;
+
+namespace Markout.Tests;
+
+// Attribute-path model: [MarkoutGoal] on numeric Change<> cells drives derived direction/status.
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class GoalAttrCard
+{
+    [MarkoutIgnore] public string Title => "Goal card";
+
+    [MarkoutPropertyName("Failures"), MarkoutGoal(Goal.Lower)]
+    public Change<int> Failures { get; set; }
+
+    [MarkoutPropertyName("Fully raised"), MarkoutGoal(Goal.Higher)]
+    public Change<int> FullyRaised { get; set; }
+
+    [MarkoutPropertyName("Fidelity"), MarkoutGoal(Goal.Higher, 0.001)]
+    public Change<double> Fidelity { get; set; }
+
+    [MarkoutPropertyName("Changed bodies")]
+    public Change<int> ChangedBodies { get; set; }
+}
+
+[MarkoutContext(typeof(GoalAttrCard))]
+public partial class GoalAttrCardContext : MarkoutSerializerContext
+{
+}
+
+public class GoalAwareCellTests
+{
+    private static List<MarkoutField> Decompose(IMarkoutCell cell, MarkoutCellFormat format)
+    {
+        var fields = new List<MarkoutField>();
+        cell.Decompose(fields, null, format);
+        return fields;
+    }
+
+    // --- Direct-cell derivation matrix (structural direction × goal-applied polarity) ---
+
+    [Theory]
+    // Increased / Introduced
+    [InlineData(0, 7, "lower", "introduced", "bad")]
+    [InlineData(0, 7, "higher", "introduced", "good")]
+    [InlineData(5, 9, "lower", "increased", "bad")]
+    [InlineData(5, 9, "higher", "increased", "good")]
+    // Decreased / Resolved
+    [InlineData(7, 0, "lower", "resolved", "good")]
+    [InlineData(7, 0, "higher", "resolved", "bad")]
+    [InlineData(9, 5, "lower", "decreased", "good")]
+    [InlineData(9, 5, "higher", "decreased", "bad")]
+    // Unchanged is always neutral regardless of goal
+    [InlineData(5, 5, "lower", "unchanged", "neutral")]
+    [InlineData(5, 5, "higher", "unchanged", "neutral")]
+    public void Change_WithGoal_DerivesDirectionAndPolarity(int before, int after, string goal, string direction, string status)
+    {
+        var format = new MarkoutCellFormat(Goal: goal == "lower" ? Goal.Lower : Goal.Higher);
+        var fields = Decompose(new Change<long>(before, after), format);
+
+        Assert.Equal(direction, fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal(status, fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
+    public void Change_ContextGoal_EmitsNeitherDirectionNorStatus()
+    {
+        var fields = Decompose(new Change<long>(45, 46), new MarkoutCellFormat(Goal: Goal.Context));
+        Assert.DoesNotContain(fields, f => f.Key is "direction" or "status");
+    }
+
+    [Fact]
+    public void Change_NoiseTolerance_ClassifiesSubThresholdAsUnchanged()
+    {
+        // 87.30% -> 87.31% with a 0.001 tolerance is within noise -> unchanged/neutral.
+        var format = new MarkoutCellFormat(Goal: Goal.Higher, Noise: 0.001);
+        var fields = Decompose(new Change<double>(0.8730, 0.8731), format);
+
+        Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("neutral", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
+    public void Change_GoalAndDelta_EmitBothDerivedAxesAndDelta()
+    {
+        var format = new MarkoutCellFormat(Delta.Absolute, Goal: Goal.Lower);
+        var fields = Decompose(new Change<long>(10, 3), format);
+
+        Assert.Equal("10", fields[0].Value); // before
+        Assert.Equal("3", fields[1].Value);  // after
+        Assert.Equal("-7", fields.Single(f => f.Key == "deltaAbs").Value);
+        Assert.Equal("decreased", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", fields.Single(f => f.Key == "status").Value);
+    }
+
+    // --- MetricChange<T> runtime path ---
+
+    [Fact]
+    public void MetricChange_Goal_DerivesStatusInMarkdownColumn()
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMetricChangeTable(new[]
+        {
+            new MetricChange<int>("Failures", 0, 7) { Goal = Goal.Lower },
+            new MetricChange<int>("Fully raised", 40, 55) { Goal = Goal.Higher },
+            new MetricChange<int>("Changed bodies", 45, 46), // Context -> no derived status
+        });
+        var md = writer.ToString();
+
+        Assert.Contains("| Failures | 0 \u2192 7 | - | bad |", md);
+        Assert.Contains("| Fully raised | 40 \u2192 55 | - | good |", md);
+        Assert.Contains("| Changed bodies | 45 \u2192 46 | - | - |", md);
+    }
+
+    [Fact]
+    public void MetricChange_Goal_EmitsDirectionAndStatusInJsonl()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMetricChangeTable(new[]
+        {
+            new MetricChange<int>("Failures", 0, 7) { Goal = Goal.Lower },
+            new MetricChange<int>("Changed bodies", 45, 46), // Context: no direction/status
+        });
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var failures = JsonDocument.Parse(lines[0]).RootElement;
+        Assert.Equal("introduced", failures.GetProperty("direction").GetString());
+        Assert.Equal("bad", failures.GetProperty("status").GetString());
+
+        var changed = JsonDocument.Parse(lines[1]).RootElement;
+        Assert.False(changed.TryGetProperty("direction", out _));
+        Assert.False(changed.TryGetProperty("status", out _));
+    }
+
+    [Fact]
+    public void MetricChange_SameCrossing_FlipsPolarityByGoal()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        writer.WriteMetricChangeTable(new[]
+        {
+            new MetricChange<int>("Pass bugs", 0, 7) { Goal = Goal.Lower },
+            new MetricChange<int>("Fully raised", 0, 7) { Goal = Goal.Higher },
+        });
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        var bad = JsonDocument.Parse(lines[0]).RootElement;
+        var good = JsonDocument.Parse(lines[1]).RootElement;
+
+        // Same structural direction, opposite polarity.
+        Assert.Equal("introduced", bad.GetProperty("direction").GetString());
+        Assert.Equal("introduced", good.GetProperty("direction").GetString());
+        Assert.Equal("bad", bad.GetProperty("status").GetString());
+        Assert.Equal("good", good.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void MetricChange_CallerStatus_OverridesDerivedPolarity_ButDirectionStillDerived()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        // Goal says decrease->good, but the caller asserts a domain-threshold "warning".
+        writer.WriteMetricChangeTable(new[]
+        {
+            new MetricChange<int>("Failures", 10, 3, Status: GateStatus.Warning, StatusLabel: "near-threshold") { Goal = Goal.Lower },
+        });
+        var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
+
+        Assert.Equal("decreased", row.GetProperty("direction").GetString()); // still derived
+        Assert.Equal("near-threshold", row.GetProperty("status").GetString()); // caller override wins
+    }
+
+    // --- Attribute path (source generator) ---
+
+    [Fact]
+    public void Generated_MarkoutGoal_EmitsDerivedAxesInJsonl()
+    {
+        var card = new GoalAttrCard
+        {
+            Failures = new(0, 7),          // Lower: introduced/bad
+            FullyRaised = new(40, 55),     // Higher: increased/good
+            Fidelity = new(0.8730, 0.8731),// Higher, noise 0.001: unchanged/neutral
+            ChangedBodies = new(45, 46),   // no goal: no direction/status
+        };
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), GoalAttrCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        var records = sw.ToString().ReplaceLineEndings("\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => JsonDocument.Parse(l).RootElement)
+            .ToList();
+
+        var failures = records.First(e => e.GetProperty("field").GetString() == "Failures");
+        Assert.Equal("introduced", failures.GetProperty("direction").GetString());
+        Assert.Equal("bad", failures.GetProperty("status").GetString());
+
+        var raised = records.First(e => e.GetProperty("field").GetString() == "Fully raised");
+        Assert.Equal("increased", raised.GetProperty("direction").GetString());
+        Assert.Equal("good", raised.GetProperty("status").GetString());
+
+        var fidelity = records.First(e => e.GetProperty("field").GetString() == "Fidelity");
+        Assert.Equal("unchanged", fidelity.GetProperty("direction").GetString());
+        Assert.Equal("neutral", fidelity.GetProperty("status").GetString());
+
+        var changed = records.First(e => e.GetProperty("field").GetString() == "Changed bodies");
+        Assert.False(changed.TryGetProperty("direction", out _));
+        Assert.False(changed.TryGetProperty("status", out _));
+    }
+}

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -255,6 +255,35 @@ public class GoalAwareCellTests
         Assert.False(row.TryGetProperty("opus_status", out _));
     }
 
+    [Fact]
+    public void MultiSourceRow_UndefinedRatioComposite_OmitsDirectionAndStatus()
+    {
+        // A zero-denominator Percent/Fraction renders — ; its magnitude is undefined (NaN),
+        // so no direction/status is derived (rather than a synthetic 0).
+        var rows = new[]
+        {
+            new MultiSourceRow("pct",
+                new Source("opus", new Change<Percent>(new Percent(5, 0), new Percent(1, 2)),
+                    new MarkoutCellFormat { Goal = Goal.Higher })),
+            new MultiSourceRow("frac",
+                new Source("opus", new Change<Fraction>(new Fraction(3, 0), new Fraction(2, 4)),
+                    new MarkoutCellFormat { Goal = Goal.Higher })),
+        };
+
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMultiSourceTable("Metric", rows);
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            var row = JsonDocument.Parse(line).RootElement;
+            Assert.False(row.TryGetProperty("opus_direction", out _));
+            Assert.False(row.TryGetProperty("opus_status", out _));
+        }
+    }
+
     // --- Attribute path (source generator) ---
 
     [Fact]


### PR DESCRIPTION
Implements Piece 1 of #133 — goal-aware cells (0.19.0).

## What changed

Callers stop hand-coding ceiling/floor/drift status and per-row New/Regressed/Improved/Resolved words. Markout derives **two separate axes** from a numeric `Change<V>` (`Before → After`):

- **`Direction`** (structural, goal-neutral): `Unchanged` / `Increased` / `Decreased` / `Introduced` (0→+N) / `Resolved` (+N→0).
- **`GateStatus`** polarity (goal-applied) = `Direction × Goal`, `Good` / `Bad` / `Neutral`.

Both decompose as separate `direction` / `status` fields (JSONL/TSV). A caller-supplied `Status` **overrides** the derived polarity. `Goal.Context` (default) is a no-op.

## Surfaces

- **Attribute:** `[MarkoutGoal(Goal.Higher|Lower, noise?)]` on a numeric `Change<V>` property.
- **`MetricChange<T>`:** `new MetricChange<int>("Failures", 0, 7) { Goal = Goal.Lower }` — `Goal`/`Noise` are `init` properties, so the shipped 0.18.0 constructor is untouched.
- **Runtime rows:** `Goal`/`Noise` on `MarkoutCellFormat` for `Source` cells.
- **Composite cells:** `Change<Share|Percent|Fraction>` derive from a new `IGoalMagnitude` extension point (`Share`→raw `Value`, `Percent`/`Fraction`→ratio; an undefined ratio or `Segments` derives nothing).

## Derivation

| Direction | `Higher` | `Lower` |
| --- | --- | --- |
| Increased / Introduced | `good` | `bad` |
| Decreased / Resolved | `bad` | `good` |
| Unchanged (within noise) | `neutral` | `neutral` |

The same `0→7` crossing yields `direction=introduced` under both goals but `status=bad` (Lower) vs `status=good` (Higher).

## Binary compatibility

`MetricChange<T>` and `MarkoutCellFormat` shipped in 0.18.0; `Goal`/`Noise` are added as `init` properties (not constructor parameters) so their shipped constructors stay binary-stable.

## Tests

36 new tests (derivation matrix incl. negative crossings, non-finite guards, `MetricChange` runtime path, polarity flip, caller override, composite Share/Fraction/Percent, undefined-ratio and Segments omission, attribute path); **635 total green**. Docs: `grounding/markout/AGENTS.md`, `docs/design/shape-system.md`, release notes.

## Adversarial review

Two-model review (GPT-5.5 + Gemini 3.1 Pro), iterated to two cleans — record posted below.

## Deferred (per the plan on #133)

Piece 2 `[MarkoutDeltaNoun]`; Piece 3 rate-row epsilon presets; later `Goal.Target`; optional fused human `Direction` column word. Also deferred: exact typed comparison for `long`/`decimal` above 2^53 (a pre-existing property of the shared `double` comparison, unreachable by gate-metric counts).
