### PR TITLE
Goal-aware dense Markdown rendering (#135, 0.20.0)

### DIFF
--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -79,7 +79,8 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
   noise, `[MarkoutGoal(Goal.Higher, 0.001)]`, treats sub-threshold movement as `unchanged`. `Goal.Context`
   (default) derives nothing. Composite `Change<Share|Percent|Fraction>` also derive `direction`/`status`
   from a single comparable magnitude (`Share` → raw `Value`; `Percent`/`Fraction` → their ratio);
-  `Change<Segments>` has no single magnitude, so it derives nothing.
+  `Change<Segments>` has no single magnitude, so it derives nothing. In dense Markdown the polarity word
+  renders inline, merged with any delta suffix into one group: `0 → 7 (bad)`, `98555 → 61190 (−38%, good)`.
 - `Fraction(count, total)` → `24/24`; `Share(value, whole)` → `5056 (24%)`
   (`[MarkoutUnit("s")]` → `103s (93%)`); `Percent(part, whole)` → `93%`;
   `Segments(new Segment(label, value), ...)` → `21/171/236` (labels become column names).
@@ -98,12 +99,15 @@ flat typed JSONL/TSV — with no imperative writer calls:
 
 - `List<MetricChange<T>>` — a gated scalar metric per row. `MetricChange<T>(Name, Before, After,
   Target? = null, TargetLabel? = null, Status = GateStatus.Unknown, StatusLabel? = null)` where
-  `T : struct`. Markdown = `Metric | Change | Target | Status`; JSONL = flat `before`/`after`/optional
-  `target`/`target_label`/`status`. `Status` is caller-supplied. Set `{ Goal = Goal.Higher|Lower }`
-  (init property; optionally `Noise`) to derive the `direction`/`status` axes from `Before → After` —
-  the derived polarity fills the `Status` column and a `direction` field, and a caller-supplied `Status`
-  still overrides it. `T` must be a numeric scalar (int/long/double/decimal/...); a composite `T` (e.g.
-  `Segments`) is a compile error (`MARKOUT005`).
+  `T : struct`. Set `{ Goal = Goal.Higher|Lower }` (init property; optionally `Noise`) to derive the
+  `direction`/`status` axes from `Before → After`; a caller-supplied `Status` overrides the derived
+  polarity. **Dense Markdown (default):** `Metric | Change | Target` with the status word inlined
+  (`0 → 7 (bad)` — caller `StatusLabel` wins over the slug) and a goal marker on the label
+  (`Failures (-)` / `Fully raised (+)`); the `Status` column is dropped. Set
+  `MarkoutWriterOptions.InlineGoalStatus = false` for the legacy `Metric | Change | Target | Status`.
+  JSONL/TSV are unaffected: flat `before`/`after`/optional `target`/`target_label`/`direction`/`status`.
+  `T` must be a numeric scalar (int/long/double/decimal/...); a composite `T` (e.g. `Segments`) is a
+  compile error (`MARKOUT005`).
 - `[MarkoutSection(Name = "...", IncludeSectionInStructuredRows = true)]` on a `List<MetricChange<T>>`
   or `List<MultiSourceRow>` section prepends a leading `section` column (the section name) to TSV/JSONL
   rows — for multiplexing several sectioned card shapes into one structured stream. Markdown is unchanged.

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -134,7 +134,7 @@ internal static class EmitHelpers
     {
         // Composite cell in a table column renders its dense form (no per-column decomposition).
         if (prop.Kind == PropertyKind.CompositeCell)
-            return $"global::Markout.MarkoutCell.ToInlineString({propAccess}, {DeltaLiteral(prop)}, {UnitLiteral(prop)})";
+            return $"global::Markout.MarkoutCell.ToInlineString({propAccess}, new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)} }})";
 
         if (prop.IsNullableValueType)
         {

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -15,7 +15,7 @@ internal static class EmitHelpers
 
         // Composite cell: render its dense, human-readable form
         if (prop.Kind == PropertyKind.CompositeCell)
-            return $"global::Markout.MarkoutCell.ToInlineString({access}, {DeltaLiteral(prop)}, {UnitLiteral(prop)})";
+            return $"global::Markout.MarkoutCell.ToInlineString({access}, {CompositeCellFormatLiteral(prop)})";
 
         // Value formatter takes highest priority
         if (prop.ValueFormatterTypeName != null)
@@ -134,7 +134,7 @@ internal static class EmitHelpers
     {
         // Composite cell in a table column renders its dense form (no per-column decomposition).
         if (prop.Kind == PropertyKind.CompositeCell)
-            return $"global::Markout.MarkoutCell.ToInlineString({propAccess}, new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)} }})";
+            return $"global::Markout.MarkoutCell.ToInlineString({propAccess}, {CompositeCellFormatLiteral(prop)})";
 
         if (prop.IsNullableValueType)
         {
@@ -376,6 +376,14 @@ internal static class EmitHelpers
             return "global::System.Double.NegativeInfinity";
         return noise.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
     }
+
+    /// <summary>
+    /// Emits the full <c>MarkoutCellFormat</c> initializer for a composite cell property — delta and unit
+    /// as constructor args, goal and noise as object-initializer members. The single source of truth for
+    /// every composite-cell rendering path (dense field layouts, table columns, composite-card rows).
+    /// </summary>
+    public static string CompositeCellFormatLiteral(PropertyMetadata prop)
+        => $"new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)} }}";
 
     public static bool IsScalarKind(PropertyKind kind)
     {

--- a/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/FieldEmitter.cs
@@ -348,7 +348,7 @@ internal static class FieldEmitter
         string rowsVar,
         string indent)
     {
-        var format = $"new global::Markout.MarkoutCellFormat({EmitHelpers.DeltaLiteral(prop)}, {EmitHelpers.UnitLiteral(prop)}) {{ Goal = {EmitHelpers.GoalLiteral(prop)}, Noise = {EmitHelpers.NoiseLiteral(prop)} }}";
+        var format = EmitHelpers.CompositeCellFormatLiteral(prop);
 
         string RowAdd(string cellExpr) =>
             $"{rowsVar}.Add(new global::Markout.MarkoutCompositeRow(\"{EmitHelpers.EscapeString(prop.DisplayName)}\", {cellExpr}, {format}));";

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -21,6 +21,12 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             (Before as IMarkoutCell)?.FormatInline(writer, format);
             writer.Write(CellText.Arrow);
             (After as IMarkoutCell)?.FormatInline(writer, format);
+
+            // Composite cells (e.g. Change<Share>) append the goal status word densely, deriving from
+            // the shape's comparable magnitude (matching the structured direction/status).
+            if (format.Goal != Goal.Context && Before is IGoalMagnitude beforeMag && After is IGoalMagnitude afterMag &&
+                GoalDerivation.TryDerive(beforeMag.GoalMagnitude, afterMag.GoalMagnitude, format.Goal, format.Noise, out _, out var compositeStatus))
+                WriteParenGroup(writer, null, GateStatusText.Slug(compositeStatus));
             return;
         }
 
@@ -28,11 +34,28 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         writer.Write(CellText.Arrow);
         writer.Write(CellText.Scalar(After));
 
-        if (format.Delta == Delta.None)
-            return;
+        // Merge an optional derived-change suffix and an optional goal status word into a single
+        // parenthetical: "(+40%)", "(bad)", or "(+40%, bad)".
+        var deltaPart = format.Delta == Delta.None ? null : DeltaSuffix(format.Delta);
+        string? statusPart = null;
+        if (format.Goal != Goal.Context &&
+            GoalDerivation.TryDerive(Before, After, format.Goal, format.Noise, out _, out var status))
+            statusPart = GateStatusText.Slug(status);
 
+        WriteParenGroup(writer, deltaPart, statusPart);
+    }
+
+    private static void WriteParenGroup(TextWriter writer, string? first, string? second)
+    {
+        if (first is null && second is null)
+            return;
         writer.Write(" (");
-        writer.Write(DeltaSuffix(format.Delta));
+        if (first is not null)
+            writer.Write(first);
+        if (first is not null && second is not null)
+            writer.Write(", ");
+        if (second is not null)
+            writer.Write(second);
         writer.Write(')');
     }
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.19.0</Version>
-    <PackageReleaseNotes>Goal-aware cells: [MarkoutGoal(Goal.Higher|Lower)] on a numeric Change&lt;T&gt; property (and a Goal on MetricChange&lt;T&gt; / MarkoutCellFormat for runtime rows) makes Markout derive a structural "direction" (increased/decreased/introduced/resolved/unchanged) and a goal-applied polarity "status" (good/bad/neutral), replacing hand-coded ceiling/floor/drift helpers. The two axes decompose as separate direction/status fields; a caller-supplied Status still overrides the derived polarity. An optional noise tolerance treats sub-threshold movement as unchanged. Goal.Context (default) leaves behavior unchanged.</PackageReleaseNotes>
+    <Version>0.20.0</Version>
+    <PackageReleaseNotes>Goal-aware dense Markdown rendering: a MetricChange&lt;T&gt; table now inlines the status word into the Change cell (0 → 7 (bad)), appends a goal marker to the metric label ((-) for Goal.Lower, (+) for Goal.Higher), and drops the separate Status column; a caller StatusLabel stays the inline word. [MarkoutGoal] Change&lt;T&gt; properties (scalar and composite Share/Percent/Fraction) render the same inline word, merged with any [MarkoutDelta] suffix into one group (0 → 7 (+40%, bad)). Set MarkoutWriterOptions.InlineGoalStatus = false to keep the legacy Metric | Change | Target | Status layout. Structured (TSV/JSONL) output is unchanged (separate direction/status fields).</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -21,6 +21,20 @@ public static class MarkoutCell
         cell.FormatInline(sw, new MarkoutCellFormat(delta, unit));
         return sw.ToString();
     }
+
+    /// <summary>
+    /// Renders a cell's dense inline form using a full <see cref="MarkoutCellFormat"/> (carrying
+    /// <see cref="MarkoutCellFormat.Goal"/>/<see cref="MarkoutCellFormat.Noise"/> in addition to delta/unit),
+    /// so goal-aware status words render in generated table columns as well as composite-card rows.
+    /// </summary>
+    public static string ToInlineString(IMarkoutCell? cell, in MarkoutCellFormat format)
+    {
+        if (cell is null)
+            return string.Empty;
+        var sw = new StringWriter();
+        cell.FormatInline(sw, format);
+        return sw.ToString();
+    }
 }
 
 /// <summary>

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -759,11 +759,43 @@ public class MarkoutWriter
         if (_formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true })
             return WriteDecomposedMetricChangeTable(rows, structuredSection);
 
+        if (_options.InlineGoalStatus)
+        {
+            var denseRows = new List<string[]>(rows.Count);
+            foreach (var metric in rows)
+                denseRows.Add([MetricLabelText(metric), DenseChangeText(metric), TargetText(metric)]);
+
+            return WriteTable(["Metric", "Change", "Target"], denseRows);
+        }
+
         var outRows = new List<string[]>(rows.Count);
         foreach (var metric in rows)
             outRows.Add([metric.Name, ChangeText(metric), TargetText(metric), StatusText(metric)]);
 
         return WriteTable(["Metric", "Change", "Target", "Status"], outRows);
+    }
+
+    /// <summary>The metric label with a goal marker appended: <c>(-)</c> for <see cref="Goal.Lower"/>,
+    /// <c>(+)</c> for <see cref="Goal.Higher"/>, nothing for <see cref="Goal.Context"/>.</summary>
+    private static string MetricLabelText<T>(in MetricChange<T> metric) where T : struct
+    {
+        var marker = metric.Goal switch
+        {
+            Goal.Lower => " (-)",
+            Goal.Higher => " (+)",
+            _ => ""
+        };
+        return metric.Name + marker;
+    }
+
+    /// <summary>The Change cell with the status word inlined: <c>0 → 7 (bad)</c>. The word is the
+    /// caller <see cref="MetricChange{T}.StatusLabel"/>, else the caller/derived polarity slug; when
+    /// there is no status (an ungated, un-annotated row) only the bare change renders.</summary>
+    private static string DenseChangeText<T>(in MetricChange<T> metric) where T : struct
+    {
+        var change = MarkoutCell.ToInlineString(new Change<T>(metric.Before, metric.After));
+        var (_, status) = Resolve(metric);
+        return status is null ? change : change + " (" + status + ")";
     }
 
     private bool WriteDecomposedMetricChangeTable<T>(IReadOnlyList<MetricChange<T>> rows, string? structuredSection) where T : struct

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -24,6 +24,7 @@ public class MarkoutWriterOptions
     private bool _omitEmptyJsonFields;
     private IReadOnlySet<int>? _jsonIdentityColumnIndices;
     private int _headingLevelOffset;
+    private bool _inlineGoalStatus = true;
 
     /// <summary>Creates a new, writable options instance with default values.</summary>
     public MarkoutWriterOptions()
@@ -49,6 +50,7 @@ public class MarkoutWriterOptions
         _omitEmptyJsonFields = source._omitEmptyJsonFields;
         _jsonIdentityColumnIndices = source._jsonIdentityColumnIndices;
         _headingLevelOffset = source._headingLevelOffset;
+        _inlineGoalStatus = source._inlineGoalStatus;
     }
 
     /// <summary>
@@ -73,6 +75,24 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _includeBadges = value;
+        }
+    }
+
+    /// <summary>
+    /// Whether a <see cref="MetricChange{T}"/> Markdown table renders goal state <em>densely</em>:
+    /// the derived (or caller-supplied) status word is inlined into the Change cell
+    /// (<c>0 → 7 (bad)</c>), a goal marker is appended to the metric label (<c>Failures (-)</c> for
+    /// <see cref="Goal.Lower"/>, <c>(+)</c> for <see cref="Goal.Higher"/>), and the separate
+    /// <c>Status</c> column is dropped. Default is <c>true</c>. Set <c>false</c> to keep the legacy
+    /// <c>Metric | Change | Target | Status</c> layout. Structured (TSV/JSONL) output is unaffected.
+    /// </summary>
+    public bool InlineGoalStatus
+    {
+        get => _inlineGoalStatus;
+        set
+        {
+            ThrowIfReadOnly();
+            _inlineGoalStatus = value;
         }
     }
 

--- a/tests/Markout.Tests/GeneratedMetricChangeTests.cs
+++ b/tests/Markout.Tests/GeneratedMetricChangeTests.cs
@@ -34,9 +34,9 @@ public class GeneratedMetricChangeTests
         var md = MarkoutSerializer.Serialize(Card(), GeneratedIlDiffCardContext.Default);
 
         Assert.Contains("## Baseline comparison", md);
-        Assert.Contains("| Metric | Change | Target | Status |", md);
-        Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", md);
-        Assert.Contains("| Changed bodies | 45 \u2192 46 | - | drift |", md);
+        Assert.Contains("| Metric | Change | Target |", md);
+        Assert.Contains("| Failures | 0 \u2192 7 (regression) | allowed failures: 0 |", md);
+        Assert.Contains("| Changed bodies | 45 \u2192 46 (drift) | - |", md);
     }
 
     [Fact]
@@ -84,8 +84,8 @@ public class GeneratedMetricChangeArrayTests
         };
         var md = MarkoutSerializer.Serialize(card, GeneratedArrayCardContext.Default);
 
-        Assert.Contains("| Metric | Change | Target | Status |", md);
-        Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", md);
+        Assert.Contains("| Metric | Change | Target |", md);
+        Assert.Contains("| Failures | 0 \u2192 7 (regression) | allowed failures: 0 |", md);
     }
 }
 

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -36,6 +36,62 @@ public class GoalAwareCellTests
         return fields;
     }
 
+    private static string Inline(IMarkoutCell cell, MarkoutCellFormat format)
+    {
+        var sw = new StringWriter();
+        cell.FormatInline(sw, format);
+        return sw.ToString();
+    }
+
+    // --- Dense inline rendering (Change<V>.FormatInline) ---
+
+    [Fact]
+    public void Change_FormatInline_AppendsGoalStatusWord()
+    {
+        Assert.Equal("10 \u2192 3 (good)", Inline(new Change<long>(10, 3), new MarkoutCellFormat { Goal = Goal.Lower }));
+        Assert.Equal("10 \u2192 3 (bad)", Inline(new Change<long>(10, 3), new MarkoutCellFormat { Goal = Goal.Higher }));
+        Assert.Equal("5 \u2192 5 (neutral)", Inline(new Change<long>(5, 5), new MarkoutCellFormat { Goal = Goal.Higher }));
+    }
+
+    [Fact]
+    public void Change_FormatInline_MergesDeltaAndGoalIntoSingleParen()
+    {
+        Assert.Equal("10 \u2192 3 (-7, good)", Inline(new Change<long>(10, 3), new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower }));
+    }
+
+    [Fact]
+    public void Change_FormatInline_ContextGoal_LeavesRenderingUnchanged()
+    {
+        Assert.Equal("10 \u2192 3", Inline(new Change<long>(10, 3), new MarkoutCellFormat { Goal = Goal.Context }));
+        Assert.Equal("10 \u2192 3 (-7)", Inline(new Change<long>(10, 3), new MarkoutCellFormat(Delta.Absolute)));
+    }
+
+    [Fact]
+    public void Change_FormatInline_Composite_AppendsGoalStatusWord()
+    {
+        // Share magnitude = raw Value: 5056 -> 3129 decreased, Lower -> good.
+        var s = Inline(new Change<Share>(new Share(5056, 21067), new Share(3129, 13037)),
+            new MarkoutCellFormat { Goal = Goal.Lower });
+        Assert.StartsWith("5056", s);
+        Assert.EndsWith(" (good)", s);
+    }
+
+    [Fact]
+    public void MultiSourceRow_CompositeCell_RendersGoalWordInPivotedMarkdown()
+    {
+        var rows = new[]
+        {
+            new MultiSourceRow("output tok",
+                new Source("opus", new Change<Share>(new Share(5056, 21067), new Share(3129, 13037)),
+                    new MarkoutCellFormat { Goal = Goal.Lower })),
+        };
+        var writer = new MarkoutWriter(new MarkdownFormatter());
+        writer.WriteMultiSourceTable("Metric", rows);
+        var md = writer.ToString();
+
+        Assert.Contains("(good)", md);
+    }
+
     // --- Direct-cell derivation matrix (structural direction × goal-applied polarity) ---
 
     [Theory]
@@ -102,20 +158,38 @@ public class GoalAwareCellTests
     // --- MetricChange<T> runtime path ---
 
     [Fact]
-    public void MetricChange_Goal_DerivesStatusInMarkdownColumn()
+    public void MetricChange_Goal_RendersDenseMarkdown_MarkerAndInlineStatus()
     {
         var writer = new MarkoutWriter(new MarkdownFormatter());
         writer.WriteMetricChangeTable(new[]
         {
             new MetricChange<int>("Failures", 0, 7) { Goal = Goal.Lower },
             new MetricChange<int>("Fully raised", 40, 55) { Goal = Goal.Higher },
-            new MetricChange<int>("Changed bodies", 45, 46), // Context -> no derived status
+            new MetricChange<int>("Changed bodies", 45, 46), // Context -> no marker, no status
+        });
+        var md = writer.ToString();
+
+        // Goal marker on the label; derived polarity inline in the Change cell; no Status column.
+        Assert.Contains("| Metric | Change | Target |", md);
+        Assert.Contains("| Failures (-) | 0 \u2192 7 (bad) | - |", md);
+        Assert.Contains("| Fully raised (+) | 40 \u2192 55 (good) | - |", md);
+        Assert.Contains("| Changed bodies | 45 \u2192 46 | - |", md);
+    }
+
+    [Fact]
+    public void MetricChange_Goal_InlineDisabled_DerivedStatusInLegacyColumn()
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter(),
+            new MarkoutWriterOptions { InlineGoalStatus = false });
+        writer.WriteMetricChangeTable(new[]
+        {
+            new MetricChange<int>("Failures", 0, 7) { Goal = Goal.Lower },
+            new MetricChange<int>("Fully raised", 40, 55) { Goal = Goal.Higher },
         });
         var md = writer.ToString();
 
         Assert.Contains("| Failures | 0 \u2192 7 | - | bad |", md);
         Assert.Contains("| Fully raised | 40 \u2192 55 | - | good |", md);
-        Assert.Contains("| Changed bodies | 45 \u2192 46 | - | - |", md);
     }
 
     [Fact]

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -429,4 +429,19 @@ public class GoalAwareCellTests
 
         Assert.Contains("0 \u2192 7 (bad)", md);
     }
+
+    [Fact]
+    public void Generated_MarkoutGoal_CardProperty_RendersInlineWord()
+    {
+        // The composite-card (field-layout) path also renders the dense goal word in Markdown.
+        var card = new GoalAttrCard
+        {
+            Failures = new(0, 7),       // Lower: introduced -> bad
+            FullyRaised = new(40, 55),  // Higher: increased -> good
+        };
+        var md = MarkoutSerializer.Serialize(card, GoalAttrCardContext.Default);
+
+        Assert.Contains("0 \u2192 7 (bad)", md);
+        Assert.Contains("40 \u2192 55 (good)", md);
+    }
 }

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -27,6 +27,29 @@ public partial class GoalAttrCardContext : MarkoutSerializerContext
 {
 }
 
+// Table-column path: a [MarkoutGoal] Change<T> as a column of a generated element table.
+public class GoalTableRow
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutGoal(Goal.Lower)]
+    public Change<int> Failures { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class GoalTableCard
+{
+    [MarkoutIgnore] public string Title => "Goal table";
+
+    [MarkoutSection(Name = "Rows")]
+    public List<GoalTableRow> Rows { get; set; } = new();
+}
+
+[MarkoutContext(typeof(GoalTableCard))]
+public partial class GoalTableCardContext : MarkoutSerializerContext
+{
+}
+
 public class GoalAwareCellTests
 {
     private static List<MarkoutField> Decompose(IMarkoutCell cell, MarkoutCellFormat format)
@@ -394,5 +417,16 @@ public class GoalAwareCellTests
         var changed = records.First(e => e.GetProperty("field").GetString() == "Changed bodies");
         Assert.False(changed.TryGetProperty("direction", out _));
         Assert.False(changed.TryGetProperty("status", out _));
+    }
+
+    [Fact]
+    public void Generated_MarkoutGoal_TableColumn_RendersInlineWord()
+    {
+        // A [MarkoutGoal] Change<T> rendered as a generated element-table column must also carry
+        // the dense goal word (the table-cell path, not just the composite-card path).
+        var card = new GoalTableCard { Rows = [new GoalTableRow { Name = "raise", Failures = new(0, 7) }] };
+        var md = MarkoutSerializer.Serialize(card, GoalTableCardContext.Default);
+
+        Assert.Contains("0 \u2192 7 (bad)", md);
     }
 }

--- a/tests/Markout.Tests/MetricChangeTableTests.cs
+++ b/tests/Markout.Tests/MetricChangeTableTests.cs
@@ -19,6 +19,22 @@ public class MetricChangeTableTests
         writer.WriteMetricChangeTable(Rows());
         var output = writer.ToString();
 
+        // Dense default: Status column dropped; caller StatusLabel inlined into the Change cell.
+        Assert.Contains("| Metric | Change | Target |", output);
+        Assert.DoesNotContain("| Metric | Change | Target | Status |", output);
+        Assert.Contains("| Failures | 0 \u2192 7 (regression) | allowed failures: 0 |", output);
+        Assert.Contains("| Changed bodies | 45 \u2192 46 (drift) | - |", output);
+        Assert.Contains("| Compared bodies | 78 \u2192 78 | - |", output);
+    }
+
+    [Fact]
+    public void Markdown_InlineGoalStatusDisabled_KeepsLegacyStatusColumn()
+    {
+        var writer = new MarkoutWriter(new MarkdownFormatter(),
+            new MarkoutWriterOptions { InlineGoalStatus = false });
+        writer.WriteMetricChangeTable(Rows());
+        var output = writer.ToString();
+
         Assert.Contains("| Metric | Change | Target | Status |", output);
         Assert.Contains("| Failures | 0 \u2192 7 | allowed failures: 0 | regression |", output);
         Assert.Contains("| Changed bodies | 45 \u2192 46 | - | drift |", output);


### PR DESCRIPTION
Implements #135 — goal-aware **dense Markdown rendering** (0.20.0). The human-facing complement to the goal-aware cells from #133. Markdown only; structured (TSV/JSONL) output is unchanged.

## What changed

- **`Change<V>.FormatInline`** appends the goal status word when `Goal != Context`, merged with any `[MarkoutDelta]` suffix into a **single** paren group: `0 → 7 (bad)`, `98555 → 61190 (−38%, good)`. Scalar and composite (`Share`/`Percent`/`Fraction` via `IGoalMagnitude`) both render it — the one seam serving `[MarkoutGoal]` `Change<T>` properties **and** `MultiSourceRow` `Source` cells.
- **`MetricChange<T>` Markdown dense shape (default):** drops the `Status` column, inlines the status word into the Change cell (caller `StatusLabel` wins over the polarity slug), and appends a goal marker to the metric label — `(-)` for `Goal.Lower`, `(+)` for `Goal.Higher`.
- **`MarkoutWriterOptions.InlineGoalStatus`** (default `true`); set `false` to restore the legacy `Metric | Change | Target | Status` layout.

## Proving shape — IL Diff baseline table

```md
| Metric | Change | Target |
| ------ | ------ | ------ |
| Failures (-) | 0 → 7 (bad) | max failures: 0 |
| Self-diff empty (+) | 79 → 78 (bad) | minimum self-diff empty: 79 |
| Changed bodies | 45 → 45 | - |
```

## Design (endorsed on #135)

Matches the confirmed defaults: goal set = opt-in; drop the Status column when polarity is inline; caller `StatusLabel` stays the inline word (`0 → 7 (regression)`); `(-)`/`(+)` markers; single-paren delta+status merge; structured output untouched. ANSI (`Markout.Ansi.Spectre`) can later color from the same `GateStatus`/`Goal` without changing the Markdown contract.

## Tests

Existing MetricChange Markdown tests updated to the dense shape, plus legacy-toggle tests, `FormatInline` delta+goal single-paren, composite inline word, and a MultiSource pivoted-Markdown test. **642 total green** (+ MarkdownTable.Tests 236, Markout.Templates.Tests 59). Version 0.20.0 + release notes; `grounding/markout/AGENTS.md` updated.

Adversarial review (GPT-5.5 + Gemini 3.1 Pro) to two cleans — record to follow.
