### PR TITLE
Goal-aware annotations: Segments sum magnitude + Delta.Multiple + [MarkoutDeltaNoun] (#137, 0.21.0)

### DIFF
--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -155,7 +155,7 @@ public readonly record struct Slice(string Category, int Count);
 public readonly record struct Breakdown(string Label, Slice[] Slices);
 
 // Composite cells — data-only cells that render densely and decompose into typed columns.
-// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit]/[MarkoutGoal] configure derivation/format.
+// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit]/[MarkoutGoal]/[MarkoutDeltaNoun] configure derivation/format.
 public readonly record struct Change<V>(V Before, V After);        // before → after (+ derived delta)
 public readonly record struct Fraction(double Count, double Total); // 24/24
 public readonly record struct Share(double Value, double Whole);    // 5056 (24%)
@@ -169,7 +169,9 @@ public readonly record struct Segments(params Segment[] Parts);     // 21/171/23
 // Change<Share|Percent|Fraction|Segments> derive from IGoalMagnitude (Share→Value, Percent/Fraction→ratio, Segments→sum of parts).
 public enum Goal { Context, Higher, Lower }                         // which direction is "good"
 public enum Direction { Unchanged, Increased, Decreased, Introduced, Resolved }; // structural, goal-neutral
-public interface IGoalMagnitude { double GoalMagnitude { get; } }   // composite cell's comparable magnitude
+public enum Delta { None, Percent, Absolute, Multiple }             // derived-change suffix mode (Multiple: 3× fewer/more)
+public interface IGoalMagnitude { double GoalMagnitude { get; } }   // composite cell's comparable magnitude (goal)
+public interface IDeltaCountable { double DeltaCount { get; } }     // composite cell's count for [MarkoutDeltaNoun] (Fraction→count, Share→value)
 
 // Card shapes — list-shapes that render as multi-format cards (Markdown table + typed JSONL/TSV).
 public readonly record struct MetricChange<T>(string Name, T Before, T After,

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -166,7 +166,7 @@ public readonly record struct Segments(params Segment[] Parts);     // 21/171/23
 // Goal-aware derivation — [MarkoutGoal] (or a Goal on MetricChange<T>/MarkoutCellFormat) derives a
 // structural Direction and a goal-applied GateStatus polarity from a numeric Change<V>, as separate
 // direction/status fields. A caller-supplied Status overrides the derived polarity. Composite
-// Change<Share|Percent|Fraction> derive from IGoalMagnitude (Share→Value, Percent/Fraction→ratio).
+// Change<Share|Percent|Fraction|Segments> derive from IGoalMagnitude (Share→Value, Percent/Fraction→ratio, Segments→sum of parts).
 public enum Goal { Context, Higher, Lower }                         // which direction is "good"
 public enum Direction { Unchanged, Increased, Decreased, Introduced, Resolved }; // structural, goal-neutral
 public interface IGoalMagnitude { double GoalMagnitude { get; } }   // composite cell's comparable magnitude

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -71,7 +71,11 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
 
 - `Change<V>` — a `before → after` change (NOT `Comparison`, which collides with `System.Comparison<T>`).
   `[MarkoutDelta(Delta.Percent)]` on a numeric `Change<V>` appends the signed change, e.g.
-  `98555 → 61190 (−38%)`; `Delta.Absolute` appends the signed difference.
+  `98555 → 61190 (−38%)`; `Delta.Absolute` appends the signed difference; `Delta.Multiple` appends a
+  multiplicative factor with a direction word, e.g. `15 → 5 (3× fewer)` / `5 → 15 (3× more)` (a zero
+  endpoint renders `—`). `[MarkoutDeltaNoun("solved")]` renders a caller noun on the signed delta —
+  `4/6 → 6/6 (+2 solved)` (sibling of `[MarkoutUnit]`; composites use `IDeltaCountable`: `Fraction`→count,
+  `Share`→value; Markdown-only).
   `[MarkoutGoal(Goal.Higher)]` / `[MarkoutGoal(Goal.Lower)]` on a numeric `Change<V>` makes Markout
   derive two decomposed fields — a structural `direction`
   (`increased`/`decreased`/`introduced` (0→N)/`resolved` (N→0)/`unchanged`) and a goal-applied polarity

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -78,8 +78,8 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
   `status` (`good`/`bad`/`neutral`) — instead of the caller hand-coding ceiling/floor/drift. Optional
   noise, `[MarkoutGoal(Goal.Higher, 0.001)]`, treats sub-threshold movement as `unchanged`. `Goal.Context`
   (default) derives nothing. Composite `Change<Share|Percent|Fraction>` also derive `direction`/`status`
-  from a single comparable magnitude (`Share` → raw `Value`; `Percent`/`Fraction` → their ratio);
-  `Change<Segments>` has no single magnitude, so it derives nothing. In dense Markdown the polarity word
+  from a single comparable magnitude (`Share` → raw `Value`; `Percent`/`Fraction` → their ratio;
+  `Segments` → the **sum** of its parts' values, i.e. the breakdown total). In dense Markdown the polarity word
   renders inline, merged with any delta suffix into one group: `0 → 7 (bad)`, `98555 → 61190 (−38%, good)`.
 - `Fraction(count, total)` → `24/24`; `Share(value, whole)` → `5056 (24%)`
   (`[MarkoutUnit("s")]` → `103s (93%)`); `Percent(part, whole)` → `93%`;

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -349,6 +349,7 @@ internal static class EmitHelpers
     {
         MarkoutDeltaKind.Percent => "global::Markout.Delta.Percent",
         MarkoutDeltaKind.Absolute => "global::Markout.Delta.Absolute",
+        MarkoutDeltaKind.Multiple => "global::Markout.Delta.Multiple",
         _ => "global::Markout.Delta.None"
     };
 
@@ -379,11 +380,15 @@ internal static class EmitHelpers
 
     /// <summary>
     /// Emits the full <c>MarkoutCellFormat</c> initializer for a composite cell property — delta and unit
-    /// as constructor args, goal and noise as object-initializer members. The single source of truth for
-    /// every composite-cell rendering path (dense field layouts, table columns, composite-card rows).
+    /// as constructor args, goal/noise/delta-noun as object-initializer members. The single source of truth
+    /// for every composite-cell rendering path (dense field layouts, table columns, composite-card rows).
     /// </summary>
     public static string CompositeCellFormatLiteral(PropertyMetadata prop)
-        => $"new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)} }}";
+        => $"new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)}, DeltaNoun = {DeltaNounLiteral(prop)} }}";
+
+    /// <summary>Emits the delta-noun string literal (or <c>null</c>) for a composite cell property.</summary>
+    public static string DeltaNounLiteral(PropertyMetadata prop)
+        => prop.DeltaNoun == null ? "null" : $"\"{EscapeString(prop.DeltaNoun)}\"";
 
     public static bool IsScalarKind(PropertyKind kind)
     {

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -185,6 +185,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? Unit { get; }
     public MarkoutGoalKind Goal { get; }
     public double Noise { get; }
+    public string? DeltaNoun { get; }
     public bool IsReferenceTypeCell { get; }
     public string? MultiSourceLabelHeader { get; }
 
@@ -240,7 +241,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         bool isReferenceTypeCell = false,
         string? multiSourceLabelHeader = null,
         MarkoutGoalKind goal = MarkoutGoalKind.Context,
-        double noise = 0)
+        double noise = 0,
+        string? deltaNoun = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -292,6 +294,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         Unit = unit;
         Goal = goal;
         Noise = noise;
+        DeltaNoun = deltaNoun;
         IsReferenceTypeCell = isReferenceTypeCell;
         MultiSourceLabelHeader = multiSourceLabelHeader;
     }
@@ -349,6 +352,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                Unit == other.Unit &&
                Goal == other.Goal &&
                Noise.Equals(other.Noise) &&
+               DeltaNoun == other.DeltaNoun &&
                IsReferenceTypeCell == other.IsReferenceTypeCell &&
                MultiSourceLabelHeader == other.MultiSourceLabelHeader &&
                SequenceEqual(ElementProperties, other.ElementProperties);
@@ -391,6 +395,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (Unit?.GetHashCode() ?? 0);
             hash = hash * 397 ^ (int)Goal;
             hash = hash * 397 ^ Noise.GetHashCode();
+            hash = hash * 397 ^ (DeltaNoun?.GetHashCode() ?? 0);
             hash = hash * 397 ^ IsReferenceTypeCell.GetHashCode();
             hash = hash * 397 ^ (MultiSourceLabelHeader?.GetHashCode() ?? 0);
             return hash;
@@ -506,7 +511,8 @@ internal enum MarkoutDeltaKind
 {
     None = 0,
     Percent = 1,
-    Absolute = 2
+    Absolute = 2,
+    Multiple = 3
 }
 
 /// <summary>

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -35,6 +35,7 @@ internal static class TypeParser
     private const string MarkoutDeltaAttribute = "Markout.MarkoutDeltaAttribute";
     private const string MarkoutUnitAttribute = "Markout.MarkoutUnitAttribute";
     private const string MarkoutGoalAttribute = "Markout.MarkoutGoalAttribute";
+    private const string MarkoutDeltaNounAttribute = "Markout.MarkoutDeltaNounAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -483,6 +484,16 @@ internal static class TypeParser
             }
         }
 
+        // Parse [MarkoutDeltaNoun] — caller noun rendered on the delta of a numeric Change<> cell
+        string? deltaNoun = null;
+        var deltaNounAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutDeltaNounAttribute);
+        if (deltaNounAttr != null && deltaNounAttr.ConstructorArguments.Length > 0 &&
+            deltaNounAttr.ConstructorArguments[0].Value is string deltaNounValue)
+        {
+            deltaNoun = deltaNounValue;
+        }
+
         // Parse [MarkoutLabelHeader] — label/identity column header for a List<MultiSourceRow> card
         string? multiSourceLabelHeader = null;
         var labelHeaderAttr = prop.GetAttributes()
@@ -576,7 +587,8 @@ internal static class TypeParser
             isReferenceTypeCell,
             multiSourceLabelHeader,
             goal,
-            noise);
+            noise,
+            deltaNoun);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutDeltaNounAttribute.cs
+++ b/src/Markout/Attributes/MarkoutDeltaNounAttribute.cs
@@ -1,0 +1,17 @@
+namespace Markout;
+
+/// <summary>
+/// Declares a caller noun rendered on the signed absolute delta of a numeric <see cref="Change{V}"/>
+/// in dense Markdown — the sibling of <see cref="MarkoutUnitAttribute"/> (which suffixes the value).
+/// <c>[MarkoutDeltaNoun("solved")]</c> turns <c>4/6 → 6/6</c> into <c>4/6 → 6/6 (+2 solved)</c>. The
+/// caller owns the word; Markout renders it on the derived delta. Markdown-only; structured
+/// (TSV/JSONL) output is unaffected. For composites, the count comes from <see cref="IDeltaCountable"/>
+/// (<see cref="Fraction"/> → count, <see cref="Share"/> → value).
+/// </summary>
+/// <param name="noun">The noun rendered after the signed delta (e.g. <c>"solved"</c>, <c>"methods"</c>).</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutDeltaNounAttribute(string noun) : Attribute
+{
+    /// <summary>The noun rendered on the delta.</summary>
+    public string Noun { get; } = noun;
+}

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -26,7 +26,10 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             // word (from IGoalMagnitude), merged into one parenthetical.
             string? compositeFirst = null;
             if (format.DeltaNoun is not null && Before is IDeltaCountable beforeCount && After is IDeltaCountable afterCount)
-                compositeFirst = CellText.SignedNumber(afterCount.DeltaCount - beforeCount.DeltaCount) + " " + format.DeltaNoun;
+            {
+                var nounDelta = CellText.SignedNumber(afterCount.DeltaCount - beforeCount.DeltaCount);
+                compositeFirst = nounDelta == CellText.Placeholder ? CellText.Placeholder : nounDelta + " " + format.DeltaNoun;
+            }
             string? compositeStatus = null;
             if (format.Goal != Goal.Context && Before is IGoalMagnitude beforeMag && After is IGoalMagnitude afterMag &&
                 GoalDerivation.TryDerive(beforeMag.GoalMagnitude, afterMag.GoalMagnitude, format.Goal, format.Noise, out _, out var compositeGate))
@@ -56,9 +59,9 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
 
     private string NounText(string noun)
     {
-        if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
-            return CellText.Placeholder;
-        return CellText.SignedNumber(after - before) + " " + noun;
+        // Reuse the exact (decimal) delta path so large long/decimal changes don't lose precision.
+        var delta = CellText.AbsoluteDelta(Before, After, signed: true);
+        return delta == CellText.Placeholder ? CellText.Placeholder : delta + " " + noun;
     }
 
     private static void WriteParenGroup(TextWriter writer, string? first, string? second)
@@ -147,6 +150,8 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
     private string MultipleText(bool withWord)
     {
         if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
+            return CellText.Placeholder;
+        if (!double.IsFinite(before) || !double.IsFinite(after))
             return CellText.Placeholder;
         var magBefore = Math.Abs(before);
         var magAfter = Math.Abs(after);

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -22,11 +22,16 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             writer.Write(CellText.Arrow);
             (After as IMarkoutCell)?.FormatInline(writer, format);
 
-            // Composite cells (e.g. Change<Share>) append the goal status word densely, deriving from
-            // the shape's comparable magnitude (matching the structured direction/status).
+            // Composite cells append a dense delta-noun (from IDeltaCountable) and/or the goal status
+            // word (from IGoalMagnitude), merged into one parenthetical.
+            string? compositeFirst = null;
+            if (format.DeltaNoun is not null && Before is IDeltaCountable beforeCount && After is IDeltaCountable afterCount)
+                compositeFirst = CellText.SignedNumber(afterCount.DeltaCount - beforeCount.DeltaCount) + " " + format.DeltaNoun;
+            string? compositeStatus = null;
             if (format.Goal != Goal.Context && Before is IGoalMagnitude beforeMag && After is IGoalMagnitude afterMag &&
-                GoalDerivation.TryDerive(beforeMag.GoalMagnitude, afterMag.GoalMagnitude, format.Goal, format.Noise, out _, out var compositeStatus))
-                WriteParenGroup(writer, null, GateStatusText.Slug(compositeStatus));
+                GoalDerivation.TryDerive(beforeMag.GoalMagnitude, afterMag.GoalMagnitude, format.Goal, format.Noise, out _, out var compositeGate))
+                compositeStatus = GateStatusText.Slug(compositeGate);
+            WriteParenGroup(writer, compositeFirst, compositeStatus);
             return;
         }
 
@@ -34,15 +39,26 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         writer.Write(CellText.Arrow);
         writer.Write(CellText.Scalar(After));
 
-        // Merge an optional derived-change suffix and an optional goal status word into a single
-        // parenthetical: "(+40%)", "(bad)", or "(+40%, bad)".
-        var deltaPart = format.Delta == Delta.None ? null : DeltaSuffix(format.Delta);
+        // Merge an optional derived-change suffix (or a delta-noun) and an optional goal status word
+        // into a single parenthetical: "(+40%)", "(bad)", "(+2 solved)", or "(+40%, bad)".
+        string? deltaPart;
+        if (format.DeltaNoun is not null)
+            deltaPart = NounText(format.DeltaNoun);
+        else
+            deltaPart = format.Delta == Delta.None ? null : DeltaSuffix(format.Delta);
         string? statusPart = null;
         if (format.Goal != Goal.Context &&
             GoalDerivation.TryDerive(Before, After, format.Goal, format.Noise, out _, out var status))
             statusPart = GateStatusText.Slug(status);
 
         WriteParenGroup(writer, deltaPart, statusPart);
+    }
+
+    private string NounText(string noun)
+    {
+        if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
+            return CellText.Placeholder;
+        return CellText.SignedNumber(after - before) + " " + noun;
     }
 
     private static void WriteParenGroup(TextWriter writer, string? first, string? second)
@@ -85,6 +101,8 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             fields.Add(new MarkoutField(CellText.SideKey(side, "deltaPct"), DeltaValue(Delta.Percent)));
         else if (format.Delta == Delta.Absolute)
             fields.Add(new MarkoutField(CellText.SideKey(side, "deltaAbs"), DeltaValue(Delta.Absolute)));
+        else if (format.Delta == Delta.Multiple)
+            fields.Add(new MarkoutField(CellText.SideKey(side, "deltaMultiple"), DeltaValue(Delta.Multiple)));
 
         if (format.Goal != Goal.Context &&
             GoalDerivation.TryDerive(Before, After, format.Goal, format.Noise, out var direction, out var status))
@@ -103,6 +121,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             // Divide by |before| so a rise from a negative base reports as a gain, not a loss.
             Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / Math.Abs(before) * 100),
             Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: true),
+            Delta.Multiple => MultipleText(withWord: true),
             _ => CellText.Placeholder
         };
     }
@@ -115,7 +134,31 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         {
             Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / Math.Abs(before) * 100),
             Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: false),
+            Delta.Multiple => MultipleText(withWord: false),
             _ => CellText.Placeholder
         };
+    }
+
+    /// <summary>
+    /// Renders the multiplicative factor <c>max/min</c> of the two magnitudes (rounded to one decimal).
+    /// With <paramref name="withWord"/>, appends <c>× more</c>/<c>× fewer</c> from the change direction;
+    /// a zero endpoint has no finite multiple and renders the placeholder.
+    /// </summary>
+    private string MultipleText(bool withWord)
+    {
+        if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
+            return CellText.Placeholder;
+        var magBefore = Math.Abs(before);
+        var magAfter = Math.Abs(after);
+        if (magBefore == 0 || magAfter == 0)
+            return CellText.Placeholder;
+        var factor = CellText.Number(Math.Round(Math.Max(magBefore, magAfter) / Math.Min(magBefore, magAfter), 1));
+        if (!withWord)
+            return factor;
+        if (after > before)
+            return factor + "\u00d7 more";
+        if (after < before)
+            return factor + "\u00d7 fewer";
+        return factor + "\u00d7";
     }
 }

--- a/src/Markout/Delta.cs
+++ b/src/Markout/Delta.cs
@@ -13,5 +13,12 @@ public enum Delta
     Percent,
 
     /// <summary>Append the signed absolute difference: <c>After − Before</c>.</summary>
-    Absolute
+    Absolute,
+
+    /// <summary>
+    /// Append the multiplicative factor between the two values with a direction word:
+    /// <c>15 → 5 (3× fewer)</c>, <c>5 → 15 (3× more)</c>. The factor is <c>max/min</c> of the
+    /// magnitudes; a zero endpoint (no finite multiple) renders the placeholder.
+    /// </summary>
+    Multiple
 }

--- a/src/Markout/Fraction.cs
+++ b/src/Markout/Fraction.cs
@@ -6,11 +6,14 @@ namespace Markout;
 /// </summary>
 /// <param name="Count">The numerator.</param>
 /// <param name="Total">The denominator.</param>
-public readonly record struct Fraction(double Count, double Total) : IMarkoutCell, IGoalMagnitude
+public readonly record struct Fraction(double Count, double Total) : IMarkoutCell, IGoalMagnitude, IDeltaCountable
 {
     /// <summary>The count-over-total rate drives goal derivation (not the raw count); an undefined rate
     /// (zero total) yields <see cref="double.NaN"/> so no direction is derived.</summary>
     double IGoalMagnitude.GoalMagnitude => Total == 0 ? double.NaN : Count / Total;
+
+    /// <summary>The numerator carries the delta noun (e.g. <c>4/6 → 6/6</c> → <c>(+2 solved)</c>).</summary>
+    double IDeltaCountable.DeltaCount => Count;
 
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)

--- a/src/Markout/IDeltaCountable.cs
+++ b/src/Markout/IDeltaCountable.cs
@@ -1,0 +1,14 @@
+namespace Markout;
+
+/// <summary>
+/// Implemented by composite cell shapes that expose a single "count" quantity whose delta carries a
+/// caller noun (<see cref="MarkoutCellFormat.DeltaNoun"/>) — e.g. <see cref="Fraction"/> exposes its
+/// <c>Count</c> so <c>4/6 → 6/6</c> renders <c>(+2 solved)</c>. Distinct from
+/// <see cref="IGoalMagnitude"/> (which drives goal direction): a <see cref="Fraction"/>'s goal
+/// magnitude is its <em>ratio</em>, but its delta-noun count is the numerator.
+/// </summary>
+public interface IDeltaCountable
+{
+    /// <summary>The count quantity whose before/after delta the noun is rendered on.</summary>
+    double DeltaCount { get; }
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.20.0</Version>
-    <PackageReleaseNotes>Goal-aware dense Markdown rendering: a MetricChange&lt;T&gt; table now inlines the status word into the Change cell (0 → 7 (bad)), appends a goal marker to the metric label ((-) for Goal.Lower, (+) for Goal.Higher), and drops the separate Status column; a caller StatusLabel stays the inline word. [MarkoutGoal] Change&lt;T&gt; properties (scalar and composite Share/Percent/Fraction) render the same inline word, merged with any [MarkoutDelta] suffix into one group (0 → 7 (+40%, bad)). Set MarkoutWriterOptions.InlineGoalStatus = false to keep the legacy Metric | Change | Target | Status layout. Structured (TSV/JSONL) output is unchanged (separate direction/status fields).</PackageReleaseNotes>
+    <Version>0.21.0</Version>
+    <PackageReleaseNotes>Segments aggregate goal magnitude: Segments now implements IGoalMagnitude as the sum of its parts' values, so a Change&lt;Segments&gt; with a Goal derives a total-based direction/status (e.g. 14/7 → 0/0 with Goal.Lower is resolved/good) while still decomposing each part. Opt-in via MarkoutCellFormat.Goal — Goal.Context (default) derives nothing, so a purely compositional breakdown declines by not setting a goal; a constant-sum breakdown reads as Unchanged. Dense Markdown shows the inline word for free through the 0.20 IGoalMagnitude seam.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -9,7 +9,7 @@
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>0.21.0</Version>
-    <PackageReleaseNotes>Segments aggregate goal magnitude: Segments now implements IGoalMagnitude as the sum of its parts' values, so a Change&lt;Segments&gt; with a Goal derives a total-based direction/status (e.g. 14/7 → 0/0 with Goal.Lower is resolved/good) while still decomposing each part. Opt-in via MarkoutCellFormat.Goal — Goal.Context (default) derives nothing, so a purely compositional breakdown declines by not setting a goal; a constant-sum breakdown reads as Unchanged. Dense Markdown shows the inline word for free through the 0.20 IGoalMagnitude seam.</PackageReleaseNotes>
+    <PackageReleaseNotes>Goal-aware annotation follow-ups (all in 0.21.0): (1) Segments implements IGoalMagnitude as the sum of its parts, so a Change&lt;Segments&gt; with a Goal derives a total-based direction/status while still decomposing each part (opt-in via Goal; constant-sum reads Unchanged). (2) Delta.Multiple renders a multiplicative factor with a direction word — 15 → 5 (3× fewer), 5 → 15 (3× more); a zero endpoint renders the placeholder; decomposes to a deltaMultiple field. (3) [MarkoutDeltaNoun("solved")] renders a caller noun on the signed absolute delta — 4/6 → 6/6 (+2 solved) — the sibling of [MarkoutUnit]; composites use IDeltaCountable (Fraction → count, Share → value); Markdown-only. All annotations merge into the single 0.20 parenthetical: 4/6 → 6/6 (+2 solved, good).</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -86,6 +86,8 @@ internal static class CellText
     public static string SignedNumber(double value)
     {
         var text = Number(value);
+        if (text == Placeholder)
+            return Placeholder;   // non-finite: bare placeholder, never "+—"
         return value > 0 ? "+" + text : text;
     }
 

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -22,4 +22,12 @@ public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string
     /// defaults to <c>0</c> (exact).
     /// </summary>
     public double Noise { get; init; }
+
+    /// <summary>
+    /// An optional caller-supplied noun rendered on the signed absolute delta in dense Markdown
+    /// (e.g. <c>[MarkoutDeltaNoun("solved")]</c> → <c>4 → 6 (+2 solved)</c>). Markdown-only; structured
+    /// output is unaffected. Applies to scalar <see cref="Change{V}"/> and composites implementing
+    /// <see cref="IDeltaCountable"/> (<see cref="Fraction"/> → count, <see cref="Share"/> → value).
+    /// </summary>
+    public string? DeltaNoun { get; init; }
 }

--- a/src/Markout/Segments.cs
+++ b/src/Markout/Segments.cs
@@ -14,8 +14,27 @@ public readonly record struct Segment(string Label, double Value);
 /// <c>{side}_{label}</c> when nested in a <see cref="Change{V}"/>).
 /// </summary>
 /// <param name="Parts">The labeled parts, rendered left-to-right in order.</param>
-public readonly record struct Segments(params Segment[] Parts) : IMarkoutCell
+public readonly record struct Segments(params Segment[] Parts) : IMarkoutCell, IGoalMagnitude
 {
+    /// <summary>
+    /// The aggregate magnitude for goal derivation is the sum of the parts' values (the breakdown's
+    /// total). Opt-in via <see cref="MarkoutCellFormat.Goal"/> — <see cref="Goal.Context"/> (the default)
+    /// derives nothing, so a purely compositional breakdown declines simply by not setting a goal. A
+    /// constant-sum (proportion) breakdown reads as <see cref="Direction.Unchanged"/>.
+    /// </summary>
+    double IGoalMagnitude.GoalMagnitude
+    {
+        get
+        {
+            if (Parts is null)
+                return 0;
+            double sum = 0;
+            foreach (var part in Parts)
+                sum += part.Value;
+            return sum;
+        }
+    }
+
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)
     {

--- a/src/Markout/Share.cs
+++ b/src/Markout/Share.cs
@@ -7,10 +7,13 @@ namespace Markout;
 /// </summary>
 /// <param name="Value">The value shown before the derived percent.</param>
 /// <param name="Whole">The whole the value is a share of. A zero renders the placeholder.</param>
-public readonly record struct Share(double Value, double Whole) : IMarkoutCell, IGoalMagnitude
+public readonly record struct Share(double Value, double Whole) : IMarkoutCell, IGoalMagnitude, IDeltaCountable
 {
     /// <summary>The raw value drives goal derivation (the share percent is secondary context).</summary>
     double IGoalMagnitude.GoalMagnitude => Value;
+
+    /// <summary>The raw value carries the delta noun.</summary>
+    double IDeltaCountable.DeltaCount => Value;
 
     /// <inheritdoc/>
     public void FormatInline(TextWriter writer, in MarkoutCellFormat format)

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -563,6 +563,15 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_DeltaNoun_PositiveInfinity_OmitsNoun()
+    {
+        // +Infinity delta must render the bare placeholder, never "+— solved".
+        var s = Inline(new Change<double>(5, double.PositiveInfinity), new MarkoutCellFormat { DeltaNoun = "solved" });
+        Assert.DoesNotContain("solved", s);
+        Assert.DoesNotContain("+\u2014", s);
+    }
+
+    [Fact]
     public void Change_DeltaNoun_IsMarkdownOnly_DecomposeUnaffected()
     {
         var fields = Decompose(new Change<long>(4, 6), new MarkoutCellFormat { DeltaNoun = "solved" });

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -50,6 +50,24 @@ public partial class GoalTableCardContext : MarkoutSerializerContext
 {
 }
 
+// Attribute path for Delta.Multiple and [MarkoutDeltaNoun].
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class DeltaModesCard
+{
+    [MarkoutIgnore] public string Title => "Delta modes";
+
+    [MarkoutPropertyName("Residual"), MarkoutDelta(Delta.Multiple)]
+    public Change<int> Residual { get; set; }
+
+    [MarkoutPropertyName("Tasks"), MarkoutDeltaNoun("solved")]
+    public Change<Fraction> Tasks { get; set; }
+}
+
+[MarkoutContext(typeof(DeltaModesCard))]
+public partial class DeltaModesCardContext : MarkoutSerializerContext
+{
+}
+
 public class GoalAwareCellTests
 {
     private static List<MarkoutField> Decompose(IMarkoutCell cell, MarkoutCellFormat format)
@@ -449,6 +467,85 @@ public class GoalAwareCellTests
         }
     }
 
+    // --- Delta.Multiple (slice 2) ---
+
+    [Fact]
+    public void Change_DeltaMultiple_RendersFactorAndDirectionWord()
+    {
+        Assert.Equal("15 \u2192 5 (3\u00d7 fewer)", Inline(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple)));
+        Assert.Equal("5 \u2192 15 (3\u00d7 more)", Inline(new Change<long>(5, 15), new MarkoutCellFormat(Delta.Multiple)));
+        Assert.Equal("15 \u2192 6 (2.5\u00d7 fewer)", Inline(new Change<long>(15, 6), new MarkoutCellFormat(Delta.Multiple)));
+    }
+
+    [Fact]
+    public void Change_DeltaMultiple_ZeroEndpoint_RendersPlaceholder()
+    {
+        Assert.Equal("15 \u2192 0 (\u2014)", Inline(new Change<long>(15, 0), new MarkoutCellFormat(Delta.Multiple)));
+    }
+
+    [Fact]
+    public void Change_DeltaMultiple_MergesWithGoalStatus()
+    {
+        Assert.Equal("15 \u2192 5 (3\u00d7 fewer, good)",
+            Inline(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Lower }));
+    }
+
+    [Fact]
+    public void Change_DeltaMultiple_DecomposesFactor()
+    {
+        var fields = Decompose(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple));
+        Assert.Equal("3", fields.Single(f => f.Key == "deltaMultiple").Value);
+    }
+
+    // --- Delta-noun (slice 3) ---
+
+    [Fact]
+    public void Change_DeltaNoun_Scalar_RendersSignedDeltaWithNoun()
+    {
+        Assert.Equal("4 \u2192 6 (+2 solved)", Inline(new Change<long>(4, 6), new MarkoutCellFormat { DeltaNoun = "solved" }));
+        Assert.Equal("6 \u2192 4 (-2 solved)", Inline(new Change<long>(6, 4), new MarkoutCellFormat { DeltaNoun = "solved" }));
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_MergesWithGoalStatus()
+    {
+        Assert.Equal("4 \u2192 6 (+2 solved, good)",
+            Inline(new Change<long>(4, 6), new MarkoutCellFormat { DeltaNoun = "solved", Goal = Goal.Higher }));
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_Fraction_UsesCountDelta()
+    {
+        // Fraction delta-noun is on the numerator (Count): 4/6 -> 6/6 => +2 solved.
+        Assert.Equal("4/6 \u2192 6/6 (+2 solved)",
+            Inline(new Change<Fraction>(new Fraction(4, 6), new Fraction(6, 6)), new MarkoutCellFormat { DeltaNoun = "solved" }));
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_Fraction_WithGoal_MergesRatioStatus()
+    {
+        // Ratio 0.667 -> 1.0 increased, Higher -> good; noun on Count delta.
+        Assert.Equal("4/6 \u2192 6/6 (+2 solved, good)",
+            Inline(new Change<Fraction>(new Fraction(4, 6), new Fraction(6, 6)),
+                new MarkoutCellFormat { DeltaNoun = "solved", Goal = Goal.Higher }));
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_Share_UsesValueDelta()
+    {
+        var s = Inline(new Change<Share>(new Share(10, 20), new Share(7, 20)), new MarkoutCellFormat { DeltaNoun = "tokens" });
+        Assert.EndsWith("(-3 tokens)", s);
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_IsMarkdownOnly_DecomposeUnaffected()
+    {
+        var fields = Decompose(new Change<long>(4, 6), new MarkoutCellFormat { DeltaNoun = "solved" });
+        Assert.DoesNotContain(fields, f => f.Value.Contains("solved"));
+        Assert.Equal("4", fields.Single(f => f.Key == "before").Value);
+        Assert.Equal("6", fields.Single(f => f.Key == "after").Value);
+    }
+
     // --- Attribute path (source generator) ---
 
     [Fact]
@@ -511,5 +608,19 @@ public class GoalAwareCellTests
 
         Assert.Contains("0 \u2192 7 (bad)", md);
         Assert.Contains("40 \u2192 55 (good)", md);
+    }
+
+    [Fact]
+    public void Generated_DeltaMultipleAndNoun_RenderInMarkdown()
+    {
+        var card = new DeltaModesCard
+        {
+            Residual = new(15, 5),
+            Tasks = new(new Fraction(4, 6), new Fraction(6, 6)),
+        };
+        var md = MarkoutSerializer.Serialize(card, DeltaModesCardContext.Default);
+
+        Assert.Contains("15 \u2192 5 (3\u00d7 fewer)", md);
+        Assert.Contains("4/6 \u2192 6/6 (+2 solved)", md);
     }
 }

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -330,16 +330,15 @@ public class GoalAwareCellTests
     }
 
     [Fact]
-    public void MultiSourceRow_SegmentsCell_NoDerivedDirection_EvenWithGoal()
+    public void MultiSourceRow_SegmentsCell_ContextGoal_NoDerivedDirection()
     {
-        // Segments has no single comparable magnitude (no IGoalMagnitude) -> no direction/status.
+        // With NO goal (Context), a Segments breakdown still derives nothing (opt-out).
         var rows = new[]
         {
             new MultiSourceRow("tool calls",
                 new Source("opus", new Change<Segments>(
                     new Segments(new Segment("web", 21), new Segment("other", 171)),
-                    new Segments(new Segment("web", 10), new Segment("other", 183))),
-                    new MarkoutCellFormat { Goal = Goal.Lower })),
+                    new Segments(new Segment("web", 10), new Segment("other", 183))))),
         };
 
         var sw = new StringWriter();
@@ -350,6 +349,75 @@ public class GoalAwareCellTests
 
         Assert.False(row.TryGetProperty("opus_direction", out _));
         Assert.False(row.TryGetProperty("opus_status", out _));
+    }
+
+    // --- Segments aggregate goal magnitude (sum of parts) ---
+
+    [Fact]
+    public void Change_Segments_WithGoal_DerivesFromSumTotal_AndKeepsParts()
+    {
+        // Archaeology-style: 14/7 -> 0/0, sum 21 -> 0, Goal.Lower -> resolved/good.
+        var cell = new Change<Segments>(
+            new Segments(new Segment("cache", 14), new Segment("nuget_org", 7)),
+            new Segments(new Segment("cache", 0), new Segment("nuget_org", 0)));
+        var fields = Decompose(cell, new MarkoutCellFormat { Goal = Goal.Lower });
+
+        // Parts still decompose.
+        Assert.Equal("14", fields.Single(f => f.Key == "before_cache").Value);
+        Assert.Equal("7", fields.Single(f => f.Key == "before_nuget_org").Value);
+        Assert.Equal("0", fields.Single(f => f.Key == "after_cache").Value);
+        // Total-derived axes.
+        Assert.Equal("resolved", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
+    public void Change_Segments_ConstantSum_IsUnchanged()
+    {
+        // Parts shift but the total is constant -> Unchanged/neutral (honest, if uninformative).
+        var cell = new Change<Segments>(
+            new Segments(new Segment("a", 3), new Segment("b", 7)),   // sum 10
+            new Segments(new Segment("a", 6), new Segment("b", 4)));  // sum 10
+        var fields = Decompose(cell, new MarkoutCellFormat { Goal = Goal.Lower });
+
+        Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("neutral", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
+    public void Change_Segments_WithGoal_RendersDenseInlineWord()
+    {
+        // Free dense rendering via the IGoalMagnitude seam: 14/7 -> 0/0 (good).
+        var s = Inline(new Change<Segments>(
+            new Segments(new Segment("cache", 14), new Segment("nuget_org", 7)),
+            new Segments(new Segment("cache", 0), new Segment("nuget_org", 0))),
+            new MarkoutCellFormat { Goal = Goal.Lower });
+
+        Assert.Equal("14/7 \u2192 0/0 (good)", s);
+    }
+
+    [Fact]
+    public void MultiSourceRow_SegmentsCell_WithGoal_DerivesTotalAxes()
+    {
+        var rows = new[]
+        {
+            new MultiSourceRow("failure buckets",
+                new Source("baseline",
+                    new Change<Segments>(
+                        new Segments(new Segment("new_body_missing", 4), new Segment("old_body_missing", 3)),
+                        new Segments(new Segment("new_body_missing", 0), new Segment("old_body_missing", 0))),
+                    new MarkoutCellFormat { Goal = Goal.Lower })),
+        };
+
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, OmitEmptyJsonFields = true });
+        writer.WriteMultiSourceTable("Metric", rows);
+        var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
+
+        Assert.Equal("4", row.GetProperty("baseline_before_new_body_missing").GetString());
+        Assert.Equal("resolved", row.GetProperty("baseline_direction").GetString());
+        Assert.Equal("good", row.GetProperty("baseline_status").GetString());
     }
 
     [Fact]

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -484,6 +484,15 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_DeltaMultiple_NonFinite_RendersPlaceholderWithoutWord()
+    {
+        var s = Inline(new Change<double>(double.PositiveInfinity, 5), new MarkoutCellFormat(Delta.Multiple));
+        Assert.EndsWith("(\u2014)", s);
+        Assert.DoesNotContain("\u00d7", s);   // no "—× fewer"
+        Assert.DoesNotContain("fewer", s);
+    }
+
+    [Fact]
     public void Change_DeltaMultiple_MergesWithGoalStatus()
     {
         Assert.Equal("15 \u2192 5 (3\u00d7 fewer, good)",
@@ -535,6 +544,22 @@ public class GoalAwareCellTests
     {
         var s = Inline(new Change<Share>(new Share(10, 20), new Share(7, 20)), new MarkoutCellFormat { DeltaNoun = "tokens" });
         Assert.EndsWith("(-3 tokens)", s);
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_Scalar_ExactForLargeIntegers()
+    {
+        // 2^53 and 2^53+1 are indistinguishable as double; the exact delta path keeps them apart.
+        var s = Inline(new Change<long>(9007199254740992L, 9007199254740993L), new MarkoutCellFormat { DeltaNoun = "solved" });
+        Assert.EndsWith("(+1 solved)", s);
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_NonFinite_OmitsNoun()
+    {
+        var s = Inline(new Change<Fraction>(new Fraction(double.NaN, 6), new Fraction(6, 6)),
+            new MarkoutCellFormat { DeltaNoun = "solved" });
+        Assert.DoesNotContain("solved", s);   // no "— solved"
     }
 
     [Fact]


### PR DESCRIPTION
Implements **all three** goal-aware annotation gaps from #137, shipped together in **0.21.0** (per maintainer: one release, not three).

## 1. `Segments` aggregate goal magnitude

`Segments` implements `IGoalMagnitude` = **sum of parts**, so a `Change<Segments>` with a `Goal` derives a total-based `direction`/`status` while still decomposing each part. Opt-in via `Goal` (`Context` derives nothing); constant-sum reads `Unchanged`. Dense inline word free via the 0.20 seam.

```jsonl
{"before_new_body_missing":4,"before_old_body_missing":3,"after_new_body_missing":0,"after_old_body_missing":0,"direction":"resolved","status":"good"}
```

## 2. `Delta.Multiple`

A multiplicative factor with a direction word — `15 → 5 (3× fewer)`, `5 → 15 (3× more)`. Factor = `max/min` (one decimal); `fewer`/`more` from the change direction (not the goal); a zero endpoint renders the placeholder `—`. Decomposes to a `deltaMultiple` field.

## 3. `[MarkoutDeltaNoun("solved")]`

Caller noun on the signed absolute delta — `4/6 → 6/6 (+2 solved)` — the sibling of `[MarkoutUnit]`. Composites use a new `IDeltaCountable` (`Fraction`→count, `Share`→value). **Markdown-only**; structured output unaffected.

All annotations merge into the single 0.20 parenthetical: `4/6 → 6/6 (+2 solved, good)`, `15 → 5 (3× fewer, good)`.

## Boundary

(1) and (2) are derived from data + declared goal (Markout owns them); (3) is caller metadata (Markout renders, doesn't invent) — the line held since #128.

## Tests

18 new tests across the three slices; **659 total green** (+236 MarkdownTable, +59 Templates). Version 0.21.0 + release notes; `grounding/markout/AGENTS.md` and `docs/design/shape-system.md` updated.

Proving consumers: dotnet-package-grounding (archaeology/tool-call rows) and dotnet-inspect (IL/C# Diff + DecompilerHarness bucket rows). Adversarial review (GPT-5.5 + Gemini 3.1 Pro) to two cleans — records follow.
