### PR TITLE
Suppress redundant inline status when Delta.Multiple aligns with goal (#141)

### DIFF
--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -73,7 +73,9 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
   `[MarkoutDelta(Delta.Percent)]` on a numeric `Change<V>` appends the signed change, e.g.
   `98555 → 61190 (−38%)`; `Delta.Absolute` appends the signed difference; `Delta.Multiple` appends a
   multiplicative factor with a direction word, e.g. `15 → 5 (3× fewer)` / `5 → 15 (3× more)` (a zero
-  endpoint renders `—`). `[MarkoutDeltaNoun("solved")]` renders a caller noun on the signed delta —
+  endpoint renders `—`). With a goal, an aligned `Delta.Multiple` word omits the redundant status word
+  (`15 → 5 (3× fewer)` under `Goal.Lower`); a conflicting one keeps it (`5 → 15 (3× more, bad)`).
+  `[MarkoutDeltaNoun("solved")]` renders a caller noun on the signed delta —
   `4/6 → 6/6 (+2 solved)` (sibling of `[MarkoutUnit]`; composites use `IDeltaCountable`: `Fraction`→count,
   `Share`→value; Markdown-only).
   `[MarkoutGoal(Goal.Higher)]` / `[MarkoutGoal(Goal.Lower)]` on a numeric `Change<V>` makes Markout

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -52,7 +52,17 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         string? statusPart = null;
         if (format.Goal != Goal.Context &&
             GoalDerivation.TryDerive(Before, After, format.Goal, format.Noise, out _, out var status))
-            statusPart = GateStatusText.Slug(status);
+        {
+            // Delta.Multiple already renders a goal-aligned direction word ("fewer"/"more"), so an
+            // aligned (Good) status word is redundant — suppress it. Keep it when it conflicts (Bad),
+            // when there is no rendered multiple phrase (placeholder), or for a delta-noun.
+            var multipleImpliesGood = format.DeltaNoun is null
+                && format.Delta == Delta.Multiple
+                && status == GateStatus.Good
+                && deltaPart is not null && deltaPart != CellText.Placeholder;
+            if (!multipleImpliesGood)
+                statusPart = GateStatusText.Slug(status);
+        }
 
         WriteParenGroup(writer, deltaPart, statusPart);
     }

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -493,10 +493,39 @@ public class GoalAwareCellTests
     }
 
     [Fact]
-    public void Change_DeltaMultiple_MergesWithGoalStatus()
+    public void Change_DeltaMultiple_AlignedGoal_SuppressesRedundantStatus()
     {
-        Assert.Equal("15 \u2192 5 (3\u00d7 fewer, good)",
+        // fewer/more already conveys the aligned (good) polarity -> omit "good" (#141).
+        Assert.Equal("15 \u2192 5 (3\u00d7 fewer)",
             Inline(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Lower }));
+        Assert.Equal("5 \u2192 15 (3\u00d7 more)",
+            Inline(new Change<long>(5, 15), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Higher }));
+    }
+
+    [Fact]
+    public void Change_DeltaMultiple_ConflictingGoal_KeepsStatus()
+    {
+        // The word conflicts with the goal -> keep "bad" (it adds information).
+        Assert.Equal("5 \u2192 15 (3\u00d7 more, bad)",
+            Inline(new Change<long>(5, 15), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Lower }));
+        Assert.Equal("15 \u2192 5 (3\u00d7 fewer, bad)",
+            Inline(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Higher }));
+    }
+
+    [Fact]
+    public void Change_DeltaMultiple_ZeroEndpoint_KeepsStatus_NoWord()
+    {
+        // No rendered multiple phrase (placeholder) -> keep the status word.
+        Assert.Equal("15 \u2192 0 (\u2014, good)",
+            Inline(new Change<long>(15, 0), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Lower }));
+    }
+
+    [Fact]
+    public void Change_NonMultipleDelta_KeepsGoalStatus()
+    {
+        // Suppression is specific to Delta.Multiple; Absolute/Percent still show the status word.
+        Assert.Equal("15 \u2192 5 (-10, good)",
+            Inline(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower }));
     }
 
     [Fact]
@@ -504,6 +533,16 @@ public class GoalAwareCellTests
     {
         var fields = Decompose(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple));
         Assert.Equal("3", fields.Single(f => f.Key == "deltaMultiple").Value);
+    }
+
+    [Fact]
+    public void Change_DeltaMultiple_AlignedGoal_KeepsStructuredStatus()
+    {
+        // #141 suppresses only the Markdown status word; structured output keeps direction/status.
+        var fields = Decompose(new Change<long>(15, 5), new MarkoutCellFormat(Delta.Multiple) { Goal = Goal.Lower });
+        Assert.Equal("3", fields.Single(f => f.Key == "deltaMultiple").Value);
+        Assert.Equal("decreased", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", fields.Single(f => f.Key == "status").Value);
     }
 
     // --- Delta-noun (slice 3) ---


### PR DESCRIPTION
Implements #141 — a quality refinement of the `Delta.Multiple` + goal-aware rendering shipped in #138 (0.21.0). **Markdown-only; structured output unchanged.**

## Rule

When `Delta.Multiple` renders a goal-**aligned** direction word (`fewer` under `Goal.Lower`, `more` under `Goal.Higher`), the derived status is `Good` and the inline `good` just repeats the same human signal — so it's suppressed:

```text
15 → 5 (3× fewer)     // Goal.Lower — decrease is good, implied by "fewer"
5 → 15 (3× more)      // Goal.Higher — increase is good, implied by "more"
```

The status word is **kept** when it adds information:

```text
5 → 15 (3× more, bad)    // Goal.Lower — "more" conflicts with the goal
15 → 5 (3× fewer, bad)   // Goal.Higher — "fewer" conflicts with the goal
15 → 0 (—, good)         // zero endpoint — no rendered multiple phrase
0 → 7 (bad)              // no Delta.Multiple at all
```

Precisely: suppress only when `DeltaNoun` is unset **and** `Delta == Multiple` **and** the derived status is `Good` **and** a real `N× fewer/more` phrase rendered (not the placeholder).

## Structured output unchanged

`Decompose` is untouched — JSONL/TSV still carry both axes:

```json
{"deltaMultiple":3,"direction":"decreased","status":"good"}
```

## Tests

5 new/updated tests (aligned-suppress, conflicting-keep, zero-endpoint-keep, non-Multiple-keep, structured-keeps-status); **667 total green**.

No version bump — batched into the 0.21.0 wave per maintainer (version updated separately). Adversarial review (GPT-5.5 + Gemini 3.1 Pro) to two cleans — record to follow.
