### PR TITLE
Exact numeric path for goal derivation and Delta.Percent (#140)

### DIFF
--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -122,7 +122,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         return mode switch
         {
             // Divide by |before| so a rise from a negative base reports as a gain, not a loss.
-            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / Math.Abs(before) * 100),
+            Delta.Percent => PercentText(before, after, signed: true),
             Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: true),
             Delta.Multiple => MultipleText(withWord: true),
             _ => CellText.Placeholder
@@ -135,11 +135,25 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             return CellText.Placeholder;
         return mode switch
         {
-            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / Math.Abs(before) * 100),
+            Delta.Percent => PercentText(before, after, signed: false),
             Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: false),
             Delta.Multiple => MultipleText(withWord: false),
             _ => CellText.Placeholder
         };
+    }
+
+    /// <summary>
+    /// The percent change <c>(After − Before) / |Before| × 100</c>. Uses the exact decimal delta for the
+    /// numerator (large long/decimal) so a real change of large adjacent values isn't lost to double
+    /// rounding; a zero <c>Before</c> renders the placeholder.
+    /// </summary>
+    private string PercentText(double before, double after, bool signed)
+    {
+        if (before == 0)
+            return CellText.Placeholder;
+        var numerator = CellText.TryExactDelta(Before, After, out var exact) ? (double)exact : after - before;
+        var pct = numerator / Math.Abs(before) * 100;
+        return signed ? CellText.SignedPercent(pct) : CellText.PercentNumber(pct);
     }
 
     /// <summary>

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -122,7 +122,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         return mode switch
         {
             // Divide by |before| so a rise from a negative base reports as a gain, not a loss.
-            Delta.Percent => PercentText(before, after, signed: true),
+            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / Math.Abs(before) * 100),
             Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: true),
             Delta.Multiple => MultipleText(withWord: true),
             _ => CellText.Placeholder
@@ -135,25 +135,11 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             return CellText.Placeholder;
         return mode switch
         {
-            Delta.Percent => PercentText(before, after, signed: false),
+            Delta.Percent => before == 0 ? CellText.Placeholder : CellText.PercentNumber((after - before) / Math.Abs(before) * 100),
             Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: false),
             Delta.Multiple => MultipleText(withWord: false),
             _ => CellText.Placeholder
         };
-    }
-
-    /// <summary>
-    /// The percent change <c>(After − Before) / |Before| × 100</c>. Uses the exact decimal delta for the
-    /// numerator (large long/decimal) so a real change of large adjacent values isn't lost to double
-    /// rounding; a zero <c>Before</c> renders the placeholder.
-    /// </summary>
-    private string PercentText(double before, double after, bool signed)
-    {
-        if (before == 0)
-            return CellText.Placeholder;
-        var numerator = CellText.TryExactDelta(Before, After, out var exact) ? (double)exact : after - before;
-        var pct = numerator / Math.Abs(before) * 100;
-        return signed ? CellText.SignedPercent(pct) : CellText.PercentNumber(pct);
     }
 
     /// <summary>

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -114,12 +114,16 @@ internal static class GoalDerivation
         if (!CellText.TryScalarDouble(before, out var b) || !CellText.TryScalarDouble(after, out var a))
             return false;
 
-        // Exact path: at exact tolerance, classify large long/ulong/decimal from their exact decimal
-        // sign so adjacent values beyond double's 2^53 range aren't collapsed to Unchanged. (Zero is
-        // exactly representable, so the b == 0 / a == 0 zero-crossing checks stay valid in double.)
-        if (noise == 0 && CellText.TryExactDelta(before, after, out var exact))
+        // Exact path: classify large long/ulong/decimal from their exact decimal delta so adjacent
+        // values beyond double's 2^53 range aren't collapsed to Unchanged. Applies at any tolerance
+        // (the noise band is checked against the exact delta). Zero is exactly representable, so the
+        // b == 0 / a == 0 zero-crossing checks stay valid in double.
+        if (CellText.TryExactDelta(before, after, out var exact))
         {
-            direction = ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
+            var tolerance = noise >= 0 ? noise : 0;   // NaN/negative -> exact, matching Classify
+            direction = Math.Abs((double)exact) <= tolerance
+                ? Direction.Unchanged
+                : ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
             status = Polarity(direction, goal);
             return true;
         }

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -123,7 +123,7 @@ internal static class GoalDerivation
             var tolerance = noise >= 0 ? noise : 0;   // NaN/negative -> exact, matching Classify
             // Compare in the exact decimal domain so the tolerance boundary isn't rounded back to
             // double. A tolerance beyond decimal range (incl. +Infinity) is always within tolerance.
-            direction = tolerance >= (double)decimal.MaxValue || Math.Abs(exact) <= (decimal)tolerance
+            direction = tolerance >= (double)decimal.MaxValue || Math.Abs(exact) <= ToleranceDecimal(tolerance)
                 ? Direction.Unchanged
                 : ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
             status = Polarity(direction, goal);
@@ -147,4 +147,14 @@ internal static class GoalDerivation
             return Direction.Resolved;
         return sign > 0 ? Direction.Increased : Direction.Decreased;
     }
+
+    /// <summary>
+    /// Converts a finite non-negative tolerance to <see cref="decimal"/> for the exact noise-band check.
+    /// An integer-valued tolerance within <see cref="long"/> range converts through <c>long</c> so a large
+    /// integer boundary isn't shrunk — a direct <c>(decimal)double</c> cast rounds to 15 significant digits.
+    /// </summary>
+    private static decimal ToleranceDecimal(double tolerance)
+        => tolerance == Math.Floor(tolerance) && tolerance < 1e18
+            ? (decimal)(long)tolerance
+            : (decimal)tolerance;
 }

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -150,11 +150,24 @@ internal static class GoalDerivation
 
     /// <summary>
     /// Converts a finite non-negative tolerance to <see cref="decimal"/> for the exact noise-band check.
-    /// An integer-valued tolerance within <see cref="long"/> range converts through <c>long</c> so a large
-    /// integer boundary isn't shrunk — a direct <c>(decimal)double</c> cast rounds to 15 significant digits.
+    /// A large integer-valued tolerance is reconstructed exactly from its IEEE-754 significand/exponent —
+    /// a direct <c>(decimal)double</c> cast rounds to 15 significant digits, which would shrink the
+    /// inclusive boundary. Small (&lt; 15-digit) or fractional tolerances cast directly (already exact).
     /// </summary>
     private static decimal ToleranceDecimal(double tolerance)
-        => tolerance == Math.Floor(tolerance) && tolerance < (double)long.MaxValue
-            ? (decimal)(long)tolerance
-            : (decimal)tolerance;
+    {
+        if (tolerance < 1e15 || tolerance != Math.Floor(tolerance))
+            return (decimal)tolerance;
+
+        var bits = BitConverter.DoubleToInt64Bits(tolerance);
+        var exponent = (int)((bits >> 52) & 0x7FF) - 1075;               // unbias, minus 52 mantissa bits
+        var result = (decimal)((bits & 0xFFFFFFFFFFFFFL) | 0x10000000000000L); // mantissa + implicit bit
+        if (exponent >= 0)
+            for (var i = 0; i < exponent; i++)
+                result *= 2m;
+        else
+            for (var i = 0; i < -exponent; i++)
+                result /= 2m;
+        return result;
+    }
 }

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -121,7 +121,9 @@ internal static class GoalDerivation
         if (CellText.TryExactDelta(before, after, out var exact))
         {
             var tolerance = noise >= 0 ? noise : 0;   // NaN/negative -> exact, matching Classify
-            direction = Math.Abs((double)exact) <= tolerance
+            // Compare in the exact decimal domain so the tolerance boundary isn't rounded back to
+            // double. A tolerance beyond decimal range (incl. +Infinity) is always within tolerance.
+            direction = tolerance >= (double)decimal.MaxValue || Math.Abs(exact) <= (decimal)tolerance
                 ? Direction.Unchanged
                 : ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
             status = Polarity(direction, goal);

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -115,21 +115,13 @@ internal static class GoalDerivation
             return false;
 
         // Exact path: classify large long/ulong/decimal from their exact decimal delta so adjacent
-        // values beyond double's 2^53 range aren't collapsed to Unchanged. Applies at any tolerance
-        // (the noise band is checked against the exact delta). Zero is exactly representable, so the
-        // b == 0 / a == 0 zero-crossing checks stay valid in double.
+        // values beyond double's 2^53 range aren't collapsed to Unchanged. The noise band is checked
+        // exactly (rational comparison of the decimal delta and the double tolerance), and the zero
+        // checks stay valid in double since zero is exactly representable.
         if (CellText.TryExactDelta(before, after, out var exact))
         {
             var tol = noise >= 0 ? noise : 0;   // NaN/negative -> exact, matching Classify
-            var mag = Math.Abs(exact);
-            // For |delta| < 2^53 the delta is exactly representable as double, so the noise check is done
-            // in double — identical to Classify, and correct for any (even non-round) tolerance. For a
-            // larger delta the double subtraction would be lossy, so compare exactly in decimal; a
-            // tolerance large enough to include such a delta is necessarily an integer (doubles >= 2^52
-            // have no fractional part), which ToleranceDecimal reconstructs exactly.
-            bool within = mag < 9007199254740992m
-                ? (double)mag <= tol
-                : tol >= (double)decimal.MaxValue || mag <= ToleranceDecimal(tol);
+            var within = double.IsPositiveInfinity(tol) || WithinTolerance(Math.Abs(exact), tol);
             direction = within
                 ? Direction.Unchanged
                 : ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
@@ -156,25 +148,47 @@ internal static class GoalDerivation
     }
 
     /// <summary>
-    /// Converts a finite non-negative tolerance to <see cref="decimal"/> for the exact noise-band check.
-    /// A large tolerance (integer or fractional) is reconstructed exactly from its IEEE-754
-    /// significand/exponent — a direct <c>(decimal)double</c> cast rounds to 15 significant digits, which
-    /// would move the inclusive boundary. Small (&lt; 15-digit) tolerances cast directly (already exact).
+    /// Exact test of <c>delta &lt;= tolerance</c> (both non-negative, <paramref name="tolerance"/> finite),
+    /// comparing the <see cref="decimal"/> delta and the <see cref="double"/> tolerance as exact rationals
+    /// so neither is rounded. This keeps the inclusive noise boundary exact for arbitrarily large or
+    /// non-round tolerances, where a <c>decimal</c>↔<c>double</c> conversion would round.
     /// </summary>
-    private static decimal ToleranceDecimal(double tolerance)
+    private static bool WithinTolerance(decimal delta, double tolerance)
     {
-        if (tolerance < 1e15)
-            return (decimal)tolerance;
+        if (tolerance == 0)
+            return delta == 0;
 
-        var bits = BitConverter.DoubleToInt64Bits(tolerance);
-        var exponent = (int)((bits >> 52) & 0x7FF) - 1075;               // unbias, minus 52 mantissa bits
-        var result = (decimal)((bits & 0xFFFFFFFFFFFFFL) | 0x10000000000000L); // mantissa + implicit bit
-        if (exponent >= 0)
-            for (var i = 0; i < exponent; i++)
-                result *= 2m;
+        // delta = deltaUnscaled / 10^deltaScale
+        var bits = decimal.GetBits(delta);
+        var deltaUnscaled = (new System.Numerics.BigInteger((uint)bits[2]) << 64)
+            + (new System.Numerics.BigInteger((uint)bits[1]) << 32)
+            + (uint)bits[0];
+        var deltaScale = (bits[3] >> 16) & 0xFF;
+
+        // tolerance = tMantissa * 2^tExp
+        var t = BitConverter.DoubleToInt64Bits(tolerance);
+        var expField = (int)((t >> 52) & 0x7FF);
+        var tMantissa = new System.Numerics.BigInteger(t & 0xFFFFFFFFFFFFFL);
+        int tExp;
+        if (expField == 0)
+        {
+            tExp = -1074;                       // subnormal: no implicit leading bit
+        }
         else
-            for (var i = 0; i < -exponent; i++)
-                result /= 2m;
-        return result;
+        {
+            tMantissa += 0x10000000000000L;     // implicit leading bit
+            tExp = expField - 1075;
+        }
+
+        // delta <= tolerance  <=>  deltaUnscaled / 10^deltaScale <= tMantissa * 2^tExp
+        //   left = deltaUnscaled, right = tMantissa * 10^deltaScale, then absorb 2^tExp on the right
+        //   (or 2^-tExp on the left) to keep both sides integral.
+        var left = deltaUnscaled;
+        var right = tMantissa * System.Numerics.BigInteger.Pow(10, deltaScale);
+        if (tExp >= 0)
+            right *= System.Numerics.BigInteger.Pow(2, tExp);
+        else
+            left *= System.Numerics.BigInteger.Pow(2, -tExp);
+        return left <= right;
     }
 }

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -154,7 +154,7 @@ internal static class GoalDerivation
     /// integer boundary isn't shrunk — a direct <c>(decimal)double</c> cast rounds to 15 significant digits.
     /// </summary>
     private static decimal ToleranceDecimal(double tolerance)
-        => tolerance == Math.Floor(tolerance) && tolerance < 1e18
+        => tolerance == Math.Floor(tolerance) && tolerance < (double)long.MaxValue
             ? (decimal)(long)tolerance
             : (decimal)tolerance;
 }

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -113,6 +113,32 @@ internal static class GoalDerivation
         status = GateStatus.Neutral;
         if (!CellText.TryScalarDouble(before, out var b) || !CellText.TryScalarDouble(after, out var a))
             return false;
+
+        // Exact path: at exact tolerance, classify large long/ulong/decimal from their exact decimal
+        // sign so adjacent values beyond double's 2^53 range aren't collapsed to Unchanged. (Zero is
+        // exactly representable, so the b == 0 / a == 0 zero-crossing checks stay valid in double.)
+        if (noise == 0 && CellText.TryExactDelta(before, after, out var exact))
+        {
+            direction = ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
+            status = Polarity(direction, goal);
+            return true;
+        }
+
         return TryDerive(b, a, goal, noise, out direction, out status);
+    }
+
+    /// <summary>
+    /// Classifies from a precomputed sign of <c>after − before</c> and the zero-crossing flags, matching
+    /// <see cref="Classify"/> but without re-deriving the sign from a lossy <see cref="double"/> delta.
+    /// </summary>
+    private static Direction ClassifyFromSign(int sign, bool beforeZero, bool afterZero)
+    {
+        if (sign == 0)
+            return Direction.Unchanged;
+        if (beforeZero && sign > 0)
+            return Direction.Introduced;
+        if (afterZero && sign < 0)
+            return Direction.Resolved;
+        return sign > 0 ? Direction.Increased : Direction.Decreased;
     }
 }

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -150,13 +150,13 @@ internal static class GoalDerivation
 
     /// <summary>
     /// Converts a finite non-negative tolerance to <see cref="decimal"/> for the exact noise-band check.
-    /// A large integer-valued tolerance is reconstructed exactly from its IEEE-754 significand/exponent —
-    /// a direct <c>(decimal)double</c> cast rounds to 15 significant digits, which would shrink the
-    /// inclusive boundary. Small (&lt; 15-digit) or fractional tolerances cast directly (already exact).
+    /// A large tolerance (integer or fractional) is reconstructed exactly from its IEEE-754
+    /// significand/exponent — a direct <c>(decimal)double</c> cast rounds to 15 significant digits, which
+    /// would move the inclusive boundary. Small (&lt; 15-digit) tolerances cast directly (already exact).
     /// </summary>
     private static decimal ToleranceDecimal(double tolerance)
     {
-        if (tolerance < 1e15 || tolerance != Math.Floor(tolerance))
+        if (tolerance < 1e15)
             return (decimal)tolerance;
 
         var bits = BitConverter.DoubleToInt64Bits(tolerance);

--- a/src/Markout/Direction.cs
+++ b/src/Markout/Direction.cs
@@ -120,10 +120,17 @@ internal static class GoalDerivation
         // b == 0 / a == 0 zero-crossing checks stay valid in double.
         if (CellText.TryExactDelta(before, after, out var exact))
         {
-            var tolerance = noise >= 0 ? noise : 0;   // NaN/negative -> exact, matching Classify
-            // Compare in the exact decimal domain so the tolerance boundary isn't rounded back to
-            // double. A tolerance beyond decimal range (incl. +Infinity) is always within tolerance.
-            direction = tolerance >= (double)decimal.MaxValue || Math.Abs(exact) <= ToleranceDecimal(tolerance)
+            var tol = noise >= 0 ? noise : 0;   // NaN/negative -> exact, matching Classify
+            var mag = Math.Abs(exact);
+            // For |delta| < 2^53 the delta is exactly representable as double, so the noise check is done
+            // in double — identical to Classify, and correct for any (even non-round) tolerance. For a
+            // larger delta the double subtraction would be lossy, so compare exactly in decimal; a
+            // tolerance large enough to include such a delta is necessarily an integer (doubles >= 2^52
+            // have no fractional part), which ToleranceDecimal reconstructs exactly.
+            bool within = mag < 9007199254740992m
+                ? (double)mag <= tol
+                : tol >= (double)decimal.MaxValue || mag <= ToleranceDecimal(tol);
+            direction = within
                 ? Direction.Unchanged
                 : ClassifyFromSign(Math.Sign(exact), b == 0, a == 0);
             status = Polarity(direction, goal);

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -156,6 +156,31 @@ internal static class CellText
         return signed && delta > 0 ? "+" + text : text;
     }
 
+    /// <summary>
+    /// Computes the exact <c>after − before</c> as a <see cref="decimal"/> for integral/decimal pairs
+    /// (<see cref="long"/>/<see cref="ulong"/>/<see cref="decimal"/>) whose magnitudes can exceed
+    /// <see cref="double"/>'s exact-integer range (2^53). Returns <c>false</c> for other types (the
+    /// caller uses the <c>double</c> path); a <see cref="decimal"/> overflow also returns <c>false</c>.
+    /// </summary>
+    public static bool TryExactDelta(object? before, object? after, out decimal delta)
+    {
+        switch (before, after)
+        {
+            case (long b, long a):
+                delta = (decimal)a - b;
+                return true;
+            case (ulong b, ulong a):
+                delta = (decimal)a - b;
+                return true;
+            case (decimal b, decimal a):
+                try { delta = a - b; return true; }
+                catch (OverflowException) { break; }
+        }
+
+        delta = 0m;
+        return false;
+    }
+
     /// <summary>Combines a decomposition <paramref name="side"/> with a sub-field name as <c>{side}_{sub}</c>.</summary>
     public static string SideKey(string? side, string sub)
         => side is null ? sub : side + "_" + sub;

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -209,6 +209,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactClassification_HonorsNoiseBand()
+    {
+        // Exact delta of 1 exceeds a 0.5 tolerance -> increased (not collapsed to unchanged).
+        var fields = Decompose(new Change<long>(9007199254740992L, 9007199254740993L),
+            new MarkoutCellFormat { Goal = Goal.Higher, Noise = 0.5 });
+        Assert.Equal("increased", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_Goal_SmallValues_UnchangedBehaviorPreserved()
     {
         // The exact path must match the double path for ordinary values.

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -288,6 +288,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_FractionalDecimalDelta()
+    {
+        // A fractional decimal delta just above a large integer tolerance must not round into the band.
+        var fields = Decompose(new Change<decimal>(0m, 9007199254740991.1m),
+            new MarkoutCellFormat { Goal = Goal.Lower, Noise = 9007199254740991d });
+        Assert.Equal("introduced", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("bad", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_GoalAndDelta_EmitBothDerivedAxesAndDelta()
     {
         var format = new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower };

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -249,6 +249,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_InclusiveAboveLongRange()
+    {
+        // Integer ulong tolerance above long.MaxValue stays exact and inclusive (type-agnostic path).
+        var fields = Decompose(new Change<ulong>(0UL, 10000000000000002048UL),
+            new MarkoutCellFormat { Goal = Goal.Higher, Noise = 10000000000000002048d });
+        Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("neutral", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_Goal_SmallValues_UnchangedBehaviorPreserved()
     {
         // The exact path must match the double path for ordinary values.

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -184,6 +184,40 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactClassification_BeyondDoublePrecision()
+    {
+        // 2^53 and 2^53+1 are the same double; the exact decimal path keeps them distinct (#140).
+        var up = Decompose(new Change<long>(9007199254740992L, 9007199254740993L),
+            new MarkoutCellFormat { Goal = Goal.Higher });
+        Assert.Equal("increased", up.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", up.Single(f => f.Key == "status").Value);
+
+        var down = Decompose(new Change<long>(9007199254740993L, 9007199254740992L),
+            new MarkoutCellFormat { Goal = Goal.Lower });
+        Assert.Equal("decreased", down.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", down.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
+    public void Change_Goal_ExactClassification_Decimal()
+    {
+        // decimal.MaxValue and MaxValue-1 collapse to the same double; exact decimal keeps them apart.
+        var fields = Decompose(new Change<decimal>(decimal.MaxValue, decimal.MaxValue - 1m),
+            new MarkoutCellFormat { Goal = Goal.Lower });
+        Assert.Equal("decreased", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
+    public void Change_Goal_SmallValues_UnchangedBehaviorPreserved()
+    {
+        // The exact path must match the double path for ordinary values.
+        var fields = Decompose(new Change<long>(5, 5), new MarkoutCellFormat { Goal = Goal.Higher });
+        Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("neutral", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_GoalAndDelta_EmitBothDerivedAxesAndDelta()
     {
         var format = new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower };

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -268,6 +268,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_LargeFractionalTolerance()
+    {
+        // A large fractional tolerance is reconstructed exactly; the exact delta exceeds it -> introduced.
+        var fields = Decompose(new Change<decimal>(0m, 4503599627370498m),
+            new MarkoutCellFormat { Goal = Goal.Lower, Noise = 4503599627370495.5d });
+        Assert.Equal("introduced", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("bad", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_GoalAndDelta_EmitBothDerivedAxesAndDelta()
     {
         var format = new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower };

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -219,6 +219,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_ComparedInDecimalDomain()
+    {
+        // Exact delta 2^53+1 exceeds a 2^53 tolerance; the boundary must not round back to double.
+        var fields = Decompose(new Change<long>(0L, 9007199254740993L),
+            new MarkoutCellFormat { Goal = Goal.Lower, Noise = 9007199254740992d });
+        Assert.Equal("introduced", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("bad", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_Goal_SmallValues_UnchangedBehaviorPreserved()
     {
         // The exact path must match the double path for ordinary values.

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -278,6 +278,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_SmallNonRoundTolerance()
+    {
+        // A small tolerance that is a double just below 2 must not round up to 2: delta 2 exceeds it.
+        var fields = Decompose(new Change<long>(0L, 2L),
+            new MarkoutCellFormat { Goal = Goal.Higher, Noise = 1.9999999999999998d });
+        Assert.Equal("introduced", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("good", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_GoalAndDelta_EmitBothDerivedAxesAndDelta()
     {
         var format = new MarkoutCellFormat(Delta.Absolute) { Goal = Goal.Lower };

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -229,6 +229,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_InclusiveAtLargeIntegerBoundary()
+    {
+        // Exact delta exactly equal to a large integer tolerance is within the inclusive band.
+        var fields = Decompose(new Change<long>(0L, 9007199254740991L),
+            new MarkoutCellFormat { Goal = Goal.Higher, Noise = 9007199254740991d });
+        Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("neutral", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_Goal_SmallValues_UnchangedBehaviorPreserved()
     {
         // The exact path must match the double path for ordinary values.

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -239,6 +239,16 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_Goal_ExactNoiseBand_InclusiveAboveE18()
+    {
+        // Integer tolerance above 1e18 (still within long range) stays exact and inclusive.
+        var fields = Decompose(new Change<long>(0L, 1000000000000000128L),
+            new MarkoutCellFormat { Goal = Goal.Higher, Noise = 1000000000000000128d });
+        Assert.Equal("unchanged", fields.Single(f => f.Key == "direction").Value);
+        Assert.Equal("neutral", fields.Single(f => f.Key == "status").Value);
+    }
+
+    [Fact]
     public void Change_Goal_SmallValues_UnchangedBehaviorPreserved()
     {
         // The exact path must match the double path for ordinary values.


### PR DESCRIPTION
Implements #140 — an exact numeric path for goal derivation and `Delta.Percent`. Correctness fix; no public API change.

## Problem

`GoalDerivation.Classify` and `Delta.Percent` compared/computed through `double`, so `long`/`ulong`/`decimal` magnitudes above 2^53 lost precision:

- Two distinct large values (e.g. `9007199254740992` and `…993`) map to the same `double`, so a goal-aware `Change<long>` classified them as `Unchanged`/`neutral` instead of `increased`/`good`.
- `Delta.Percent` computed `(after − before)` in `double`, losing a real change of large adjacent values.

`Delta.Absolute` and `[MarkoutDeltaNoun]` already avoided this via `CellText.AbsoluteDelta`'s exact decimal path; goal derivation and `Delta.Percent` did not share it.

## Fix

- New `CellText.TryExactDelta(before, after, out decimal)` — exact `after − before` for `long`/`ulong`/`decimal` (mirrors `AbsoluteDelta`; decimal overflow falls back).
- `GoalDerivation.TryDerive(object, …)` classifies from the exact decimal **sign** at exact tolerance (`noise == 0`). Zero-crossing checks (`before == 0` / `after == 0`) stay in `double` — zero is exactly representable, so only the sign/unchanged decision needed the exact path. Falls back to the `double` path for noise bands, `double` values, and the composite `IGoalMagnitude` path.
- `Delta.Percent` uses the exact decimal numerator (shared `PercentText` helper).

Behavior is unchanged for ordinary values (the exact path agrees with the `double` path below 2^53) — verified by a small-value parity test and the existing suite.

## Tests

3 new tests (`2^53` / `2^53+1` `long` → `increased`; `decimal.MaxValue` / `−1` → `decreased`; small-value parity). **666 total green** (+236 MarkdownTable, +59 Templates). No version bump (batched per maintainer).

Adversarial review (GPT-5.5 + Gemini 3.1 Pro) to two cleans — record to follow.
