### PR TITLE
Decompose composite element-table columns for structured output (#139)

### DIFF
--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -96,6 +96,12 @@ JSONL decomposition is **heterogeneous** (each record holds only its own keys); 
 column union (absent cells blank). Set `MarkoutWriterOptions.JsonTypedValues = true` to emit numeric
 columns as JSON numbers instead of strings.
 
+When a composite cell (`Change<V>`, etc.) is a **column of an element table** (`List<T>` where `T` has a
+composite property), structured formatters (TSV/JSONL) **decompose it into typed `{column}_{sub}` columns**
+— `score_before`/`score_after`/`score_delta_pct`, `bugs_direction`/`bugs_status`, `tasks_delta_count`/
+`tasks_delta_noun` — so the card is reconstructable from the data. Markdown keeps the dense cell
+(`100 → 50 (-50%)`). Scalar columns and Markdown are unchanged.
+
 ## Card shapes (declare a list; the generator picks the layout)
 
 Two list-shapes render as multi-format cards from a `[MarkoutSerializable]` model — Markdown table +

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -100,7 +100,8 @@ When a composite cell (`Change<V>`, etc.) is a **column of an element table** (`
 composite property), structured formatters (TSV/JSONL) **decompose it into typed `{column}_{sub}` columns**
 — `score_before`/`score_after`/`score_delta_pct`, `bugs_direction`/`bugs_status`, `tasks_delta_count`/
 `tasks_delta_noun` — so the card is reconstructable from the data. Markdown keeps the dense cell
-(`100 → 50 (-50%)`). Scalar columns and Markdown are unchanged.
+(`100 → 50 (-50%)`). Scalar columns and Markdown are unchanged. `[MarkoutIgnoreColumnWhen]` columns that
+are hidden for the table are dropped from the decomposed output too.
 
 ## Card shapes (declare a list; the generator picks the layout)
 

--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -135,65 +135,112 @@ internal static class CollectionEmitter
         var itemVar = nestingDepth == 0 ? "item" : $"item{nestingDepth}";
         var dynamicLookup = dynamicIgnoreColumns.ToDictionary(d => d.ColumnName, d => d.ConditionVar);
 
-        // Build headers dynamically
-        sb.AppendLine($"{indent}var __headers = new global::System.Collections.Generic.List<string>();");
-        sb.AppendLine($"{indent}var __headerNames = new global::System.Collections.Generic.List<string>();");
-        foreach (var p in visibleProps)
+        // Resolve the dynamic-ignore condition variable (loop-invariant) for a column, if any.
+        bool TryDynamicCond(PropertyMetadata p, out string condVar)
         {
-            var headerStr = p.Name == prop.SectionFormatProperty && prop.SectionColumnName != null
-                ? $"\"{EmitHelpers.EscapeString(prop.SectionColumnName)}\""
-                : $"\"{EmitHelpers.EscapeString(p.DisplayName)}\"";
-            var headerNameStr = $"\"{EmitHelpers.EscapeString(p.Name)}\"";
-
             var dynamicKey = dynamicLookup.ContainsKey(p.Name) ? p.Name : p.DisplayName;
-            if (dynamicLookup.TryGetValue(dynamicKey, out var condVar))
-            {
-                sb.AppendLine($"{indent}if (!{condVar})");
-                sb.AppendLine($"{indent}{{");
-                sb.AppendLine($"{indent}    __headers.Add({headerStr});");
-                sb.AppendLine($"{indent}    __headerNames.Add({headerNameStr});");
-                sb.AppendLine($"{indent}}}");
-            }
-            else
-            {
-                sb.AppendLine($"{indent}__headers.Add({headerStr});");
-                sb.AppendLine($"{indent}__headerNames.Add({headerNameStr});");
-            }
+            return dynamicLookup.TryGetValue(dynamicKey, out condVar!);
         }
-        sb.AppendLine($"{indent}writer.WriteTableStart(__headers.ToArray(), __headerNames.ToArray());");
 
-        // Instantiate formatter if configured
-        if (prop.SectionFormatterTypeName != null)
-            sb.AppendLine($"{indent}var __fmt = new {prop.SectionFormatterTypeName}();");
-
-        // Build rows dynamically
-        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
-        sb.AppendLine($"{indent}{{");
-        sb.AppendLine($"{indent}    var __row = new global::System.Collections.Generic.List<string>();");
-
-        foreach (var elemProp in visibleProps)
+        // Dense cell string for a column (formatted-property override, else the cell value).
+        string ScalarValue(PropertyMetadata p)
         {
-            string value;
-            if (elemProp.Name == prop.SectionFormatProperty && prop.SectionFormatterTypeName != null)
+            if (p.Name == prop.SectionFormatProperty && prop.SectionFormatterTypeName != null)
             {
-                var access = $"{itemVar}.{elemProp.Name}";
-                value = $"{access} != null ? __fmt.Format({access}) : \"\"";
+                var access = $"{itemVar}.{p.Name}";
+                return $"{access} != null ? __fmt.Format({access}) : \"\"";
             }
-            else
-            {
-                value = EmitHelpers.GetTableCellValue(elemProp, itemVar);
-            }
-
-            var dynamicKey = dynamicLookup.ContainsKey(elemProp.Name) ? elemProp.Name : elemProp.DisplayName;
-            if (dynamicLookup.TryGetValue(dynamicKey, out var condVar))
-                sb.AppendLine($"{indent}    if (!{condVar}) __row.Add({value});");
-            else
-                sb.AppendLine($"{indent}    __row.Add({value});");
+            return EmitHelpers.GetTableCellValue(p, itemVar);
         }
 
-        sb.AppendLine($"{indent}    writer.WriteTableRow(__row.ToArray());");
-        sb.AppendLine($"{indent}}}");
-        sb.AppendLine($"{indent}writer.WriteTableEnd();");
+        void EmitDense(string ind)
+        {
+            sb.AppendLine($"{ind}var __headers = new global::System.Collections.Generic.List<string>();");
+            sb.AppendLine($"{ind}var __headerNames = new global::System.Collections.Generic.List<string>();");
+            foreach (var p in visibleProps)
+            {
+                var headerStr = p.Name == prop.SectionFormatProperty && prop.SectionColumnName != null
+                    ? $"\"{EmitHelpers.EscapeString(prop.SectionColumnName)}\""
+                    : $"\"{EmitHelpers.EscapeString(p.DisplayName)}\"";
+                var headerNameStr = $"\"{EmitHelpers.EscapeString(p.Name)}\"";
+
+                if (TryDynamicCond(p, out var condVar))
+                {
+                    sb.AppendLine($"{ind}if (!{condVar})");
+                    sb.AppendLine($"{ind}{{");
+                    sb.AppendLine($"{ind}    __headers.Add({headerStr});");
+                    sb.AppendLine($"{ind}    __headerNames.Add({headerNameStr});");
+                    sb.AppendLine($"{ind}}}");
+                }
+                else
+                {
+                    sb.AppendLine($"{ind}__headers.Add({headerStr});");
+                    sb.AppendLine($"{ind}__headerNames.Add({headerNameStr});");
+                }
+            }
+            sb.AppendLine($"{ind}writer.WriteTableStart(__headers.ToArray(), __headerNames.ToArray());");
+            if (prop.SectionFormatterTypeName != null)
+                sb.AppendLine($"{ind}var __fmt = new {prop.SectionFormatterTypeName}();");
+            sb.AppendLine($"{ind}foreach (var {itemVar} in {propAccess})");
+            sb.AppendLine($"{ind}{{");
+            sb.AppendLine($"{ind}    var __row = new global::System.Collections.Generic.List<string>();");
+            foreach (var elemProp in visibleProps)
+            {
+                var value = ScalarValue(elemProp);
+                if (TryDynamicCond(elemProp, out var condVar))
+                    sb.AppendLine($"{ind}    if (!{condVar}) __row.Add({value});");
+                else
+                    sb.AppendLine($"{ind}    __row.Add({value});");
+            }
+            sb.AppendLine($"{ind}    writer.WriteTableRow(__row.ToArray());");
+            sb.AppendLine($"{ind}}}");
+            sb.AppendLine($"{ind}writer.WriteTableEnd();");
+        }
+
+        // Decomposing formatters: same dynamic-hidden-column rules, but composite columns emit typed
+        // sub-fields. A hidden column contributes an empty source column (kept so column indices stay stable).
+        void EmitDecompose(string ind)
+        {
+            if (prop.SectionFormatterTypeName != null)
+                sb.AppendLine($"{ind}var __fmt = new {prop.SectionFormatterTypeName}();");
+            sb.AppendLine($"{ind}var __drows = new global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::Markout.MarkoutField>>>();");
+            sb.AppendLine($"{ind}foreach (var {itemVar} in {propAccess})");
+            sb.AppendLine($"{ind}{{");
+            sb.AppendLine($"{ind}    var __cols = new global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::Markout.MarkoutField>>();");
+            foreach (var p in visibleProps)
+            {
+                sb.AppendLine($"{ind}    {{");
+                sb.AppendLine($"{ind}        var __c = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+                var fill = p.Kind == PropertyKind.CompositeCell
+                    ? $"((global::Markout.IMarkoutCell?){itemVar}.{p.Name})?.Decompose(__c, \"{EmitHelpers.EscapeString(p.Name)}\", {EmitHelpers.CompositeCellFormatLiteral(p)});"
+                    : $"__c.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(p.Name)}\", {ScalarValue(p)}));";
+                if (TryDynamicCond(p, out var condVar))
+                    sb.AppendLine($"{ind}        if (!{condVar}) {fill}");
+                else
+                    sb.AppendLine($"{ind}        {fill}");
+                sb.AppendLine($"{ind}        __cols.Add(__c);");
+                sb.AppendLine($"{ind}    }}");
+            }
+            sb.AppendLine($"{ind}    __drows.Add(__cols);");
+            sb.AppendLine($"{ind}}}");
+            sb.AppendLine($"{ind}writer.WriteDecomposedRows(__drows);");
+        }
+
+        if (visibleProps.Any(p => p.Kind == PropertyKind.CompositeCell))
+        {
+            sb.AppendLine($"{indent}if (writer.DecomposesCompositeCells)");
+            sb.AppendLine($"{indent}{{");
+            EmitDecompose(indent + "    ");
+            sb.AppendLine($"{indent}}}");
+            sb.AppendLine($"{indent}else");
+            sb.AppendLine($"{indent}{{");
+            EmitDense(indent + "    ");
+            sb.AppendLine($"{indent}}}");
+        }
+        else
+        {
+            EmitDense(indent);
+        }
     }
 
     public static void EmitSubsectionPerItemSerialization(

--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -84,22 +84,26 @@ internal static class CollectionEmitter
         var di = indent + "    ";
         if (prop.SectionFormatterTypeName != null)
             sb.AppendLine($"{di}var __fmt = new {prop.SectionFormatterTypeName}();");
-        sb.AppendLine($"{di}var __drows = new global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::Markout.MarkoutField>>();");
+        sb.AppendLine($"{di}var __drows = new global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::Markout.MarkoutField>>>();");
         sb.AppendLine($"{di}foreach (var {itemVar} in {propAccess})");
         sb.AppendLine($"{di}{{");
-        sb.AppendLine($"{di}    var __df = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+        sb.AppendLine($"{di}    var __cols = new global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::Markout.MarkoutField>>();");
         foreach (var p in visibleProps)
         {
+            sb.AppendLine($"{di}    {{");
+            sb.AppendLine($"{di}        var __c = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
             if (p.Kind == PropertyKind.CompositeCell)
             {
-                sb.AppendLine($"{di}    ((global::Markout.IMarkoutCell?){itemVar}.{p.Name})?.Decompose(__df, \"{EmitHelpers.EscapeString(p.Name)}\", {EmitHelpers.CompositeCellFormatLiteral(p)});");
+                sb.AppendLine($"{di}        ((global::Markout.IMarkoutCell?){itemVar}.{p.Name})?.Decompose(__c, \"{EmitHelpers.EscapeString(p.Name)}\", {EmitHelpers.CompositeCellFormatLiteral(p)});");
             }
             else
             {
-                sb.AppendLine($"{di}    __df.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(p.Name)}\", {CellExpr(p)}));");
+                sb.AppendLine($"{di}        __c.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(p.Name)}\", {CellExpr(p)}));");
             }
+            sb.AppendLine($"{di}        __cols.Add(__c);");
+            sb.AppendLine($"{di}    }}");
         }
-        sb.AppendLine($"{di}    __drows.Add(__df);");
+        sb.AppendLine($"{di}    __drows.Add(__cols);");
         sb.AppendLine($"{di}}}");
         sb.AppendLine($"{di}writer.WriteDecomposedRows(__drows);");
         sb.AppendLine($"{indent}}}");

--- a/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/CollectionEmitter.cs
@@ -46,36 +46,67 @@ internal static class CollectionEmitter
         }));
         var headerNames = string.Join(", ", visibleProps.Select(p =>
             $"\"{EmitHelpers.EscapeString(p.Name)}\""));
-        sb.AppendLine($"{indent}writer.WriteTableStart(new string[] {{ {headers} }}, new string[] {{ {headerNames} }});");
 
-        // Instantiate formatter if configured
-        if (prop.SectionFormatterTypeName != null)
+        // Per-column dense value expression (formatted property override, else the cell value).
+        string CellExpr(PropertyMetadata p)
         {
-            sb.AppendLine($"{indent}var __fmt = new {prop.SectionFormatterTypeName}();");
+            if (p.Name == prop.SectionFormatProperty && prop.SectionFormatterTypeName != null)
+            {
+                var access = $"{itemVar}.{p.Name}";
+                return $"{access} != null ? __fmt.Format({access}) : \"\"";
+            }
+            return EmitHelpers.GetTableCellValue(p, itemVar);
         }
 
-        sb.AppendLine($"{indent}foreach (var {itemVar} in {propAccess})");
-        sb.AppendLine($"{indent}{{");
-
-        // Build row values
-        var values = new List<string>();
-        foreach (var elemProp in visibleProps)
+        void EmitDense(string ind)
         {
-            if (elemProp.Name == prop.SectionFormatProperty && prop.SectionFormatterTypeName != null)
+            sb.AppendLine($"{ind}writer.WriteTableStart(new string[] {{ {headers} }}, new string[] {{ {headerNames} }});");
+            if (prop.SectionFormatterTypeName != null)
+                sb.AppendLine($"{ind}var __fmt = new {prop.SectionFormatterTypeName}();");
+            sb.AppendLine($"{ind}foreach (var {itemVar} in {propAccess})");
+            sb.AppendLine($"{ind}{{");
+            var values = visibleProps.Select(CellExpr).ToList();
+            sb.AppendLine($"{ind}    writer.WriteTableRow({string.Join(", ", values)});");
+            sb.AppendLine($"{ind}}}");
+            sb.AppendLine($"{ind}writer.WriteTableEnd();");
+        }
+
+        // Scalar-only tables render identically to structured output as before; only tables with
+        // composite columns need a decompose branch (typed sub-columns for TSV/JSONL, dense otherwise).
+        if (!visibleProps.Any(p => p.Kind == PropertyKind.CompositeCell))
+        {
+            EmitDense(indent);
+            return;
+        }
+
+        sb.AppendLine($"{indent}if (writer.DecomposesCompositeCells)");
+        sb.AppendLine($"{indent}{{");
+        var di = indent + "    ";
+        if (prop.SectionFormatterTypeName != null)
+            sb.AppendLine($"{di}var __fmt = new {prop.SectionFormatterTypeName}();");
+        sb.AppendLine($"{di}var __drows = new global::System.Collections.Generic.List<global::System.Collections.Generic.List<global::Markout.MarkoutField>>();");
+        sb.AppendLine($"{di}foreach (var {itemVar} in {propAccess})");
+        sb.AppendLine($"{di}{{");
+        sb.AppendLine($"{di}    var __df = new global::System.Collections.Generic.List<global::Markout.MarkoutField>();");
+        foreach (var p in visibleProps)
+        {
+            if (p.Kind == PropertyKind.CompositeCell)
             {
-                var access = $"{itemVar}.{elemProp.Name}";
-                values.Add($"{access} != null ? __fmt.Format({access}) : \"\"");
+                sb.AppendLine($"{di}    ((global::Markout.IMarkoutCell?){itemVar}.{p.Name})?.Decompose(__df, \"{EmitHelpers.EscapeString(p.Name)}\", {EmitHelpers.CompositeCellFormatLiteral(p)});");
             }
             else
             {
-                var value = EmitHelpers.GetTableCellValue(elemProp, itemVar);
-                values.Add(value);
+                sb.AppendLine($"{di}    __df.Add(new global::Markout.MarkoutField(\"{EmitHelpers.EscapeString(p.Name)}\", {CellExpr(p)}));");
             }
         }
-
-        sb.AppendLine($"{indent}    writer.WriteTableRow({string.Join(", ", values)});");
+        sb.AppendLine($"{di}    __drows.Add(__df);");
+        sb.AppendLine($"{di}}}");
+        sb.AppendLine($"{di}writer.WriteDecomposedRows(__drows);");
         sb.AppendLine($"{indent}}}");
-        sb.AppendLine($"{indent}writer.WriteTableEnd();");
+        sb.AppendLine($"{indent}else");
+        sb.AppendLine($"{indent}{{");
+        EmitDense(indent + "    ");
+        sb.AppendLine($"{indent}}}");
     }
 
     /// <summary>

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -94,6 +94,14 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
                 fields.Add(new MarkoutField(CellText.SideKey(side, "direction"), DirectionText.Slug(compositeDir)));
                 fields.Add(new MarkoutField(CellText.SideKey(side, "status"), GateStatusText.Slug(compositeStatus)));
             }
+
+            // Caller delta-noun decomposes to a typed count + the noun word (caller metadata that is not
+            // derivable downstream), keeping structured output reconstructable.
+            if (format.DeltaNoun is not null && Before is IDeltaCountable beforeCount && After is IDeltaCountable afterCount)
+            {
+                fields.Add(new MarkoutField(CellText.SideKey(side, "deltaCount"), CellText.Number(afterCount.DeltaCount - beforeCount.DeltaCount)));
+                fields.Add(new MarkoutField(CellText.SideKey(side, "deltaNoun"), format.DeltaNoun));
+            }
             return;
         }
 
@@ -112,6 +120,12 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         {
             fields.Add(new MarkoutField(CellText.SideKey(side, "direction"), DirectionText.Slug(direction)));
             fields.Add(new MarkoutField(CellText.SideKey(side, "status"), GateStatusText.Slug(status)));
+        }
+
+        if (format.DeltaNoun is not null && CellText.TryScalarDouble(Before, out _) && CellText.TryScalarDouble(After, out _))
+        {
+            fields.Add(new MarkoutField(CellText.SideKey(side, "deltaCount"), CellText.AbsoluteDelta(Before, After, signed: false)));
+            fields.Add(new MarkoutField(CellText.SideKey(side, "deltaNoun"), format.DeltaNoun));
         }
     }
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -739,13 +739,18 @@ public class MarkoutWriter
 
     /// <summary>
     /// Writes an element table whose columns are already decomposed into typed fields (used by the
-    /// generated element-table path for decomposing formatters: each row's composite columns are
-    /// decomposed into <c>{column}_{sub}</c> fields, scalar columns into a single field). Columns are the
-    /// union of keys across rows in first-appearance order; a row missing a key renders blank.
+    /// generated element-table path for decomposing formatters). Each row is a list of <em>source
+    /// columns</em>, and each source column is the list of fields it contributed (a composite column
+    /// decomposes into <c>{column}_{sub}</c> fields; a scalar column contributes a single field; a null
+    /// composite contributes none). Output columns are identified by <c>(source-column index, field key)</c>
+    /// so a scalar column whose key collides with a composite subfield keeps its own column regardless of
+    /// whether the composite is present in a given row. Columns appear in first-appearance order across rows;
+    /// a row that omits a column renders blank. Display headers are the raw field keys, snake_cased and
+    /// de-duplicated.
     /// </summary>
-    /// <param name="rows">Per-row decomposed fields (one list per element row).</param>
+    /// <param name="rows">Per-row source columns, each source column being its decomposed fields.</param>
     /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
-    public bool WriteDecomposedRows(IReadOnlyList<IReadOnlyList<MarkoutField>> rows)
+    public bool WriteDecomposedRows(IReadOnlyList<IReadOnlyList<IReadOnlyList<MarkoutField>>> rows)
     {
         if (_sectionExcluded || rows.Count == 0)
             return true;
@@ -754,29 +759,32 @@ public class MarkoutWriter
             return false;
 
         var keyOrder = new List<string>();
-        var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
-        // Resolve each row's fields to columns. Keys that repeat WITHIN a row (e.g. a scalar column named
-        // "x_before" colliding with composite column "x"'s "x_before" subfield) get distinct columns so no
-        // field is silently dropped; the raw key stays the display header (snake_case dedupe below makes the
-        // emitted column names distinct). Heterogeneous rows with unique keys are unaffected.
+        var keyIndex = new Dictionary<(int Column, string Key), int>();
+        // Column identity is (source-column index, field key), not the raw key alone. The source-column
+        // index is stable across rows (every row emits the same source columns in order, even when a
+        // nullable composite contributes no fields), so a scalar column whose key collides with a composite
+        // subfield keeps its own output column in every row. Within a source column, keys are unique.
         var resolvedRows = new List<(int Col, string Value)[]>(rows.Count);
         foreach (var row in rows)
         {
-            var seen = new Dictionary<string, int>(StringComparer.Ordinal);
-            var resolved = new (int, string)[row.Count];
-            for (int i = 0; i < row.Count; i++)
+            var count = 0;
+            foreach (var column in row)
+                count += column.Count;
+            var resolved = new (int, string)[count];
+            var n = 0;
+            for (int ci = 0; ci < row.Count; ci++)
             {
-                var field = row[i];
-                int occurrence = seen.TryGetValue(field.Key, out var c) ? c + 1 : 1;
-                seen[field.Key] = occurrence;
-                var resolvedKey = occurrence == 1 ? field.Key : field.Key + "\0" + occurrence;
-                if (!keyIndex.TryGetValue(resolvedKey, out var col))
+                foreach (var field in row[ci])
                 {
-                    col = keyOrder.Count;
-                    keyIndex[resolvedKey] = col;
-                    keyOrder.Add(field.Key);
+                    var id = (ci, field.Key);
+                    if (!keyIndex.TryGetValue(id, out var col))
+                    {
+                        col = keyOrder.Count;
+                        keyIndex[id] = col;
+                        keyOrder.Add(field.Key);
+                    }
+                    resolved[n++] = (col, field.Value);
                 }
-                resolved[i] = (col, field.Value);
             }
             resolvedRows.Add(resolved);
         }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -63,6 +63,14 @@ public class MarkoutWriter
     public MarkoutWriterOptions Options => _options;
 
     /// <summary>
+    /// Whether the active formatter decomposes composite cells into typed columns (TSV/JSONL). Element-table
+    /// serialization uses this to decompose composite columns into typed sub-columns for structured output
+    /// while keeping the dense string for document formatters.
+    /// </summary>
+    public bool DecomposesCompositeCells
+        => _formatter is Formatting.ICompositeCellFormatter { DecomposesCompositeCells: true };
+
+    /// <summary>
     /// Gets whether descriptions should be included in output.
     /// </summary>
     public bool IncludeDescription => _options.IncludeDescription;
@@ -730,7 +738,62 @@ public class MarkoutWriter
     }
 
     /// <summary>
-    /// Writes a gated-metric table from <see cref="MetricChange{T}"/> rows: document formatters
+    /// Writes an element table whose columns are already decomposed into typed fields (used by the
+    /// generated element-table path for decomposing formatters: each row's composite columns are
+    /// decomposed into <c>{column}_{sub}</c> fields, scalar columns into a single field). Columns are the
+    /// union of keys across rows in first-appearance order; a row missing a key renders blank.
+    /// </summary>
+    /// <param name="rows">Per-row decomposed fields (one list per element row).</param>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support tables.</returns>
+    public bool WriteDecomposedRows(IReadOnlyList<IReadOnlyList<MarkoutField>> rows)
+    {
+        if (_sectionExcluded || rows.Count == 0)
+            return true;
+
+        if (_formatter is not ITableFormatter and not IStreamingTableFormatter)
+            return false;
+
+        var keyOrder = new List<string>();
+        var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var row in rows)
+            foreach (var field in row)
+                if (keyIndex.TryAdd(field.Key, keyOrder.Count))
+                    keyOrder.Add(field.Key);
+
+        var headers = new string[keyOrder.Count];
+        var headerNames = new string[keyOrder.Count];
+        var usedStableKeys = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < keyOrder.Count; i++)
+        {
+            headers[i] = keyOrder[i];
+            var stable = Formatting.FormatHelper.ToSnakeCase(keyOrder[i]);
+            if (string.IsNullOrEmpty(stable))
+                stable = "column";
+            if (!usedStableKeys.Add(stable))
+            {
+                int suffix = 2;
+                string candidate;
+                do { candidate = stable + "_" + suffix++; } while (!usedStableKeys.Add(candidate));
+                stable = candidate;
+            }
+            headerNames[i] = stable;
+        }
+
+        var outRows = new List<string[]>(rows.Count);
+        foreach (var row in rows)
+        {
+            var values = new string[keyOrder.Count];
+            for (int i = 0; i < values.Length; i++)
+                values[i] = "";
+            foreach (var field in row)
+                if (keyIndex.TryGetValue(field.Key, out var idx))
+                    values[idx] = field.Value;
+            outRows.Add(values);
+        }
+
+        return WriteTable(headers, headerNames, outRows);
+    }
+
     /// render fixed <c>Metric | Change | Target | Status</c> columns; decomposing formatters
     /// (TSV/JSONL) emit flat typed fields (<c>before</c>, <c>after</c>, optional <c>target</c>/
     /// <c>target_label</c>, <c>status</c>). Absent targets render <c>-</c> and are omitted from

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -755,10 +755,31 @@ public class MarkoutWriter
 
         var keyOrder = new List<string>();
         var keyIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        // Resolve each row's fields to columns. Keys that repeat WITHIN a row (e.g. a scalar column named
+        // "x_before" colliding with composite column "x"'s "x_before" subfield) get distinct columns so no
+        // field is silently dropped; the raw key stays the display header (snake_case dedupe below makes the
+        // emitted column names distinct). Heterogeneous rows with unique keys are unaffected.
+        var resolvedRows = new List<(int Col, string Value)[]>(rows.Count);
         foreach (var row in rows)
-            foreach (var field in row)
-                if (keyIndex.TryAdd(field.Key, keyOrder.Count))
+        {
+            var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+            var resolved = new (int, string)[row.Count];
+            for (int i = 0; i < row.Count; i++)
+            {
+                var field = row[i];
+                int occurrence = seen.TryGetValue(field.Key, out var c) ? c + 1 : 1;
+                seen[field.Key] = occurrence;
+                var resolvedKey = occurrence == 1 ? field.Key : field.Key + "\0" + occurrence;
+                if (!keyIndex.TryGetValue(resolvedKey, out var col))
+                {
+                    col = keyOrder.Count;
+                    keyIndex[resolvedKey] = col;
                     keyOrder.Add(field.Key);
+                }
+                resolved[i] = (col, field.Value);
+            }
+            resolvedRows.Add(resolved);
+        }
 
         var headers = new string[keyOrder.Count];
         var headerNames = new string[keyOrder.Count];
@@ -780,14 +801,13 @@ public class MarkoutWriter
         }
 
         var outRows = new List<string[]>(rows.Count);
-        foreach (var row in rows)
+        foreach (var resolved in resolvedRows)
         {
             var values = new string[keyOrder.Count];
             for (int i = 0; i < values.Length; i++)
                 values[i] = "";
-            foreach (var field in row)
-                if (keyIndex.TryGetValue(field.Key, out var idx))
-                    values[idx] = field.Value;
+            foreach (var (col, value) in resolved)
+                values[col] = value;
             outRows.Add(values);
         }
 

--- a/tests/Markout.Tests/DecomposedElementTableTests.cs
+++ b/tests/Markout.Tests/DecomposedElementTableTests.cs
@@ -52,6 +52,30 @@ public partial class ScalarElementCardContext : MarkoutSerializerContext
 {
 }
 
+// Reconstruction target: string columns matching the original card's headers, so re-serializing the
+// reconstructed dense cells yields the same Markdown document (same title/section/headers/widths).
+public class ReconstructedRow
+{
+    public string Name { get; set; } = "";
+    public string Score { get; set; } = "";
+    public string Tasks { get; set; } = "";
+    public string Bugs { get; set; } = "";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ReconstructedCard
+{
+    [MarkoutIgnore] public string Title => "Rows";
+
+    [MarkoutSection(Name = "Rows")]
+    public List<ReconstructedRow> Rows { get; set; } = new();
+}
+
+[MarkoutContext(typeof(ReconstructedCard))]
+public partial class ReconstructedCardContext : MarkoutSerializerContext
+{
+}
+
 public class DecomposedElementTableTests
 {
     private static DecomposedElementCard Card() => new()
@@ -132,5 +156,50 @@ public class DecomposedElementTableTests
         var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
         Assert.Equal("x", row.GetProperty("name").GetString());
         Assert.Equal(3, row.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public void MarkdownCard_IsByteForByteReconstructableFromJson()
+    {
+        // The reconstructable-JSON contract: rebuild the dense Markdown card from the JSON fields alone
+        // (a hard-coded algorithm that re-applies Markout's display formatting), and require it to be
+        // byte-for-byte identical to the directly-rendered Markdown. This proves the JSON carries all the
+        // data (raw + derived judgement + caller metadata) needed to reconstruct the card.
+        var card = Card();
+        var markdown = MarkoutSerializer.Serialize(card, DecomposedElementCardContext.Default);
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), DecomposedElementCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var records = sw.ToString().ReplaceLineEndings("\n")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => JsonDocument.Parse(l).RootElement)
+            .ToList();
+
+        const string arrow = " \u2192 ";
+        static string SignedPct(int pct) => (pct > 0 ? "+" : "") + pct + "%";
+        static string Signed(int n) => (n > 0 ? "+" : "") + n;
+
+        var reconstructed = new ReconstructedCard
+        {
+            Rows = records.Select(r => new ReconstructedRow
+            {
+                Name = r.GetProperty("name").GetString()!,
+                // score: [MarkoutDelta(Percent)] -> "before → after (±pct%)"
+                Score = r.GetProperty("score_before").GetInt64() + arrow + r.GetProperty("score_after").GetInt64()
+                    + " (" + SignedPct(r.GetProperty("score_delta_pct").GetInt32()) + ")",
+                // tasks: [MarkoutDeltaNoun] -> "bc/bt → ac/at (±count noun)"
+                Tasks = r.GetProperty("tasks_before_count").GetInt32() + "/" + r.GetProperty("tasks_before_total").GetInt32()
+                    + arrow + r.GetProperty("tasks_after_count").GetInt32() + "/" + r.GetProperty("tasks_after_total").GetInt32()
+                    + " (" + Signed(r.GetProperty("tasks_delta_count").GetInt32()) + " " + r.GetProperty("tasks_delta_noun").GetString() + ")",
+                // bugs: [MarkoutGoal] -> "before → after (status)"
+                Bugs = r.GetProperty("bugs_before").GetInt32() + arrow + r.GetProperty("bugs_after").GetInt32()
+                    + " (" + r.GetProperty("bugs_status").GetString() + ")",
+            }).ToList(),
+        };
+
+        var reconstructedMarkdown = MarkoutSerializer.Serialize(reconstructed, ReconstructedCardContext.Default);
+
+        Assert.Equal(markdown, reconstructedMarkdown);
     }
 }

--- a/tests/Markout.Tests/DecomposedElementTableTests.cs
+++ b/tests/Markout.Tests/DecomposedElementTableTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using Markout;
+
+namespace Markout.Tests;
+
+public class DecomposedElementRow
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutDelta(Delta.Percent)]
+    public Change<long> Score { get; set; }
+
+    [MarkoutDeltaNoun("solved")]
+    public Change<Fraction> Tasks { get; set; }
+
+    [MarkoutGoal(Goal.Lower)]
+    public Change<int> Bugs { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class DecomposedElementCard
+{
+    [MarkoutIgnore] public string Title => "Rows";
+
+    [MarkoutSection(Name = "Rows")]
+    public List<DecomposedElementRow> Rows { get; set; } = new();
+}
+
+[MarkoutContext(typeof(DecomposedElementCard))]
+public partial class DecomposedElementCardContext : MarkoutSerializerContext
+{
+}
+
+// A scalar-only element table (regression guard: no decompose branch, unchanged output).
+public class ScalarElementRow
+{
+    public string Name { get; set; } = "";
+    public int Count { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ScalarElementCard
+{
+    [MarkoutIgnore] public string Title => "Items";
+
+    [MarkoutSection(Name = "Items")]
+    public List<ScalarElementRow> Items { get; set; } = new();
+}
+
+[MarkoutContext(typeof(ScalarElementCard))]
+public partial class ScalarElementCardContext : MarkoutSerializerContext
+{
+}
+
+public class DecomposedElementTableTests
+{
+    private static DecomposedElementCard Card() => new()
+    {
+        Rows =
+        [
+            new DecomposedElementRow
+            {
+                Name = "a", Score = new(100, 50),
+                Tasks = new(new Fraction(4, 6), new Fraction(6, 6)), Bugs = new(7, 0),
+            },
+        ],
+    };
+
+    [Fact]
+    public void Markdown_KeepsDenseCompositeColumns()
+    {
+        var md = MarkoutSerializer.Serialize(Card(), DecomposedElementCardContext.Default);
+
+        Assert.Contains("| Name | Score | Tasks | Bugs |", md);
+        Assert.Contains("| a | 100 \u2192 50 (-50%) | 4/6 \u2192 6/6 (+2 solved) | 7 \u2192 0 (good) |", md);
+    }
+
+    [Fact]
+    public void Jsonl_DecomposesCompositeColumnsIntoTypedPrefixedFields()
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(Card(), sw, new TableFormatter(), DecomposedElementCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
+
+        Assert.Equal("a", row.GetProperty("name").GetString());
+        // score ([MarkoutDelta]) -> before/after/delta_pct
+        Assert.Equal(100, row.GetProperty("score_before").GetInt32());
+        Assert.Equal(50, row.GetProperty("score_after").GetInt32());
+        Assert.Equal(-50, row.GetProperty("score_delta_pct").GetInt32());
+        // tasks ([MarkoutDeltaNoun]) -> parts + delta_count + delta_noun
+        Assert.Equal(4, row.GetProperty("tasks_before_count").GetInt32());
+        Assert.Equal(6, row.GetProperty("tasks_after_count").GetInt32());
+        Assert.Equal(2, row.GetProperty("tasks_delta_count").GetInt32());
+        Assert.Equal("solved", row.GetProperty("tasks_delta_noun").GetString());
+        // bugs ([MarkoutGoal]) -> before/after/direction/status
+        Assert.Equal(7, row.GetProperty("bugs_before").GetInt32());
+        Assert.Equal(0, row.GetProperty("bugs_after").GetInt32());
+        Assert.Equal("resolved", row.GetProperty("bugs_direction").GetString());
+        Assert.Equal("good", row.GetProperty("bugs_status").GetString());
+        // The dense string must NOT appear as a value.
+        Assert.False(row.TryGetProperty("score", out _));
+    }
+
+    [Fact]
+    public void Tsv_DecomposesToUnionColumns()
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(Card(), sw, new TableFormatter(), DecomposedElementCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv });
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var header = lines[0];
+
+        Assert.Contains("score_before", header);
+        Assert.Contains("bugs_status", header);
+        Assert.Contains("tasks_delta_noun", header);
+        Assert.DoesNotContain("\tscore\t", "\t" + header + "\t"); // no dense composite column
+    }
+
+    [Fact]
+    public void ScalarOnlyTable_Unchanged()
+    {
+        var card = new ScalarElementCard { Items = [new ScalarElementRow { Name = "x", Count = 3 }] };
+
+        var md = MarkoutSerializer.Serialize(card, ScalarElementCardContext.Default);
+        Assert.Contains("| Name | Count |", md);
+        Assert.Contains("| x | 3 |", md);
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), ScalarElementCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
+        Assert.Equal("x", row.GetProperty("name").GetString());
+        Assert.Equal(3, row.GetProperty("count").GetInt32());
+    }
+}

--- a/tests/Markout.Tests/DecomposedElementTableTests.cs
+++ b/tests/Markout.Tests/DecomposedElementTableTests.cs
@@ -102,6 +102,32 @@ public partial class CollisionCardContext : MarkoutSerializerContext
 {
 }
 
+// Same collision, but the composite column is nullable so it contributes no fields in rows where it is
+// null. Guards that the scalar column stays in one output column across rows (no cross-row source mixing).
+public class NullableCollisionRow
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutDelta(Delta.Percent)]
+    public Change<long>? Score { get; set; }
+
+    public long Score_before { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class NullableCollisionCard
+{
+    [MarkoutIgnore] public string Title => "Rows";
+
+    [MarkoutSection(Name = "Rows")]
+    public List<NullableCollisionRow> Rows { get; set; } = new();
+}
+
+[MarkoutContext(typeof(NullableCollisionCard))]
+public partial class NullableCollisionCardContext : MarkoutSerializerContext
+{
+}
+
 public class DecomposedElementTableTests
 {
     private static DecomposedElementCard Card() => new()
@@ -202,6 +228,40 @@ public class DecomposedElementTableTests
 
         Assert.Equal(100, row.GetProperty("score_before").GetInt64());
         Assert.Equal(999, row.GetProperty("score_before_2").GetInt64());
+    }
+
+    [Fact]
+    public void NullableCompositeAbsentInSomeRows_ScalarColumnStaysAligned()
+    {
+        // Row 1's composite is null (contributes no fields); row 2's is present. The scalar "Score_before"
+        // must stay in a single output column across BOTH rows — never landing in the composite's column
+        // just because the composite was absent in row 1. Column identity is per source column, not per-row
+        // occurrence, so the two sources never mix.
+        var card = new NullableCollisionCard
+        {
+            Rows =
+            [
+                new NullableCollisionRow { Name = "a", Score = null, Score_before = 999 },
+                new NullableCollisionRow { Name = "b", Score = new Change<long>(100, 50), Score_before = 888 },
+            ],
+        };
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), NullableCollisionCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var r0 = JsonDocument.Parse(lines[0]).RootElement;
+        var r1 = JsonDocument.Parse(lines[1]).RootElement;
+
+        // The scalar column is stable across rows (established first, so it owns "score_before").
+        Assert.Equal(999, r0.GetProperty("score_before").GetInt64());
+        Assert.Equal(888, r1.GetProperty("score_before").GetInt64());
+        // The composite's before value lives in its own separate column, present only when the composite is.
+        Assert.Equal(100, r1.GetProperty("score_before_2").GetInt64());
+        // Row 0 has no composite, so its own separate column carries no numeric value.
+        bool row0HasCompositeValue = r0.TryGetProperty("score_before_2", out var v)
+            && v.ValueKind is JsonValueKind.Number;
+        Assert.False(row0HasCompositeValue, "row 0 must not carry a composite before value");
     }
 
     [Fact]

--- a/tests/Markout.Tests/DecomposedElementTableTests.cs
+++ b/tests/Markout.Tests/DecomposedElementTableTests.cs
@@ -76,6 +76,32 @@ public partial class ReconstructedCardContext : MarkoutSerializerContext
 {
 }
 
+// Pathological naming: a scalar column whose name equals a composite column's decomposed subkey
+// ("Score" -> "Score_before"). Guards that both survive as distinct columns (no silent overwrite).
+public class CollisionRow
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutDelta(Delta.Percent)]
+    public Change<long> Score { get; set; }
+
+    public long Score_before { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class CollisionCard
+{
+    [MarkoutIgnore] public string Title => "Rows";
+
+    [MarkoutSection(Name = "Rows")]
+    public List<CollisionRow> Rows { get; set; } = new();
+}
+
+[MarkoutContext(typeof(CollisionCard))]
+public partial class CollisionCardContext : MarkoutSerializerContext
+{
+}
+
 public class DecomposedElementTableTests
 {
     private static DecomposedElementCard Card() => new()
@@ -156,6 +182,26 @@ public class DecomposedElementTableTests
         var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
         Assert.Equal("x", row.GetProperty("name").GetString());
         Assert.Equal(3, row.GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public void CompositeSubkeyCollidingWithScalarColumn_KeepsBothColumns()
+    {
+        // The composite "Score" decomposes to "score_before"; a sibling scalar column is also named
+        // "Score_before". Both must survive: the later one is disambiguated to "score_before_2" rather
+        // than silently overwriting the first (which would violate the reconstructable-JSON contract).
+        var card = new CollisionCard
+        {
+            Rows = [new CollisionRow { Name = "a", Score = new(100, 50), Score_before = 999 }],
+        };
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), CollisionCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var row = JsonDocument.Parse(sw.ToString().Trim()).RootElement;
+
+        Assert.Equal(100, row.GetProperty("score_before").GetInt64());
+        Assert.Equal(999, row.GetProperty("score_before_2").GetInt64());
     }
 
     [Fact]

--- a/tests/Markout.Tests/DecomposedElementTableTests.cs
+++ b/tests/Markout.Tests/DecomposedElementTableTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using Markout;
 
@@ -125,6 +126,39 @@ public class NullableCollisionCard
 
 [MarkoutContext(typeof(NullableCollisionCard))]
 public partial class NullableCollisionCardContext : MarkoutSerializerContext
+{
+}
+
+// Element table combining [MarkoutIgnoreColumnWhen] (dynamic-ignore path) with composite columns:
+// composite columns must still decompose for structured formatters while dynamic hidden columns drop out.
+public class DynIgnoreRow
+{
+    public string Name { get; set; } = "";
+
+    [MarkoutDelta(Delta.Percent)]
+    public Change<long> Score { get; set; }
+
+    [MarkoutGoal(Goal.Lower)]
+    public Change<int> Bugs { get; set; }
+
+    public string Note { get; set; } = "";
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+public class DynIgnoreCard
+{
+    [MarkoutIgnore] public string Title => "Rows";
+
+    [MarkoutSection(Name = "Rows")]
+    [MarkoutIgnoreColumnWhen(nameof(NoteIsUniform), "Note")]
+    public List<DynIgnoreRow> Rows { get; set; } = new();
+
+    public static bool NoteIsUniform(List<DynIgnoreRow> rows)
+        => rows.Select(r => r.Note).Distinct().Count() <= 1;
+}
+
+[MarkoutContext(typeof(DynIgnoreCard))]
+public partial class DynIgnoreCardContext : MarkoutSerializerContext
 {
 }
 
@@ -262,6 +296,67 @@ public class DecomposedElementTableTests
         bool row0HasCompositeValue = r0.TryGetProperty("score_before_2", out var v)
             && v.ValueKind is JsonValueKind.Number;
         Assert.False(row0HasCompositeValue, "row 0 must not carry a composite before value");
+    }
+
+    [Fact]
+    public void DynamicIgnoreTable_DecomposesCompositesAndDropsHiddenColumn()
+    {
+        // Uniform Note -> the "Note" column is dynamically ignored. Composite columns must still decompose
+        // (Score/Bugs -> typed sub-fields) in structured output, and Markdown stays dense with Note dropped.
+        var card = new DynIgnoreCard
+        {
+            Rows =
+            [
+                new DynIgnoreRow { Name = "a", Score = new(100, 50), Bugs = new(7, 0), Note = "x" },
+                new DynIgnoreRow { Name = "b", Score = new(40, 60), Bugs = new(2, 5), Note = "x" },
+            ],
+        };
+
+        var md = MarkoutSerializer.Serialize(card, DynIgnoreCardContext.Default);
+        Assert.Contains("| Name | Score | Bugs |", md);          // Note dropped (uniform)
+        Assert.Contains("| a | 100 \u2192 50 (-50%) | 7 \u2192 0 (good) |", md);
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), DynIgnoreCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var r0 = JsonDocument.Parse(sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0]).RootElement;
+
+        // Composites decomposed, not dense strings.
+        Assert.Equal(100, r0.GetProperty("score_before").GetInt64());
+        Assert.Equal(50, r0.GetProperty("score_after").GetInt64());
+        Assert.Equal(-50, r0.GetProperty("score_delta_pct").GetInt32());
+        Assert.Equal(7, r0.GetProperty("bugs_before").GetInt32());
+        Assert.Equal(0, r0.GetProperty("bugs_after").GetInt32());
+        Assert.Equal("good", r0.GetProperty("bugs_status").GetString());
+        Assert.False(r0.TryGetProperty("score", out _), "composite must not leak a dense 'score' field");
+        // Hidden column absent from structured output too.
+        Assert.False(r0.TryGetProperty("note", out _), "uniform Note column must be dropped");
+    }
+
+    [Fact]
+    public void DynamicIgnoreTable_KeepsVaryingColumnAlongsideDecomposedComposites()
+    {
+        // Note varies -> the column is kept; composites still decompose.
+        var card = new DynIgnoreCard
+        {
+            Rows =
+            [
+                new DynIgnoreRow { Name = "a", Score = new(100, 50), Bugs = new(7, 0), Note = "x" },
+                new DynIgnoreRow { Name = "b", Score = new(40, 60), Bugs = new(2, 5), Note = "y" },
+            ],
+        };
+
+        var md = MarkoutSerializer.Serialize(card, DynIgnoreCardContext.Default);
+        Assert.Contains("| Name | Score | Bugs | Note |", md);
+
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(card, sw, new TableFormatter(), DynIgnoreCardContext.Default,
+            new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl, JsonTypedValues = true });
+        var r0 = JsonDocument.Parse(sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0]).RootElement;
+
+        Assert.Equal(100, r0.GetProperty("score_before").GetInt64());
+        Assert.Equal("good", r0.GetProperty("bugs_status").GetString());
+        Assert.Equal("x", r0.GetProperty("note").GetString());
     }
 
     [Fact]

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -572,12 +572,26 @@ public class GoalAwareCellTests
     }
 
     [Fact]
-    public void Change_DeltaNoun_IsMarkdownOnly_DecomposeUnaffected()
+    public void Change_DeltaNoun_DecomposesToCountAndNoun()
     {
+        // Delta-noun is now structured too (reconstructable contract): scalar count delta + the noun.
         var fields = Decompose(new Change<long>(4, 6), new MarkoutCellFormat { DeltaNoun = "solved" });
-        Assert.DoesNotContain(fields, f => f.Value.Contains("solved"));
         Assert.Equal("4", fields.Single(f => f.Key == "before").Value);
         Assert.Equal("6", fields.Single(f => f.Key == "after").Value);
+        Assert.Equal("2", fields.Single(f => f.Key == "deltaCount").Value);
+        Assert.Equal("solved", fields.Single(f => f.Key == "deltaNoun").Value);
+    }
+
+    [Fact]
+    public void Change_DeltaNoun_Fraction_DecomposesCountDeltaAndNoun()
+    {
+        // Composite delta-noun: count delta from IDeltaCountable + the noun, alongside the parts.
+        var fields = Decompose(new Change<Fraction>(new Fraction(4, 6), new Fraction(6, 6)),
+            new MarkoutCellFormat { DeltaNoun = "solved" });
+        Assert.Equal("4", fields.Single(f => f.Key == "before_count").Value);
+        Assert.Equal("6", fields.Single(f => f.Key == "after_count").Value);
+        Assert.Equal("2", fields.Single(f => f.Key == "deltaCount").Value);
+        Assert.Equal("solved", fields.Single(f => f.Key == "deltaNoun").Value);
     }
 
     // --- Attribute path (source generator) ---


### PR DESCRIPTION
Implements #139 (**Option B** — "the card should be reconstructable from the JSON/JSONL"). Structured formatters (TSV/JSONL) only; Markdown unchanged.

## What changed

**Part 1 — delta-noun becomes structured.** `[MarkoutDeltaNoun]` was Markdown-only; `Change<V>.Decompose` now also emits a typed `delta_count` and the caller `delta_noun` (scalar and composite `IDeltaCountable` paths) — caller metadata that isn't derivable downstream. Applies everywhere decomposition runs (cards, `MultiSourceRow`, element tables).

**Part 2 — element-table composite columns decompose.** A composite cell used as a column of a `List<T>` element table previously rendered its dense Markdown string into TSV/JSONL. For decomposing formatters, the generated element-table path now decomposes each composite column into typed `{column}_{sub}` fields, prefixed by the column name, via the shared `Change<V>.Decompose`.

- `MarkoutWriter.DecomposesCompositeCells` (public formatter signal) + `WriteDecomposedRows` (buffers rows, builds the column union, emits typed columns).
- `CollectionEmitter.EmitTableSerialization` emits a runtime **decompose/dense branch** only when composite columns are present — scalar-only tables and Markdown are untouched.

## Result

Markdown (unchanged):
```md
| Name | Score | Tasks | Bugs |
| a | 100 → 50 (-50%) | 4/6 → 6/6 (+2 solved) | 7 → 0 (good) |
```

JSONL (`JsonTypedValues`):
```json
{"name":"a","score_before":100,"score_after":50,"score_delta_pct":-50,"tasks_before_count":4,"tasks_before_total":6,"tasks_after_count":6,"tasks_after_total":6,"tasks_delta_count":2,"tasks_delta_noun":"solved","bugs_before":7,"bugs_after":0,"bugs_direction":"resolved","bugs_status":"good"}
```

Meets the consumer's four requirements: column-prefixed subfields, Markdown dense unchanged, `delta_noun` kept structured, and the same `Change<V>.Decompose` used by cards / `MultiSourceRow`.

## Scope

The primary `List<T>` element-table path. The dynamic-ignore / grouped / subsection table variants keep their existing dense behavior (documented follow-up; not a regression — they were dense before).

## Tests

Updated the #137 delta-noun Markdown-only test to the new structured behavior; 4 new element-table tests (Markdown dense, JSONL typed decomposition, TSV union, scalar-only unchanged). **668 total green** (+236 MarkdownTable, +59 Templates). No version bump (batched per maintainer). grounding AGENTS.md updated.

Adversarial review (GPT-5.5 + Gemini 3.1 Pro) to two cleans — record to follow.
