### PR TITLE
Render a lone scalar Metric/Breakdown property as its bar shape

### DIFF
--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -625,12 +625,25 @@ internal static class SerializerEmitter
         }
         else if (prop.Kind == PropertyKind.Metric)
         {
-            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-            sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
-            sb.AppendLine($"{indent}    writer.WriteMetrics({propAccess});");
-            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
-            sb.AppendLine($"{indent}}}");
+            if (prop.IsScalarShape)
+            {
+                var (guard, value) = ScalarShapeAccess(prop, propAccess);
+                sb.AppendLine($"{indent}if ({guard})");
+                sb.AppendLine($"{indent}{{");
+                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+                sb.AppendLine($"{indent}    writer.WriteMetrics(new[] {{ {value} }});");
+                sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+                sb.AppendLine($"{indent}}}");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}{{");
+                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+                sb.AppendLine($"{indent}    writer.WriteMetrics({propAccess});");
+                sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+                sb.AppendLine($"{indent}}}");
+            }
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.Description)
@@ -645,12 +658,25 @@ internal static class SerializerEmitter
         }
         else if (prop.Kind == PropertyKind.Breakdown)
         {
-            sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-            sb.AppendLine($"{indent}{{");
-            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
-            sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
-            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
-            sb.AppendLine($"{indent}}}");
+            if (prop.IsScalarShape)
+            {
+                var (guard, value) = ScalarShapeAccess(prop, propAccess);
+                sb.AppendLine($"{indent}if ({guard})");
+                sb.AppendLine($"{indent}{{");
+                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+                sb.AppendLine($"{indent}    writer.WriteBreakdown(new[] {{ {value} }});");
+                sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+                sb.AppendLine($"{indent}}}");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                sb.AppendLine($"{indent}{{");
+                sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+                sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
+                sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+                sb.AppendLine($"{indent}}}");
+            }
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
         else if (prop.Kind == PropertyKind.MetricChange)
@@ -752,6 +778,19 @@ internal static class SerializerEmitter
         return name;
     }
 
+    // Builds the (guard, value) pair for a scalar Metric/Breakdown property so it renders as its
+    // bar shape via the single-item list overload. Nullable value types guard on HasValue and read
+    // .Value; the shape guard skips a default/empty struct (avoids CS8073 value-type null checks).
+    private static (string Guard, string Value) ScalarShapeAccess(PropertyMetadata prop, string propAccess)
+    {
+        var value = prop.IsNullableValueType ? $"{propAccess}.Value" : propAccess;
+        var shapeGuard = prop.Kind == PropertyKind.Breakdown
+            ? $"{value}.Slices is not null && {value}.Slices.Length > 0"
+            : $"{value}.Label is not null";
+        var guard = prop.IsNullableValueType ? $"{propAccess}.HasValue && {shapeGuard}" : shapeGuard;
+        return (guard, value);
+    }
+
     private static void EmitSectionEmptyFallback(
         StringBuilder sb,
         PropertyMetadata prop,
@@ -800,8 +839,17 @@ internal static class SerializerEmitter
                 break;
 
             case PropertyKind.Metric:
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                sb.AppendLine($"{indent}    writer.WriteMetrics({propAccess});");
+                if (prop.IsScalarShape)
+                {
+                    var (mGuard, mValue) = ScalarShapeAccess(prop, propAccess);
+                    sb.AppendLine($"{indent}if ({mGuard})");
+                    sb.AppendLine($"{indent}    writer.WriteMetrics(new[] {{ {mValue} }});");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                    sb.AppendLine($"{indent}    writer.WriteMetrics({propAccess});");
+                }
                 break;
 
             case PropertyKind.Description:
@@ -824,8 +872,17 @@ internal static class SerializerEmitter
                 break;
 
             case PropertyKind.Breakdown:
-                sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
-                sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
+                if (prop.IsScalarShape)
+                {
+                    var (bGuard, bValue) = ScalarShapeAccess(prop, propAccess);
+                    sb.AppendLine($"{indent}if ({bGuard})");
+                    sb.AppendLine($"{indent}    writer.WriteBreakdown(new[] {{ {bValue} }});");
+                }
+                else
+                {
+                    sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
+                    sb.AppendLine($"{indent}    writer.WriteBreakdown({propAccess});");
+                }
                 break;
 
             case PropertyKind.MetricChange:

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -166,6 +166,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     public string? BoolFalseValue { get; }
     public bool IsNullableValueType { get; }
     public bool IsArray { get; }
+    // A lone Metric/Breakdown property (not a List<T>) that still renders as its bar shape.
+    public bool IsScalarShape { get; }
     public string? CustomFormat { get; }
     public string? JoinSeparator { get; }
     public bool SkipWhenDefault { get; }
@@ -242,7 +244,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         string? multiSourceLabelHeader = null,
         MarkoutGoalKind goal = MarkoutGoalKind.Context,
         double noise = 0,
-        string? deltaNoun = null)
+        string? deltaNoun = null,
+        bool isScalarShape = false)
     {
         Name = name;
         DisplayName = displayName;
@@ -275,6 +278,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         BoolFalseValue = boolFalseValue;
         IsNullableValueType = isNullableValueType;
         IsArray = isArray;
+        IsScalarShape = isScalarShape;
         CustomFormat = customFormat;
         JoinSeparator = joinSeparator;
         SkipWhenDefault = skipWhenDefault;
@@ -333,6 +337,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                BoolFalseValue == other.BoolFalseValue &&
                IsNullableValueType == other.IsNullableValueType &&
                IsArray == other.IsArray &&
+               IsScalarShape == other.IsScalarShape &&
                CustomFormat == other.CustomFormat &&
                JoinSeparator == other.JoinSeparator &&
                SkipWhenDefault == other.SkipWhenDefault &&
@@ -396,6 +401,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ (int)Goal;
             hash = hash * 397 ^ Noise.GetHashCode();
             hash = hash * 397 ^ (DeltaNoun?.GetHashCode() ?? 0);
+            hash = hash * 397 ^ IsScalarShape.GetHashCode();
             hash = hash * 397 ^ IsReferenceTypeCell.GetHashCode();
             hash = hash * 397 ^ (MultiSourceLabelHeader?.GetHashCode() ?? 0);
             return hash;

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -519,6 +519,19 @@ internal static class TypeParser
         bool isJoinedArray = joinSeparator != null && (kind == PropertyKind.StringArray || kind == PropertyKind.ComplexArray);
         bool isUnsupportedInTable = !isIgnored && !isSection && !isUnwrapped && !IsScalarKind(kind) && !isJoinedArray && kind != PropertyKind.Formattable;
 
+        // A lone Metric/Breakdown property (not a List<T>/array) that still renders as its bar shape.
+        // The type arrives unwrapped of Nullable<T>, so compare against the unwrapped shape type.
+        var shapeType = prop.Type;
+        if (shapeType is INamedTypeSymbol shapeNullable &&
+            shapeNullable.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            shapeType = shapeNullable.TypeArguments[0];
+        }
+        bool isScalarShape = !isArray &&
+            (kind == PropertyKind.Metric || kind == PropertyKind.Breakdown) &&
+            ((knownTypes.Metric is not null && SymbolEqualityComparer.Default.Equals(shapeType, knownTypes.Metric)) ||
+             (knownTypes.Breakdown is not null && SymbolEqualityComparer.Default.Equals(shapeType, knownTypes.Breakdown)));
+
         // Emit warning for unsupported properties without [MarkoutIgnoreInTable]
         if (isUnsupportedInTable && !isIgnoredInTable)
         {
@@ -588,7 +601,8 @@ internal static class TypeParser
             multiSourceLabelHeader,
             goal,
             noise,
-            deltaNoun);
+            deltaNoun,
+            isScalarShape);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)
@@ -630,6 +644,13 @@ internal static class TypeParser
         // Callout type - renders as admonition block
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.Callout))
             return (PropertyKind.Callout, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+
+        // Scalar Metric / Breakdown - a lone shape property renders as its bar, same as List<T>.
+        // (Nullable<T> is already unwrapped before we get here; the emitter guards on the shape.)
+        if (knownTypes.Metric is not null && SymbolEqualityComparer.Default.Equals(type, knownTypes.Metric))
+            return (PropertyKind.Metric, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+        if (knownTypes.Breakdown is not null && SymbolEqualityComparer.Default.Equals(type, knownTypes.Breakdown))
+            return (PropertyKind.Breakdown, null, null, false, null, null, true, FieldLayoutKind.Table, false);
 
         // Composite-cell shapes (Comparison<>, Fraction, Share, Percent, Segments) implement IMarkoutCell
         if (knownTypes.IMarkoutCell != null &&

--- a/tests/Markout.Tests/ScalarShapeTests.cs
+++ b/tests/Markout.Tests/ScalarShapeTests.cs
@@ -1,0 +1,136 @@
+using System.IO;
+using Markout;
+using Markout.Formatting;
+
+namespace Markout.Tests;
+
+// A lone Metric/Breakdown property (not a List<T>) must render as its bar shape, same as the list
+// form. Regression guard for the CT10 footgun where a scalar Breakdown fell through to a
+// Field/Value + Slices table (plus MARKOUT001/CS8073 warnings) instead of a bar.
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class ScalarShapeReport
+{
+    public string Title { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    public Metric Score { get; set; }
+
+    [MarkoutIgnoreInTable]
+    public Breakdown Coverage { get; set; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class NullableScalarShapeReport
+{
+    public string Title { get; set; } = "";
+
+    [MarkoutIgnoreInTable]
+    public Metric? Score { get; set; }
+
+    [MarkoutIgnoreInTable]
+    public Breakdown? Coverage { get; set; }
+}
+
+[MarkoutContext(typeof(ScalarShapeReport))]
+[MarkoutContext(typeof(NullableScalarShapeReport))]
+public partial class ScalarShapeTestContext : MarkoutSerializerContext
+{
+}
+
+public class ScalarShapeTests
+{
+    private static string Unicode<T>(T value, MarkoutSerializerContext context)
+    {
+        var sw = new StringWriter();
+        MarkoutSerializer.Serialize(value, sw, new UnicodeFormatter(), context);
+        return sw.ToString();
+    }
+
+    [Fact]
+    public void ScalarMetric_RendersAsBar()
+    {
+        var report = new ScalarShapeReport
+        {
+            Title = "Report",
+            Score = new Metric("Score", 87),
+            Coverage = new Breakdown("Coverage", new[] { new Slice("Covered", 82), new Slice("Uncovered", 18) }),
+        };
+
+        var md = Unicode(report, ScalarShapeTestContext.Default);
+
+        // Bars, not a Field/Value complex-object fallback table.
+        Assert.Contains("█", md);
+        Assert.Contains("Score", md);
+        Assert.Contains("Coverage", md);
+        Assert.DoesNotContain("| Field | Value |", md);
+    }
+
+    [Fact]
+    public void ScalarBreakdown_RendersBarLine()
+    {
+        var report = new ScalarShapeReport
+        {
+            Title = "Report",
+            Coverage = new Breakdown("Coverage", new[] { new Slice("Covered", 82), new Slice("Uncovered", 18) }),
+        };
+
+        var md = Unicode(report, ScalarShapeTestContext.Default);
+
+        // The CT10 assertion shape: the Coverage label followed by a bar.
+        Assert.Matches(@"Coverage[\s\S]*█", md);
+    }
+
+    [Fact]
+    public void ScalarBreakdown_Markdown_RoutesToBreakdownTable_NotFieldValue()
+    {
+        var report = new ScalarShapeReport
+        {
+            Title = "Report",
+            Coverage = new Breakdown("Coverage", new[] { new Slice("Covered", 82), new Slice("Uncovered", 18) }),
+        };
+
+        // Default markdown formatter renders a breakdown as its category table, not the generic
+        // complex-object Field/Value fallback the scalar shape used to fall through to.
+        var md = MarkoutSerializer.Serialize(report, ScalarShapeTestContext.Default);
+
+        Assert.Contains("| Category | Count | % |", md);
+        Assert.DoesNotContain("| Field | Value |", md);
+    }
+
+    [Fact]
+    public void ScalarShapes_Unset_RenderNothing()
+    {
+        var report = new ScalarShapeReport { Title = "Empty" };
+
+        var md = Unicode(report, ScalarShapeTestContext.Default);
+
+        Assert.DoesNotContain("█", md);
+    }
+
+    [Fact]
+    public void NullableScalarShapes_Set_RenderBars()
+    {
+        var report = new NullableScalarShapeReport
+        {
+            Title = "Report",
+            Score = new Metric("Score", 55),
+            Coverage = new Breakdown("Coverage", new[] { new Slice("A", 40), new Slice("B", 60) }),
+        };
+
+        var md = Unicode(report, ScalarShapeTestContext.Default);
+
+        Assert.Contains("█", md);
+        Assert.Matches(@"Coverage[\s\S]*█", md);
+    }
+
+    [Fact]
+    public void NullableScalarShapes_Unset_RenderNothing()
+    {
+        var report = new NullableScalarShapeReport { Title = "Empty" };
+
+        var md = Unicode(report, ScalarShapeTestContext.Default);
+
+        Assert.DoesNotContain("█", md);
+    }
+}


### PR DESCRIPTION
## Problem

A lone `Metric`/`Breakdown` property (a single value, not a `List<T>`/array) did **not** render as its bar. Only the collection forms (`List<Metric>`, `List<Breakdown>`/`Breakdown[]`) had a bar path in the generator. A scalar shape fell through to the generic complex-object renderer, producing a Field/Value + Slices table **plus** two warnings:

- `MARKOUT001` (unsupported property in table)
- `CS8073` ("the result of the expression is always the same since a value of type `Breakdown` is never null")

This is a footgun: the shape *implies* a bar, and the docs/skill say a single `Breakdown`/`Metric` renders as one bar.

## Fix

- **`TypeParser`** — route a scalar `Metric`/`Breakdown` type to `PropertyKind.Metric`/`Breakdown`; flag it via a new `PropertyMetadata.IsScalarShape` (threaded through equality/hashing for incremental-generator value caching).
- **`SerializerEmitter`** — for a scalar shape, emit the single-item overload (`writer.WriteMetrics(new[] { value })` / `WriteBreakdown(...)`) in both the section and non-section paths, guarding on the shape's own content (`Metric.Label` / `Breakdown.Slices`) and on `HasValue` for nullable value types. No more value-type null checks (fixes CS8073).

Handles non-nullable and nullable (`Metric?`/`Breakdown?`) forms; unset/default shapes render nothing.

## Behavior

```
// before: scalar `Breakdown Coverage`
| Field | Value | ...   + MARKOUT001 + CS8073

// after
Coverage        ████████████████████████████████████████████████████████████
```

## Tests

New `ScalarShapeTests` (6): unicode bar for scalar Metric + Breakdown, markdown breakdown-table routing (not the Field/Value fallback), and nullable set/unset cases. Full suite: **700/700 pass**, generator builds with **0 warnings**.
