### PR TITLE
Reject zero-column table row types at compile time (MARKOUT006) (#157)

### DIFF
--- a/docs/design/compile-time-errors.md
+++ b/docs/design/compile-time-errors.md
@@ -78,6 +78,31 @@ Not yet implemented. Would detect single complex objects (not lists) in table ce
 
 Not yet implemented. Would detect `Dictionary<TKey, TValue>` and suggest conversion to `List<KeyValuePair>`.
 
+### MARKOUT006: Table Row Type Has No Visible Columns
+
+**Trigger:** A `List<T>` renders `T` as a table, but `T` has at least one property yet none is a
+visible column — every property is `[MarkoutIgnore]`'d, section-ignored, or a `[MarkoutChild]` flag.
+
+A table emits a fixed header row before any data rows, so a row type with zero renderable columns
+produces an empty header set and throws at runtime (`At least one header is required`) — even for an
+empty list. This is now rejected at compile time (Error severity).
+
+**Message:**
+
+```
+error MARKOUT006: Property 'Rows' renders 'ChildOnlyRow' as a table, but that row type has no
+visible columns (every property is [MarkoutIgnore]'d, section-ignored, or a [MarkoutChild] flag).
+Add at least one scalar column, or render it as sections instead.
+```
+
+**Solutions:**
+1. Add at least one scalar value column to the row type.
+2. Render the collection as sections (nested content) instead of a table.
+
+A `[MarkoutChild]` flag is a nesting marker, not a column, so a row whose only property is the child
+flag is degenerate. Note: a row type with *no* properties at all does not trigger this — the emitter
+renders nothing for it.
+
 ## Implementation
 
 ### Detection Algorithm

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -117,7 +117,9 @@ on rich sinks (`IGlyphFormatter`: Markdown/ANSI/Unicode) a child row's first cel
 configurable glyph (default `↳`). Override it via `MarkoutWriterOptions.Glyphs` `{ Child = "»" }` —
 *easy mode*; or *advanced mode* `MarkoutWriterOptions.ComposeGlyph` (`GlyphSlot.ChildRow`) to swap in a
 string or integrate it. TSV/JSONL and plain text omit the marker, so structured and non-Unicode output
-stay clean.
+stay clean. The child flag is a nesting marker, not a column: a row type whose *only* property is a
+`[MarkoutChild]` flag (or is otherwise all-ignored) has no visible columns and is a compile error
+(`MARKOUT006`) — a table needs at least one scalar value column.
 
 ```csharp
 public class OrgRow

--- a/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
+++ b/src/Markout.SourceGeneration/DiagnosticDescriptors.cs
@@ -75,4 +75,19 @@ internal static class DiagnosticDescriptors
                      "renders incorrectly (e.g. a target prints the raw struct), so it is rejected at compile time."
     );
 
+    public static readonly DiagnosticDescriptor TableRowNoVisibleColumns = new(
+        id: "MARKOUT006",
+        title: "Table row type has no visible columns",
+        messageFormat: "Property '{0}' renders '{1}' as a table, but that row type has no visible columns " +
+                       "(every property is [MarkoutIgnore]'d, section-ignored, or a [MarkoutChild] flag). " +
+                       "Add at least one scalar column, or render it as sections instead.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A table is emitted with a fixed header row before any data rows, so a row type with no " +
+                     "renderable columns throws at runtime (\"At least one header is required\"). This is rejected " +
+                     "at compile time. A [MarkoutChild] flag is a nesting marker, not a column, so a row whose only " +
+                     "property is the child flag is degenerate; give the row at least one scalar value column."
+    );
+
 }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -516,6 +516,28 @@ internal static class TypeParser
 
         var (kind, elementTypeName, elementProperties, hasNestedContent, elementTitleProperty, elementTitleContextProperty, elementAutoFields, elementFieldLayout, isArray) = DeterminePropertyKind(prop.Type, compilation, knownTypes, diagnostics, prop.Name, prop.Locations.FirstOrDefault(), visitedTypes);
 
+        // A collection rendered as a table (ComplexArray without nested subsections) emits a fixed
+        // header row up front, so a row type whose properties are all ignored/section-ignored/child
+        // flags produces zero headers and throws at runtime. Reject it at compile time (MARKOUT006).
+        if (kind == PropertyKind.ComplexArray && !hasNestedContent && joinSeparator == null &&
+            elementProperties is { Count: > 0 })
+        {
+            var columnIgnoreNames = sectionIgnoreProperty != null
+                ? new HashSet<string>(sectionIgnoreProperty.Split(',').Select(s => s.Trim()))
+                : null;
+            bool hasVisibleColumn = elementProperties.Any(p =>
+                !p.IsIgnored && !p.IsChildFlag &&
+                (columnIgnoreNames == null || !columnIgnoreNames.Contains(p.Name)));
+            if (!hasVisibleColumn)
+            {
+                diagnostics.Add(new DiagnosticInfo(
+                    DiagnosticDescriptors.TableRowNoVisibleColumns,
+                    prop.Locations.FirstOrDefault(),
+                    prop.Name,
+                    elementTypeName ?? prop.Type.ToDisplayString()));
+            }
+        }
+
         // Determine if property is unsupported in table context
         // Joined arrays (string or complex) are treated as scalars, so they're fine in tables
         bool isJoinedArray = joinSeparator != null && (kind == PropertyKind.StringArray || kind == PropertyKind.ComplexArray);

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.25.0</Version>
-    <PackageReleaseNotes>[#152] A [MarkoutChild] bool on an element-table row type marks that row as a semantic child of the preceding row (single level). It is a data relationship, not indentation: the flag is never a column; rich sinks (Markdown/ANSI/Unicode) prefix the child row's first cell with a configurable glyph (default ↳). Easy mode: override MarkoutWriterOptions.Glyphs.Child. Advanced mode: MarkoutWriterOptions.ComposeGlyph composes it (GlyphSlot.ChildRow) — replace with a string or integrate it. TSV/JSONL and plain text omit the marker so machine-readable and non-Unicode output stay clean.</PackageReleaseNotes>
+    <Version>0.26.0</Version>
+    <PackageReleaseNotes>[#157] The source generator now rejects (MARKOUT006, error) a collection whose element type renders as a table but has no visible columns — every property is [MarkoutIgnore]'d, section-ignored, or a [MarkoutChild] flag. Such a row type produced a zero-header table that threw at runtime ("At least one header is required"); it is now caught at compile time. Give the row at least one scalar column, or render it as sections. A [MarkoutChild] flag is a nesting marker, not a column, so a row whose only property is the child flag is degenerate.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Markout.Tests/ChildRowTests.cs
+++ b/tests/Markout.Tests/ChildRowTests.cs
@@ -27,28 +27,6 @@ public partial class OrgCardContext : MarkoutSerializerContext
 {
 }
 
-// Degenerate row whose ONLY property is the child flag: the generator must still emit valid C#
-// (regression for a trailing-comma / empty-argument-list codegen bug). Declaring the context here is
-// the compile-time guard — if codegen were broken, this test project would not compile.
-public class ChildOnlyRow
-{
-    [MarkoutChild] public bool IsChild { get; set; }
-}
-
-[MarkoutSerializable(TitleProperty = nameof(Title))]
-public class ChildOnlyCard
-{
-    [MarkoutIgnore] public string Title => "Child only";
-
-    [MarkoutSection(Name = "Rows")]
-    public List<ChildOnlyRow> Rows { get; set; } = new();
-}
-
-[MarkoutContext(typeof(ChildOnlyCard))]
-public partial class ChildOnlyCardContext : MarkoutSerializerContext
-{
-}
-
 public class GroupedChildRow
 {
     public string Group { get; set; } = "";
@@ -220,12 +198,5 @@ public class ChildRowTests
         Assert.DoesNotContain("IsChild", md);
         Assert.Contains("| Parent | 1 |", md);
         Assert.Contains("| \u21b3 Kid | 2 |", md);
-    }
-
-    [Fact]
-    public void ChildOnlyRow_GeneratesCompilableSerializer()
-    {
-        // The value is that this project compiles at all (see ChildOnlyCard); assert the context exists.
-        Assert.NotNull(ChildOnlyCardContext.Default);
     }
 }


### PR DESCRIPTION
## Summary

A collection rendered as a dense Markdown table emits a **fixed header row** before any data rows. If the row type's properties are *all* `[MarkoutIgnore]`'d, section-ignored, or `[MarkoutChild]` flags, the header set is empty and serialization throws at runtime:

> `System.ArgumentException: At least one header is required.`

This throws even for an **empty list**, so any such type is unusable. This was surfaced by the #152 adversarial review (a populated child-only card). The generator now catches it at **compile time**.

## Change

- New diagnostic **`MARKOUT006`** (Error, `Markout.Design`): *"Table row type has no visible columns."* Reported on the offending collection property with the row type name.
- Emitted in `TypeParser.ParseProperty` for `ComplexArray` row types (non-nested, non-joined) that have `>= 1` property but **zero visible columns**, using the *same* visibility filter as `CollectionEmitter` (`!IsIgnored && !IsChildFlag && !section-ignored`) so the diagnostic never drifts from the emitter across all three emit paths (dense, dynamic-ignore, grouped).
- A truly **empty** row type (no properties) does **not** trigger it — the emitter renders nothing for it, no throw.
- `[MarkoutChild]` flags and static `[MarkoutIgnore]` are excluded from the column count; `[MarkoutIgnoreColumnWhen]` (runtime-conditional) columns still count as visible.

## Behavior

| Row type | Before | After |
|---|---|---|
| `>= 1` visible column | renders | renders (unchanged) |
| all-ignored / child-only (`>= 1` prop) | throws at runtime | **MARKOUT006 at build** |
| no properties at all | renders nothing | renders nothing (unchanged) |

## Docs / tests

- Removed the now-invalid `ChildOnlyCard` model + `ChildOnlyRow_GeneratesCompilableSerializer` test — child-only is intentionally a build error now.
- Bumped `Markout` to **0.26.0** with release notes.
- Documented MARKOUT006 in `docs/design/compile-time-errors.md` and `grounding/markout/AGENTS.md`.

## Validation

- `dotnet build Markout.sln -c Release` clean (0 warnings) — proves no false positives across all existing table models.
- Throwaway builds confirm MARKOUT006 **fires** for child-only and all-ignored rows, and does **not** fire for empty-row-type or normal tables.
- Tests: **728** Markout.Tests + **236** MarkdownTable.Tests + **59** Templates — all green. markdownlint clean.

Closes #157