### PR TITLE
Numeric format for native Change<T> delta suffix (MarkoutNumberFormat) (#159)

### DIFF
--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -155,7 +155,7 @@ public readonly record struct Slice(string Category, int Count);
 public readonly record struct Breakdown(string Label, Slice[] Slices);
 
 // Composite cells — data-only cells that render densely and decompose into typed columns.
-// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit]/[MarkoutGoal]/[MarkoutDeltaNoun] configure derivation/format.
+// The type picks the rendering; [MarkoutDelta]/[MarkoutUnit]/[MarkoutGoal]/[MarkoutDeltaNoun]/[MarkoutNumberFormat] configure derivation/format.
 public readonly record struct Change<V>(V Before, V After);        // before → after (+ derived delta)
 public readonly record struct Fraction(double Count, double Total); // 24/24
 public readonly record struct Share(double Value, double Whole);    // 5056 (24%)
@@ -179,6 +179,10 @@ public enum Direction { Unchanged, Increased, Decreased, Introduced, Resolved };
 public enum Delta { None, Percent, Absolute, Multiple }             // derived-change suffix mode (Multiple: 3× fewer/more)
 public interface IGoalMagnitude { double GoalMagnitude { get; } }   // composite cell's comparable magnitude (goal)
 public interface IDeltaCountable { double DeltaCount { get; } }     // composite cell's count for [MarkoutDeltaNoun] (Fraction→count, Share→value)
+// [MarkoutNumberFormat("N0")] (MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout
+// renders for a Change<V>: scalar before/after operands + the Absolute/delta-noun/IDeltaCountable delta — keeping a grouped cell
+// and its folded delta consistent (165 → 1,168 (+1,003)). Composite operands stay shape-owned; %/multiple deltas and structured
+// (TSV/JSONL) output are unaffected (structured stays raw/ungrouped for machine parsing).
 
 // Card shapes — list-shapes that render as multi-format cards (Markdown table + typed JSONL/TSV).
 public readonly record struct MetricChange<T>(string Name, T Before, T After,

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -78,6 +78,12 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
   `[MarkoutDeltaNoun("solved")]` renders a caller noun on the signed delta —
   `4/6 → 6/6 (+2 solved)` (sibling of `[MarkoutUnit]`; composites use `IDeltaCountable`: `Fraction`→count,
   `Share`→value; Markdown-only).
+  `[MarkoutNumberFormat("N0")]` on a numeric `Change<V>` applies a .NET numeric format string to the
+  numbers Markout renders for the cell — the scalar `before`/`after` operands, the `Delta.Absolute`
+  suffix, and the delta-noun/`IDeltaCountable` count — so a grouped cell no longer folds an ungrouped
+  delta: `165 → 1,168 (+1,003)` instead of `165 → 1168 (+1,003)`. Composite operands keep their own shape
+  formatting; percentage/multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and
+  ungrouped so it remains machine-parseable.
   `[MarkoutGoal(Goal.Higher)]` / `[MarkoutGoal(Goal.Lower)]` on a numeric `Change<V>` makes Markout
   derive two decomposed fields — a structural `direction`
   (`increased`/`decreased`/`introduced` (0→N)/`resolved` (N→0)/`unchanged`) and a goal-applied polarity

--- a/grounding/markout/AGENTS.md
+++ b/grounding/markout/AGENTS.md
@@ -83,7 +83,9 @@ value, and `TableFormatter` (TSV/JSONL) decomposes each into typed columns from 
   suffix, and the delta-noun/`IDeltaCountable` count — so a grouped cell no longer folds an ungrouped
   delta: `165 → 1,168 (+1,003)` instead of `165 → 1168 (+1,003)`. Composite operands keep their own shape
   formatting; percentage/multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and
-  ungrouped so it remains machine-parseable.
+  ungrouped so it remains machine-parseable. Markout owns the delta sign (it prepends `+`/`-`), so the
+  format applies to the magnitude only — pass a grouping/precision format (`N0`, `F1`, `#,0`), not one
+  with its own sign sections (`+0;-0;0`) or integer-only specifiers (`D`/`X`, which throw).
   `[MarkoutGoal(Goal.Higher)]` / `[MarkoutGoal(Goal.Lower)]` on a numeric `Change<V>` makes Markout
   derive two decomposed fields — a structural `direction`
   (`increased`/`decreased`/`introduced` (0→N)/`resolved` (N→0)/`unchanged`) and a goal-applied polarity

--- a/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
+++ b/src/Markout.SourceGeneration/Emitter/EmitHelpers.cs
@@ -384,11 +384,15 @@ internal static class EmitHelpers
     /// for every composite-cell rendering path (dense field layouts, table columns, composite-card rows).
     /// </summary>
     public static string CompositeCellFormatLiteral(PropertyMetadata prop)
-        => $"new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)}, DeltaNoun = {DeltaNounLiteral(prop)} }}";
+        => $"new global::Markout.MarkoutCellFormat({DeltaLiteral(prop)}, {UnitLiteral(prop)}) {{ Goal = {GoalLiteral(prop)}, Noise = {NoiseLiteral(prop)}, DeltaNoun = {DeltaNounLiteral(prop)}, NumberFormat = {NumberFormatLiteral(prop)} }}";
 
     /// <summary>Emits the delta-noun string literal (or <c>null</c>) for a composite cell property.</summary>
     public static string DeltaNounLiteral(PropertyMetadata prop)
         => prop.DeltaNoun == null ? "null" : $"\"{EscapeString(prop.DeltaNoun)}\"";
+
+    /// <summary>Emits the number-format string literal (or <c>null</c>) for a composite cell property.</summary>
+    public static string NumberFormatLiteral(PropertyMetadata prop)
+        => prop.NumberFormat == null ? "null" : $"\"{EscapeString(prop.NumberFormat)}\"";
 
     public static bool IsScalarKind(PropertyKind kind)
     {

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -195,6 +195,10 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
     /// a nested child of the preceding row. Excluded from table columns; drives the child glyph.</summary>
     public bool IsChildFlag { get; }
 
+    /// <summary>The <c>[MarkoutNumberFormat]</c> numeric format string (e.g. <c>"N0"</c>) applied to a
+    /// numeric <c>Change&lt;&gt;</c> cell's operands and derived delta; <c>null</c> when unset.</summary>
+    public string? NumberFormat { get; }
+
     public PropertyMetadata(
         string name,
         string displayName,
@@ -250,7 +254,8 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         double noise = 0,
         string? deltaNoun = null,
         bool isScalarShape = false,
-        bool isChildFlag = false)
+        bool isChildFlag = false,
+        string? numberFormat = null)
     {
         Name = name;
         DisplayName = displayName;
@@ -307,6 +312,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
         IsReferenceTypeCell = isReferenceTypeCell;
         MultiSourceLabelHeader = multiSourceLabelHeader;
         IsChildFlag = isChildFlag;
+        NumberFormat = numberFormat;
     }
 
     public bool Equals(PropertyMetadata? other)
@@ -367,6 +373,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
                IsReferenceTypeCell == other.IsReferenceTypeCell &&
                MultiSourceLabelHeader == other.MultiSourceLabelHeader &&
                IsChildFlag == other.IsChildFlag &&
+               NumberFormat == other.NumberFormat &&
                SequenceEqual(ElementProperties, other.ElementProperties);
     }
 
@@ -412,6 +419,7 @@ internal sealed class PropertyMetadata : IEquatable<PropertyMetadata>
             hash = hash * 397 ^ IsReferenceTypeCell.GetHashCode();
             hash = hash * 397 ^ (MultiSourceLabelHeader?.GetHashCode() ?? 0);
             hash = hash * 397 ^ IsChildFlag.GetHashCode();
+            hash = hash * 397 ^ (NumberFormat?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -37,6 +37,7 @@ internal static class TypeParser
     private const string MarkoutUnitAttribute = "Markout.MarkoutUnitAttribute";
     private const string MarkoutGoalAttribute = "Markout.MarkoutGoalAttribute";
     private const string MarkoutDeltaNounAttribute = "Markout.MarkoutDeltaNounAttribute";
+    private const string MarkoutNumberFormatAttribute = "Markout.MarkoutNumberFormatAttribute";
 
     private const string MarkoutContextOptionsAttribute = "Markout.MarkoutContextOptionsAttribute";
 
@@ -496,6 +497,16 @@ internal static class TypeParser
             deltaNoun = deltaNounValue;
         }
 
+        // Parse [MarkoutNumberFormat] — numeric format string for a numeric Change<> cell's operands + delta
+        string? numberFormat = null;
+        var numberFormatAttr = prop.GetAttributes()
+            .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == MarkoutNumberFormatAttribute);
+        if (numberFormatAttr != null && numberFormatAttr.ConstructorArguments.Length > 0 &&
+            numberFormatAttr.ConstructorArguments[0].Value is string numberFormatValue)
+        {
+            numberFormat = numberFormatValue;
+        }
+
         // Parse [MarkoutLabelHeader] — label/identity column header for a List<MultiSourceRow> card
         string? multiSourceLabelHeader = null;
         var labelHeaderAttr = prop.GetAttributes()
@@ -627,7 +638,8 @@ internal static class TypeParser
             noise,
             deltaNoun,
             isScalarShape,
-            isChildFlag);
+            isChildFlag,
+            numberFormat);
     }
 
     private static (PropertyKind Kind, string? ElementTypeName, IReadOnlyList<PropertyMetadata>? ElementProperties, bool HasNestedContent, string? ElementTitleProperty, string? ElementTitleContextProperty, bool ElementAutoFields, FieldLayoutKind ElementFieldLayout, bool IsArray)

--- a/src/Markout/Attributes/MarkoutNumberFormatAttribute.cs
+++ b/src/Markout/Attributes/MarkoutNumberFormatAttribute.cs
@@ -1,0 +1,19 @@
+namespace Markout;
+
+/// <summary>
+/// Declares a .NET numeric format string applied to the numbers Markout renders for a numeric
+/// <see cref="Change{V}"/> cell in dense Markdown: the scalar <c>before</c>/<c>after</c> operands and
+/// the derived signed delta (the <see cref="MarkoutDeltaAttribute"/> absolute suffix and the
+/// <see cref="MarkoutDeltaNounAttribute"/> / <see cref="IDeltaCountable"/> delta count). It keeps a
+/// grouped cell and its folded delta consistent — <c>165 → 1,168 (+1,003)</c> instead of
+/// <c>165 → 1168 (+1,003)</c>. Composite operands keep their own shape formatting; percentage and
+/// multiple deltas are unaffected. Markdown-only: structured (TSV/JSONL) output stays raw and
+/// ungrouped so it remains machine-parseable.
+/// </summary>
+/// <param name="format">A standard or custom .NET numeric format string (e.g. <c>"N0"</c>, <c>"N2"</c>).</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class MarkoutNumberFormatAttribute(string format) : Attribute
+{
+    /// <summary>The numeric format string applied to the change cell's numbers.</summary>
+    public string Format { get; } = format;
+}

--- a/src/Markout/Attributes/MarkoutNumberFormatAttribute.cs
+++ b/src/Markout/Attributes/MarkoutNumberFormatAttribute.cs
@@ -11,9 +11,12 @@ namespace Markout;
 /// ungrouped so it remains machine-parseable.
 /// </summary>
 /// <remarks>
-/// The format string must be one that the widened delta type (<see cref="double"/> for most integral
-/// operands, <see cref="decimal"/> for <see cref="long"/>/<see cref="ulong"/>/<see cref="decimal"/>)
-/// can render — the standard numeric formats (<c>"N0"</c>, <c>"F1"</c>, <c>"G"</c>, <c>"P"</c>,
+/// Markout owns the delta sign — it prepends <c>+</c> for a gain and <c>-</c> for a loss — so the
+/// format applies to the delta <em>magnitude</em> only and must not include its own sign sections
+/// (e.g. <c>"+0;-0;0"</c>) or sign literals, which would double the sign. The format string must be
+/// one that the widened delta type (<see cref="double"/> for most integral operands,
+/// <see cref="decimal"/> for <see cref="long"/>/<see cref="ulong"/>/<see cref="decimal"/>) can
+/// render — the standard numeric formats (<c>"N0"</c>, <c>"F1"</c>, <c>"G"</c>, <c>"P"</c>,
 /// <c>"E"</c>, <c>"C"</c>) and custom numeric patterns (<c>"#,0"</c>). Integer-only specifiers
 /// (<c>"D"</c>, <c>"X"</c>, <c>"B"</c>) are not supported because the derived delta is not an integral
 /// type, and passing one throws <see cref="System.FormatException"/> at render time.

--- a/src/Markout/Attributes/MarkoutNumberFormatAttribute.cs
+++ b/src/Markout/Attributes/MarkoutNumberFormatAttribute.cs
@@ -10,6 +10,14 @@ namespace Markout;
 /// multiple deltas are unaffected. Markdown-only: structured (TSV/JSONL) output stays raw and
 /// ungrouped so it remains machine-parseable.
 /// </summary>
+/// <remarks>
+/// The format string must be one that the widened delta type (<see cref="double"/> for most integral
+/// operands, <see cref="decimal"/> for <see cref="long"/>/<see cref="ulong"/>/<see cref="decimal"/>)
+/// can render — the standard numeric formats (<c>"N0"</c>, <c>"F1"</c>, <c>"G"</c>, <c>"P"</c>,
+/// <c>"E"</c>, <c>"C"</c>) and custom numeric patterns (<c>"#,0"</c>). Integer-only specifiers
+/// (<c>"D"</c>, <c>"X"</c>, <c>"B"</c>) are not supported because the derived delta is not an integral
+/// type, and passing one throws <see cref="System.FormatException"/> at render time.
+/// </remarks>
 /// <param name="format">A standard or custom .NET numeric format string (e.g. <c>"N0"</c>, <c>"N2"</c>).</param>
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 public sealed class MarkoutNumberFormatAttribute(string format) : Attribute

--- a/src/Markout/Change.cs
+++ b/src/Markout/Change.cs
@@ -32,7 +32,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
             string? compositeFirst = null;
             if (format.DeltaNoun is not null && Before is IDeltaCountable beforeCount && After is IDeltaCountable afterCount)
             {
-                var nounDelta = CellText.SignedNumber(afterCount.DeltaCount - beforeCount.DeltaCount);
+                var nounDelta = CellText.SignedNumber(afterCount.DeltaCount - beforeCount.DeltaCount, format.NumberFormat);
                 compositeFirst = nounDelta == CellText.Placeholder ? CellText.Placeholder : nounDelta + " " + format.DeltaNoun;
             }
             GateStatus? compositeStatus = null;
@@ -50,18 +50,18 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         var scalarGlyphMode = format.Glyphs is not null;
         TextWriter target = scalarGlyphMode ? new StringWriter() : writer;
 
-        target.Write(CellText.Scalar(Before));
+        target.Write(CellText.Scalar(Before, format.NumberFormat));
         target.Write(CellText.Arrow);
-        target.Write(CellText.Scalar(After));
+        target.Write(CellText.Scalar(After, format.NumberFormat));
 
         // Merge an optional derived-change suffix (or a delta-noun) and an optional goal status into a
         // single parenthetical in word mode: "(+40%)", "(bad)", "(+2 solved)", or "(+40%, bad)". In
         // glyph mode the status leaves the parenthetical and trails as a composed glyph: "(+40%) ✗".
         string? deltaPart;
         if (format.DeltaNoun is not null)
-            deltaPart = NounText(format.DeltaNoun);
+            deltaPart = NounText(format.DeltaNoun, format.NumberFormat);
         else
-            deltaPart = format.Delta == Delta.None ? null : DeltaSuffix(format.Delta);
+            deltaPart = format.Delta == Delta.None ? null : DeltaSuffix(format.Delta, format.NumberFormat);
         GateStatus? statusValue = null;
         if (format.Goal != Goal.Context &&
             GoalDerivation.TryDerive(Before, After, format.Goal, format.Noise, out _, out var status))
@@ -98,10 +98,10 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         return format.Compose is { } compose ? compose(context) : context.Combine();
     }
 
-    private string NounText(string noun)
+    private string NounText(string noun, string? numberFormat)
     {
         // Reuse the exact (decimal) delta path so large long/decimal changes don't lose precision.
-        var delta = CellText.AbsoluteDelta(Before, After, signed: true);
+        var delta = CellText.AbsoluteDelta(Before, After, signed: true, numberFormat);
         return delta == CellText.Placeholder ? CellText.Placeholder : delta + " " + noun;
     }
 
@@ -170,7 +170,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         }
     }
 
-    private string DeltaSuffix(Delta mode)
+    private string DeltaSuffix(Delta mode, string? numberFormat)
     {
         if (!CellText.TryScalarDouble(Before, out var before) || !CellText.TryScalarDouble(After, out var after))
             return CellText.Placeholder;
@@ -178,7 +178,7 @@ public readonly record struct Change<V>(V Before, V After) : IMarkoutCell
         {
             // Divide by |before| so a rise from a negative base reports as a gain, not a loss.
             Delta.Percent => before == 0 ? CellText.Placeholder : CellText.SignedPercent((after - before) / Math.Abs(before) * 100),
-            Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: true),
+            Delta.Absolute => CellText.AbsoluteDelta(Before, After, signed: true, numberFormat),
             Delta.Multiple => MultipleText(withWord: true),
             _ => CellText.Placeholder
         };

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -9,7 +9,7 @@
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>0.27.0</Version>
-    <PackageReleaseNotes>[#159] New [MarkoutNumberFormat("N0")] attribute (and MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout renders for a numeric Change&lt;V&gt; cell: the scalar before/after operands, the Delta.Absolute suffix, and the delta-noun / IDeltaCountable delta count. This keeps a grouped cell and its folded delta consistent — 165 → 1,168 (+1,003) instead of 165 → 1168 (+1,003). Composite operands keep their own shape formatting; percentage and multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable.</PackageReleaseNotes>
+    <PackageReleaseNotes>[#159] New [MarkoutNumberFormat("N0")] attribute (and MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout renders for a numeric Change&lt;V&gt; cell: the scalar before/after operands, the Delta.Absolute suffix, and the delta-noun / IDeltaCountable delta count. This keeps a grouped cell and its folded delta consistent — 165 → 1,168 (+1,003) instead of 165 → 1168 (+1,003). Composite operands keep their own shape formatting; percentage and multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable. Markout owns the delta sign (it prepends +/-), so the format applies to the magnitude only.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.26.0</Version>
-    <PackageReleaseNotes>[#157] The source generator now rejects (MARKOUT006, error) a collection whose element type renders as a table but has no visible columns — every property is [MarkoutIgnore]'d, section-ignored, or a [MarkoutChild] flag. Such a row type produced a zero-header table that threw at runtime ("At least one header is required"); it is now caught at compile time. Give the row at least one scalar column, or render it as sections. A [MarkoutChild] flag is a nesting marker, not a column, so a row whose only property is the child flag is degenerate.</PackageReleaseNotes>
+    <Version>0.27.0</Version>
+    <PackageReleaseNotes>[#159] New [MarkoutNumberFormat("N0")] attribute (and MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout renders for a numeric Change&lt;V&gt; cell: the scalar before/after operands, the Delta.Absolute suffix, and the delta-noun / IDeltaCountable delta count. This keeps a grouped cell and its folded delta consistent — 165 → 1,168 (+1,003) instead of 165 → 1168 (+1,003). Composite operands keep their own shape formatting; percentage and multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -111,7 +111,8 @@ internal static class CellText
         var text = format is null ? Number(value) : FormatNumber(value, format);
         if (text == Placeholder)
             return Placeholder;   // non-finite: bare placeholder, never "+—"
-        return value > 0 ? "+" + text : text;
+        // A custom format may already emit its own positive sign (e.g. "+0;-0;0"); don't double it.
+        return value > 0 && !text.StartsWith('+') ? "+" + text : text;
     }
 
     /// <summary>
@@ -223,7 +224,8 @@ internal static class CellText
         var text = format is null
             ? delta.ToString(CultureInfo.InvariantCulture)
             : delta.ToString(format, CultureInfo.InvariantCulture);
-        return signed && delta > 0 ? "+" + text : text;
+        // A custom format may already emit its own positive sign (e.g. "+0;-0;0"); don't double it.
+        return signed && delta > 0 && !text.StartsWith('+') ? "+" + text : text;
     }
 
     /// <summary>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -102,26 +102,32 @@ internal static class CellText
         => SignedNumber(value, null);
 
     /// <summary>
-    /// Formats a signed number for an absolute delta suffix (explicit <c>+</c> for gains), applying an
-    /// optional .NET numeric format string (e.g. <c>"N0"</c> for thousands grouping); <c>null</c> keeps
-    /// the default trailing-<c>.0</c>-trimmed formatting.
+    /// Formats a signed number for an absolute delta suffix, applying an optional .NET numeric format
+    /// string (e.g. <c>"N0"</c> for thousands grouping) to the <em>magnitude</em>; <c>null</c> keeps the
+    /// default trailing-<c>.0</c>-trimmed formatting. Markout owns the sign — it prepends <c>+</c> for a
+    /// gain and <c>-</c> for a loss — so the format never sees a signed value and cannot collide with
+    /// (or double) the delta sign. The format therefore governs the magnitude only and should not carry
+    /// its own sign sections or sign literals.
     /// </summary>
     public static string SignedNumber(double value, string? format)
     {
-        var text = format is null ? Number(value) : FormatNumber(value, format);
-        if (text == Placeholder)
+        var magnitude = format is null ? Number(Math.Abs(value)) : FormatNumber(Math.Abs(value), format);
+        if (magnitude == Placeholder)
             return Placeholder;   // non-finite: bare placeholder, never "+—"
-        return value > 0 && !FormatControlsSign(format) ? "+" + text : text;
+        return SignPrefix(value, signed: true) + magnitude;
     }
 
     /// <summary>
-    /// True when a numeric format string carries explicit sign sections (a <c>positive;negative;zero</c>
-    /// pattern, detected by the section separator <c>;</c>): the caller then fully controls the positive
-    /// sign, so the automatic <c>+</c> delta prefix must not be added (a section-less standard/custom
-    /// format never emits a leading <c>+</c> for positives, so the prefix is safe there).
+    /// The leading sign Markout prepends to a delta magnitude: <c>-</c> for a decrease and, when
+    /// <paramref name="signed"/> is set, <c>+</c> for an increase (otherwise nothing). Markout is the
+    /// sole authority for the delta sign; the numeric format applies to the magnitude alone.
     /// </summary>
-    private static bool FormatControlsSign(string? format)
-        => format is not null && format.Contains(';');
+    private static string SignPrefix(double value, bool signed)
+        => value < 0 ? "-" : (signed && value > 0 ? "+" : string.Empty);
+
+    /// <inheritdoc cref="SignPrefix(double, bool)"/>
+    private static string SignPrefix(decimal value, bool signed)
+        => value < 0 ? "-" : (signed && value > 0 ? "+" : string.Empty);
 
     /// <summary>
     /// Formats a finite numeric value with a .NET numeric format string (invariant culture); a
@@ -217,9 +223,8 @@ internal static class CellText
         if (TryScalarDouble(before, out var bd) && TryScalarDouble(after, out var ad))
         {
             var d = ad - bd;
-            return signed
-                ? SignedNumber(d, format)
-                : (format is null ? Number(d) : FormatNumber(d, format));
+            var magnitude = format is null ? Number(Math.Abs(d)) : FormatNumber(Math.Abs(d), format);
+            return magnitude == Placeholder ? Placeholder : SignPrefix(d, signed) + magnitude;
         }
         return Placeholder;
     }
@@ -229,10 +234,10 @@ internal static class CellText
 
     private static string SignDecimal(decimal delta, bool signed, string? format)
     {
-        var text = format is null
-            ? delta.ToString(CultureInfo.InvariantCulture)
-            : delta.ToString(format, CultureInfo.InvariantCulture);
-        return signed && delta > 0 && !FormatControlsSign(format) ? "+" + text : text;
+        var magnitude = format is null
+            ? Math.Abs(delta).ToString(CultureInfo.InvariantCulture)
+            : Math.Abs(delta).ToString(format, CultureInfo.InvariantCulture);
+        return SignPrefix(delta, signed) + magnitude;
     }
 
     /// <summary>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -111,9 +111,17 @@ internal static class CellText
         var text = format is null ? Number(value) : FormatNumber(value, format);
         if (text == Placeholder)
             return Placeholder;   // non-finite: bare placeholder, never "+—"
-        // A custom format may already emit its own positive sign (e.g. "+0;-0;0"); don't double it.
-        return value > 0 && !text.StartsWith('+') ? "+" + text : text;
+        return value > 0 && !FormatControlsSign(format) ? "+" + text : text;
     }
+
+    /// <summary>
+    /// True when a numeric format string carries explicit sign sections (a <c>positive;negative;zero</c>
+    /// pattern, detected by the section separator <c>;</c>): the caller then fully controls the positive
+    /// sign, so the automatic <c>+</c> delta prefix must not be added (a section-less standard/custom
+    /// format never emits a leading <c>+</c> for positives, so the prefix is safe there).
+    /// </summary>
+    private static bool FormatControlsSign(string? format)
+        => format is not null && format.Contains(';');
 
     /// <summary>
     /// Formats a finite numeric value with a .NET numeric format string (invariant culture); a
@@ -224,8 +232,7 @@ internal static class CellText
         var text = format is null
             ? delta.ToString(CultureInfo.InvariantCulture)
             : delta.ToString(format, CultureInfo.InvariantCulture);
-        // A custom format may already emit its own positive sign (e.g. "+0;-0;0"); don't double it.
-        return signed && delta > 0 && !text.StartsWith('+') ? "+" + text : text;
+        return signed && delta > 0 && !FormatControlsSign(format) ? "+" + text : text;
     }
 
     /// <summary>

--- a/src/Markout/MarkoutCell.cs
+++ b/src/Markout/MarkoutCell.cs
@@ -99,11 +99,30 @@ internal static class CellText
 
     /// <summary>Formats a signed number for an absolute delta suffix (explicit <c>+</c> for gains).</summary>
     public static string SignedNumber(double value)
+        => SignedNumber(value, null);
+
+    /// <summary>
+    /// Formats a signed number for an absolute delta suffix (explicit <c>+</c> for gains), applying an
+    /// optional .NET numeric format string (e.g. <c>"N0"</c> for thousands grouping); <c>null</c> keeps
+    /// the default trailing-<c>.0</c>-trimmed formatting.
+    /// </summary>
+    public static string SignedNumber(double value, string? format)
     {
-        var text = Number(value);
+        var text = format is null ? Number(value) : FormatNumber(value, format);
         if (text == Placeholder)
             return Placeholder;   // non-finite: bare placeholder, never "+—"
         return value > 0 ? "+" + text : text;
+    }
+
+    /// <summary>
+    /// Formats a finite numeric value with a .NET numeric format string (invariant culture); a
+    /// non-finite value renders the placeholder rather than <c>NaN</c>/<c>Inf</c>.
+    /// </summary>
+    private static string FormatNumber(double value, string format)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            return Placeholder;
+        return value.ToString(format, CultureInfo.InvariantCulture);
     }
 
     /// <summary>Renders a scalar comparison value; numeric types drop trailing <c>.0</c>.</summary>
@@ -119,6 +138,26 @@ internal static class CellText
             => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
         _ => value.ToString() ?? string.Empty
     };
+
+    /// <summary>
+    /// Renders a scalar comparison value applying an optional .NET numeric format string (e.g.
+    /// <c>"N0"</c>); <c>null</c> defers to <see cref="Scalar(object?)"/>. A non-finite
+    /// <see cref="double"/>/<see cref="float"/> renders the placeholder; every numeric type formats
+    /// with invariant culture to preserve precision and stay locale-stable.
+    /// </summary>
+    public static string Scalar(object? value, string? format)
+    {
+        if (format is null)
+            return Scalar(value);
+        return value switch
+        {
+            null => string.Empty,
+            double d => double.IsNaN(d) || double.IsInfinity(d) ? Placeholder : d.ToString(format, CultureInfo.InvariantCulture),
+            float f => float.IsNaN(f) || float.IsInfinity(f) ? Placeholder : f.ToString(format, CultureInfo.InvariantCulture),
+            IFormattable formattable => formattable.ToString(format, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty
+        };
+    }
 
     /// <summary>Attempts to interpret a scalar comparison value as a double for derivations.</summary>
     public static bool TryScalarDouble(object? value, out double result)
@@ -145,29 +184,45 @@ internal static class CellText
     /// overflow falls back to <c>double</c> rather than throwing.
     /// </summary>
     public static string AbsoluteDelta(object? before, object? after, bool signed)
+        => AbsoluteDelta(before, after, signed, null);
+
+    /// <summary>
+    /// As <see cref="AbsoluteDelta(object?, object?, bool)"/>, but applies an optional .NET numeric
+    /// format string (e.g. <c>"N0"</c> for thousands grouping) to the delta; <c>null</c> keeps the
+    /// default formatting. The exact integral/decimal path formats the <see cref="decimal"/> delta
+    /// directly so grouping applies without routing large values through <see cref="double"/>.
+    /// </summary>
+    public static string AbsoluteDelta(object? before, object? after, bool signed, string? format)
     {
         switch (before, after)
         {
             case (long b, long a):
-                return SignDecimal((decimal)a - (decimal)b, signed);
+                return SignDecimal((decimal)a - (decimal)b, signed, format);
             case (ulong b, ulong a):
-                return SignDecimal((decimal)a - (decimal)b, signed);
+                return SignDecimal((decimal)a - (decimal)b, signed, format);
             case (decimal b, decimal a):
-                try { return SignDecimal(a - b, signed); }
+                try { return SignDecimal(a - b, signed, format); }
                 catch (OverflowException) { break; } // fall through to the double path
         }
 
         if (TryScalarDouble(before, out var bd) && TryScalarDouble(after, out var ad))
         {
             var d = ad - bd;
-            return signed ? SignedNumber(d) : Number(d);
+            return signed
+                ? SignedNumber(d, format)
+                : (format is null ? Number(d) : FormatNumber(d, format));
         }
         return Placeholder;
     }
 
     private static string SignDecimal(decimal delta, bool signed)
+        => SignDecimal(delta, signed, null);
+
+    private static string SignDecimal(decimal delta, bool signed, string? format)
     {
-        var text = delta.ToString(CultureInfo.InvariantCulture);
+        var text = format is null
+            ? delta.ToString(CultureInfo.InvariantCulture)
+            : delta.ToString(format, CultureInfo.InvariantCulture);
         return signed && delta > 0 ? "+" + text : text;
     }
 

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -32,6 +32,18 @@ public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string
     public string? DeltaNoun { get; init; }
 
     /// <summary>
+    /// An optional .NET numeric format string (e.g. <c>"N0"</c>) applied to the numbers Markout itself
+    /// renders for a numeric <see cref="Change{V}"/> cell in dense Markdown: the scalar
+    /// <c>before</c>/<c>after</c> operands, the derived <see cref="Delta.Absolute"/> suffix, and the
+    /// signed delta count on both the scalar <see cref="DeltaNoun"/> path and the composite
+    /// <see cref="IDeltaCountable"/> path — so a grouped cell (<c>1,168</c>) no longer folds an
+    /// ungrouped delta (<c>+1003</c>). Composite operands keep their own shape formatting; percentage
+    /// and multiple deltas are unaffected. <c>null</c> keeps the default invariant formatting.
+    /// Structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable.
+    /// </summary>
+    public string? NumberFormat { get; init; }
+
+    /// <summary>
     /// The active glyph set when the target sink renders glyphs (a formatter implementing
     /// <see cref="Formatting.IGlyphFormatter"/>); <c>null</c> keeps the <c>good</c>/<c>bad</c> status
     /// <em>word</em>. The writer injects this (with <see cref="Compose"/>) before formatting a

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -40,6 +40,9 @@ public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string
     /// ungrouped delta (<c>+1003</c>). Composite operands keep their own shape formatting; percentage
     /// and multiple deltas are unaffected. <c>null</c> keeps the default invariant formatting.
     /// Structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable.
+    /// Use a format the widened delta type can render — standard numeric formats (<c>"N0"</c>,
+    /// <c>"F1"</c>, <c>"G"</c>, <c>"P"</c>) or custom patterns (<c>"#,0"</c>); integer-only specifiers
+    /// (<c>"D"</c>/<c>"X"</c>) are unsupported and throw at render time.
     /// </summary>
     public string? NumberFormat { get; init; }
 

--- a/src/Markout/MarkoutCellFormat.cs
+++ b/src/Markout/MarkoutCellFormat.cs
@@ -40,8 +40,10 @@ public readonly record struct MarkoutCellFormat(Delta Delta = Delta.None, string
     /// ungrouped delta (<c>+1003</c>). Composite operands keep their own shape formatting; percentage
     /// and multiple deltas are unaffected. <c>null</c> keeps the default invariant formatting.
     /// Structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable.
-    /// Use a format the widened delta type can render — standard numeric formats (<c>"N0"</c>,
-    /// <c>"F1"</c>, <c>"G"</c>, <c>"P"</c>) or custom patterns (<c>"#,0"</c>); integer-only specifiers
+    /// Markout owns the delta sign (it prepends <c>+</c>/<c>-</c>), so the format applies to the
+    /// <em>magnitude</em> only and must not carry its own sign sections or sign literals. Use a format
+    /// the widened delta type can render — standard numeric formats (<c>"N0"</c>, <c>"F1"</c>,
+    /// <c>"G"</c>, <c>"P"</c>) or custom patterns (<c>"#,0"</c>); integer-only specifiers
     /// (<c>"D"</c>/<c>"X"</c>) are unsupported and throw at render time.
     /// </summary>
     public string? NumberFormat { get; init; }

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -1058,6 +1058,25 @@ public class GoalAwareCellTests
     }
 
     [Fact]
+    public void Change_NumberFormat_CustomPositiveSignFormat_DoesNotDoubleSign()
+    {
+        // A custom format with its own positive-sign section must not get a second "+" prepended.
+        Assert.Equal("+1 \u2192 +3 (+2)",
+            Inline(new Change<int>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "+0;-0;0" }));
+        // Same for the exact integral (decimal) delta path.
+        Assert.Equal("+1 \u2192 +3 (+2)",
+            Inline(new Change<long>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "+0;-0;0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_HonorsFractionalFormats()
+    {
+        // Non-grouping numeric formats (decimals) apply to operands and the absolute delta alike.
+        Assert.Equal("1.50 \u2192 3.25 (+1.75)",
+            Inline(new Change<double>(1.5, 3.25), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "F2" }));
+    }
+
+    [Fact]
     public void Generated_NumberFormat_RendersGroupedInMarkdown()
     {
         var card = new NumberFormatCard

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -1058,14 +1058,18 @@ public class GoalAwareCellTests
     }
 
     [Fact]
-    public void Change_NumberFormat_CustomPositiveSignFormat_DoesNotDoubleSign()
+    public void Change_NumberFormat_SectionedFormat_ControlsSign_NoDoubling()
     {
-        // A custom format with its own positive-sign section must not get a second "+" prepended.
+        // A format with explicit sign sections (containing ';') owns positive-sign rendering, so the
+        // automatic "+" is not prepended — no doubling, even with a prefix in the positive section.
         Assert.Equal("+1 \u2192 +3 (+2)",
             Inline(new Change<int>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "+0;-0;0" }));
-        // Same for the exact integral (decimal) delta path.
+        // Exact integral (decimal) delta path.
         Assert.Equal("+1 \u2192 +3 (+2)",
             Inline(new Change<long>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "+0;-0;0" }));
+        // Prefix + sign section: the delta keeps the format's own sign, no second "+".
+        Assert.Equal("$+1 \u2192 $+3 ($+2)",
+            Inline(new Change<int>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "$+0;-$0;0" }));
     }
 
     [Fact]

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -68,6 +68,24 @@ public partial class DeltaModesCardContext : MarkoutSerializerContext
 {
 }
 
+// Attribute path for [MarkoutNumberFormat]: grouped operands + grouped delta.
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class NumberFormatCard
+{
+    [MarkoutIgnore] public string Title => "Number format";
+
+    [MarkoutPropertyName("Methods"), MarkoutDelta(Delta.Absolute), MarkoutNumberFormat("N0")]
+    public Change<int> Methods { get; set; }
+
+    [MarkoutPropertyName("Solved"), MarkoutDeltaNoun("methods"), MarkoutNumberFormat("N0")]
+    public Change<Fraction> Solved { get; set; }
+}
+
+[MarkoutContext(typeof(NumberFormatCard))]
+public partial class NumberFormatCardContext : MarkoutSerializerContext
+{
+}
+
 public class GoalAwareCellTests
 {
     private static List<MarkoutField> Decompose(IMarkoutCell cell, MarkoutCellFormat format)
@@ -977,5 +995,79 @@ public class GoalAwareCellTests
 
         Assert.Contains("15 \u2192 5 (3\u00d7 fewer)", md);
         Assert.Contains("4/6 \u2192 6/6 (+2 solved)", md);
+    }
+
+    // --- [MarkoutNumberFormat] / MarkoutCellFormat.NumberFormat (issue #159) ---
+
+    [Fact]
+    public void Change_NumberFormat_GroupsScalarOperandsAndAbsoluteDelta()
+    {
+        // Acceptance: scalar Change<int> with the option renders grouped operands *and* delta.
+        Assert.Equal("165 \u2192 1,168 (+1,003)",
+            Inline(new Change<int>(165, 1168), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "N0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_Unset_LeavesRenderingUnchanged()
+    {
+        Assert.Equal("165 \u2192 1168 (+1003)",
+            Inline(new Change<int>(165, 1168), new MarkoutCellFormat(Delta.Absolute)));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_GroupsScalarDeltaNounCount()
+    {
+        Assert.Equal("165 \u2192 1,168 (+1,003 methods)",
+            Inline(new Change<int>(165, 1168), new MarkoutCellFormat { DeltaNoun = "methods", NumberFormat = "N0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_GroupsCompositeDeltaCount_OperandsStayShapeOwned()
+    {
+        // Composite operands are formatted by the shape (Fraction => "1003/2000"); only the
+        // IDeltaCountable delta count picks up the number format.
+        Assert.Equal("165/2000 \u2192 1168/2000 (+1,003 methods)",
+            Inline(new Change<Fraction>(new Fraction(165, 2000), new Fraction(1168, 2000)),
+                new MarkoutCellFormat { DeltaNoun = "methods", NumberFormat = "N0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_GroupsExactLongDelta()
+    {
+        // The exact integral/decimal delta path must group without routing through double.
+        Assert.Equal("1,000,000 \u2192 2,500,000 (+1,500,000)",
+            Inline(new Change<long>(1_000_000, 2_500_000), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "N0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_DoesNotAffectPercentDelta()
+    {
+        // Percentages are not counts: NumberFormat groups the operands but leaves the "%" delta alone.
+        Assert.Equal("1,000 \u2192 2,000 (+100%)",
+            Inline(new Change<int>(1000, 2000), new MarkoutCellFormat(Delta.Percent) { NumberFormat = "N0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_StructuredDecompositionStaysRaw()
+    {
+        // Structured output must remain machine-parseable: no grouping separators.
+        var fields = Decompose(new Change<int>(165, 1168), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "N0" });
+        Assert.Equal("165", fields.Single(f => f.Key == "before").Value);
+        Assert.Equal("1168", fields.Single(f => f.Key == "after").Value);
+        Assert.Equal("1003", fields.Single(f => f.Key == "deltaAbs").Value);
+    }
+
+    [Fact]
+    public void Generated_NumberFormat_RendersGroupedInMarkdown()
+    {
+        var card = new NumberFormatCard
+        {
+            Methods = new(165, 1168),
+            Solved = new(new Fraction(165, 2000), new Fraction(1168, 2000)),
+        };
+        var md = MarkoutSerializer.Serialize(card, NumberFormatCardContext.Default);
+
+        Assert.Contains("165 \u2192 1,168 (+1,003)", md);
+        Assert.Contains("(+1,003 methods)", md);
     }
 }

--- a/tests/Markout.Tests/GoalAwareCellTests.cs
+++ b/tests/Markout.Tests/GoalAwareCellTests.cs
@@ -1058,18 +1058,22 @@ public class GoalAwareCellTests
     }
 
     [Fact]
-    public void Change_NumberFormat_SectionedFormat_ControlsSign_NoDoubling()
+    public void Change_NumberFormat_NegativeDelta_MarkoutOwnsSign()
     {
-        // A format with explicit sign sections (containing ';') owns positive-sign rendering, so the
-        // automatic "+" is not prepended — no doubling, even with a prefix in the positive section.
-        Assert.Equal("+1 \u2192 +3 (+2)",
-            Inline(new Change<int>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "+0;-0;0" }));
+        // Markout prepends the sign to the formatted magnitude, so a decrease groups and reads
+        // "-1,003" — the numeric format never sees a signed value (no format/BCL sign collision).
+        Assert.Equal("1,168 \u2192 165 (-1,003)",
+            Inline(new Change<int>(1168, 165), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "N0" }));
         // Exact integral (decimal) delta path.
-        Assert.Equal("+1 \u2192 +3 (+2)",
-            Inline(new Change<long>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "+0;-0;0" }));
-        // Prefix + sign section: the delta keeps the format's own sign, no second "+".
-        Assert.Equal("$+1 \u2192 $+3 ($+2)",
-            Inline(new Change<int>(1, 3), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "$+0;-$0;0" }));
+        Assert.Equal("2,500,000 \u2192 1,000,000 (-1,500,000)",
+            Inline(new Change<long>(2_500_000, 1_000_000), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "N0" }));
+    }
+
+    [Fact]
+    public void Change_NumberFormat_ZeroDelta_HasNoSign()
+    {
+        Assert.Equal("1,000 \u2192 1,000 (0)",
+            Inline(new Change<int>(1000, 1000), new MarkoutCellFormat(Delta.Absolute) { NumberFormat = "N0" }));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`Change<T>` folds a signed numeric delta into the cell — `(±N)` for scalar cells and `(±N <noun>)` for composites — but that delta was always emitted **without thousands separators** (`+1500`). When a cell's operands are grouped but the folded delta is not, the two read inconsistently:

```
77,376 (88.02%) → 79,000 (90.00%) (+1624 methods)
```

The delta is produced inside `Change<V>.FormatInline`, so a consumer cannot reintroduce grouping without abandoning native delta folding. This adds the library-side lever.

## Change

New **`MarkoutCellFormat.NumberFormat`** (a standard/custom .NET numeric format string), surfaced declaratively as **`[MarkoutNumberFormat("N0")]`**. It formats the numbers Markout itself renders for a numeric `Change<V>` cell:

- the scalar `before`/`after` operands,
- the `Delta.Absolute` suffix,
- the delta-noun / `IDeltaCountable` delta count (both scalar and composite paths).

```csharp
[MarkoutDelta(Delta.Absolute), MarkoutNumberFormat("N0")]  public Change<int>      Methods { get; set; }
[MarkoutDeltaNoun("methods"),  MarkoutNumberFormat("N0")]  public Change<Fraction> Solved  { get; set; }
```

## Behavior

| | Before | After (with `NumberFormat = "N0"`) |
|---|---|---|
| scalar `Change<int>(165, 1168)`, `Delta.Absolute` | `165 → 1168 (+1003)` | `165 → 1,168 (+1,003)` |
| composite `Change<T>` + `DeltaNoun` | `… (+1003 methods)` | `… (+1,003 methods)` |
| default (unset) | unchanged | unchanged |

- **Composite operands** keep their own shape formatting (shape-owned).
- **Percentage / multiple** deltas are unaffected (not counts).
- **Structured (TSV/JSONL)** `Decompose` output stays **raw and ungrouped** so it remains machine-parseable.
- The exact integral/decimal delta path formats the `decimal` directly (no rounding through `double`).

## Implementation

- `MarkoutCellFormat.NumberFormat` (`init` property — binary-compatible, like `Goal`/`Noise`/`DeltaNoun`).
- `CellText` gains format-aware `Scalar` / `SignedNumber` / `AbsoluteDelta` overloads (invariant culture); `Change<V>.FormatInline` threads `format.NumberFormat` through operands + delta + noun.
- New `[MarkoutNumberFormat]` attribute; generator parses it → `PropertyMetadata.NumberFormat` and emits it in `CompositeCellFormatLiteral` (the single `MarkoutCellFormat` construction site).

## Validation

- Acceptance criteria reproduced exactly (`165 → 1,168 (+1,003)`; `(+1,003 methods)`; default unchanged).
- Tests: **736** Markout.Tests (+8) + **236** MarkdownTable.Tests + **59** Templates — all green. Solution builds clean (0 warnings). markdownlint clean.
- New tests cover scalar operands+delta, delta-noun count, composite (operands stay shape-owned), exact-`long` grouping, percent-delta untouched, structured-output-stays-raw, and the generated `[MarkoutNumberFormat]` card path.

Bumps Markout to **0.27.0**. Closes #159. Unblocks the richlander/dotnet-inspect#3167 review nit.