### PR TITLE
Add inline conditionals and richer bindings to Markout.Templates (0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Templates support:
 
 - **`{{key}}`** — inline substitution in headings and prose, or block-level data rendering
 - **`{{#if key}}`** / **`{{/if}}`** — conditional sections. Use standalone directive lines for multi-line blocks, or wrap a single line inline (`{{#if ref}}Baseline ref: {{ref}}{{/if}}`) so an omitted optional line leaves no blank gap and neighbouring lines stay tight. Keys are falsy when unbound, `null`, `false`, an empty string, an empty collection, or numeric zero
+- **Reserved directive sigils** — the `{{#…}}` and `{{/…}}` forms are reserved for directives. `{{#if key}}` and `{{/if}}` are the only recognized ones; any other `{{#…}}`/`{{/…}}` token (a typo, an unbalanced or malformed directive, or another template language's syntax) raises a `FormatException` at parse time. There is no escape mechanism, so directive-shaped text cannot be emitted as literal prose. Unknown *data* placeholders (`{{unknown}}`) degrade gracefully and are left verbatim
 - **Pipe tables** — parsed and re-rendered through the writer's table shape, with optional statistical column-width optimization
 - **`IMarkoutFormattable`** and **`MarkoutTypeInfo<T>`** bindings for shape-aware data rendering; **`Bind(key, IEnumerable<string>)`** renders a bullet list and **`Bind(key, bool)`** gates a conditional section
 

--- a/README.md
+++ b/README.md
@@ -379,9 +379,9 @@ template.Render(plainWriter);
 Templates support:
 
 - **`{{key}}`** — inline substitution in headings and prose, or block-level data rendering
-- **`{{#if key}}`** / **`{{/if}}`** — conditional sections (included when key is bound and non-null)
+- **`{{#if key}}`** / **`{{/if}}`** — conditional sections. Use standalone directive lines for multi-line blocks, or wrap a single line inline (`{{#if ref}}Baseline ref: {{ref}}{{/if}}`) so an omitted optional line leaves no blank gap and neighbouring lines stay tight. Keys are falsy when unbound, `null`, `false`, an empty string, an empty collection, or numeric zero
 - **Pipe tables** — parsed and re-rendered through the writer's table shape, with optional statistical column-width optimization
-- **`IMarkoutFormattable`** and **`MarkoutTypeInfo<T>`** bindings for shape-aware data rendering
+- **`IMarkoutFormattable`** and **`MarkoutTypeInfo<T>`** bindings for shape-aware data rendering; **`Bind(key, IEnumerable<string>)`** renders a bullet list and **`Bind(key, bool)`** gates a conditional section
 
 ```bash
 dotnet add package Markout.Templates

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout.Templates</RootNamespace>
     <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\README.md"

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -256,7 +256,7 @@ public class MarkoutTemplate
 
             case ParagraphNode paragraph:
                 string resolvedText;
-                if (paragraph.Text.Contains("{{#if ", StringComparison.Ordinal)
+                if (paragraph.Text.Contains("{{#if", StringComparison.Ordinal)
                     || paragraph.Text.Contains("{{/if}}", StringComparison.Ordinal))
                 {
                     // Resolve inline conditionals first, then drop only the lines they emptied —

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -255,15 +255,27 @@ public class MarkoutTemplate
                 break;
 
             case ParagraphNode paragraph:
-                var resolvedText = ResolveInline(paragraph.Text);
-                // Inline conditionals may have emptied individual lines; drop those so an omitted
-                // optional line leaves no blank gap and the surrounding lines stay tight.
-                if (resolvedText.Contains('\n'))
+                string resolvedText;
+                if (paragraph.Text.Contains("{{#if ", StringComparison.Ordinal)
+                    || paragraph.Text.Contains("{{/if}}", StringComparison.Ordinal))
                 {
-                    var kept = resolvedText
-                        .Split('\n')
-                        .Where(l => !string.IsNullOrWhiteSpace(l));
-                    resolvedText = string.Join('\n', kept);
+                    // Resolve inline conditionals first, then drop only the lines they emptied —
+                    // before expanding placeholders, so multi-line *bound values* keep their own
+                    // blank lines. (Dropping after placeholder expansion would swallow blank-line
+                    // separators inside a bound value.)
+                    var afterConditionals = TemplateParser.ResolveInlineConditionals(paragraph.Text, IsBindingTruthy);
+                    if (afterConditionals.Contains('\n'))
+                    {
+                        var kept = afterConditionals
+                            .Split('\n')
+                            .Where(l => !string.IsNullOrWhiteSpace(l));
+                        afterConditionals = string.Join('\n', kept);
+                    }
+                    resolvedText = ResolvePlaceholders(afterConditionals);
+                }
+                else
+                {
+                    resolvedText = ResolvePlaceholders(paragraph.Text);
                 }
                 if (!string.IsNullOrWhiteSpace(resolvedText))
                     writer.WriteParagraph(resolvedText);
@@ -310,7 +322,12 @@ public class MarkoutTemplate
     private string ResolveInline(string text)
     {
         var withConditionals = TemplateParser.ResolveInlineConditionals(text, IsBindingTruthy);
-        return TemplateParser.ResolveInlinePlaceholders(withConditionals, key =>
+        return ResolvePlaceholders(withConditionals);
+    }
+
+    private string ResolvePlaceholders(string text)
+    {
+        return TemplateParser.ResolveInlinePlaceholders(text, key =>
         {
             if (_bindings.TryGetValue(key, out var binding))
                 return binding.RenderInline();

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -256,8 +256,7 @@ public class MarkoutTemplate
 
             case ParagraphNode paragraph:
                 string resolvedText;
-                if (paragraph.Text.Contains("{{#if", StringComparison.Ordinal)
-                    || paragraph.Text.Contains("{{/if}}", StringComparison.Ordinal))
+                if (paragraph.Text.Contains("{{", StringComparison.Ordinal))
                 {
                     // Resolve inline conditionals first, then drop only the lines they emptied —
                     // before expanding placeholders, so multi-line *bound values* keep their own

--- a/src/Markout.Templates/MarkoutTemplate.cs
+++ b/src/Markout.Templates/MarkoutTemplate.cs
@@ -84,6 +84,26 @@ public class MarkoutTemplate
     }
 
     /// <summary>
+    /// Binds a sequence of strings rendered as a bullet list at a block placeholder, or joined with
+    /// ", " when used inline. An empty or null sequence is falsy for conditional sections.
+    /// </summary>
+    public MarkoutTemplate Bind(string key, IEnumerable<string>? items)
+    {
+        _bindings[key] = new ListBinding(items is null ? null : [.. items]);
+        return this;
+    }
+
+    /// <summary>
+    /// Binds a boolean, primarily to drive a <c>{{#if key}}</c> conditional section
+    /// (<see langword="false"/> is falsy). Inline, it renders as <c>true</c>/<c>false</c>.
+    /// </summary>
+    public MarkoutTemplate Bind(string key, bool value)
+    {
+        _bindings[key] = new BoolBinding(value);
+        return this;
+    }
+
+    /// <summary>
     /// Binds a source-generated type for block-level rendering through the shape system.
     /// </summary>
     public MarkoutTemplate Bind<T>(string key, T value, MarkoutTypeInfo<T> typeInfo)
@@ -236,7 +256,17 @@ public class MarkoutTemplate
 
             case ParagraphNode paragraph:
                 var resolvedText = ResolveInline(paragraph.Text);
-                writer.WriteParagraph(resolvedText);
+                // Inline conditionals may have emptied individual lines; drop those so an omitted
+                // optional line leaves no blank gap and the surrounding lines stay tight.
+                if (resolvedText.Contains('\n'))
+                {
+                    var kept = resolvedText
+                        .Split('\n')
+                        .Where(l => !string.IsNullOrWhiteSpace(l));
+                    resolvedText = string.Join('\n', kept);
+                }
+                if (!string.IsNullOrWhiteSpace(resolvedText))
+                    writer.WriteParagraph(resolvedText);
                 break;
 
             case PlaceholderNode placeholder:
@@ -279,7 +309,8 @@ public class MarkoutTemplate
 
     private string ResolveInline(string text)
     {
-        return TemplateParser.ResolveInlinePlaceholders(text, key =>
+        var withConditionals = TemplateParser.ResolveInlineConditionals(text, IsBindingTruthy);
+        return TemplateParser.ResolveInlinePlaceholders(withConditionals, key =>
         {
             if (_bindings.TryGetValue(key, out var binding))
                 return binding.RenderInline();

--- a/src/Markout.Templates/TemplateBinding.cs
+++ b/src/Markout.Templates/TemplateBinding.cs
@@ -136,6 +136,11 @@ internal sealed class ObjectBinding(object? value) : TemplateBinding
         null => false,
         bool b => b,
         string s => s.Length > 0,
+        // Non-generic ICollection covers List<T>, arrays, Dictionary, Queue, Stack, Collection<T>,
+        // etc. Generic-only collections (e.g. HashSet<T>) and lazy sequences are intentionally NOT
+        // probed here: counting them would require reflection (breaks AOT) or enumeration (consumes
+        // one-shot sequences). Bind collections through Bind(key, IEnumerable<string>) — which
+        // materializes and uses ListBinding — to get emptiness-driven truthiness for any sequence.
         System.Collections.ICollection c => c.Count > 0,
         _ => !IsZeroNumeric(value),
     };
@@ -156,6 +161,8 @@ internal sealed class ObjectBinding(object? value) : TemplateBinding
         Half n => n == (Half)0,
         nint n => n == 0,
         nuint n => n == 0,
+        Int128 n => n == 0,
+        UInt128 n => n == 0,
         System.Numerics.BigInteger n => n.IsZero,
         _ => false,
     };

--- a/src/Markout.Templates/TemplateBinding.cs
+++ b/src/Markout.Templates/TemplateBinding.cs
@@ -163,7 +163,9 @@ internal sealed class ObjectBinding(object? value) : TemplateBinding
         nuint n => n == 0,
         Int128 n => n == 0,
         UInt128 n => n == 0,
+        System.Runtime.InteropServices.NFloat n => n.Value == 0,
         System.Numerics.BigInteger n => n.IsZero,
+        System.Numerics.Complex n => n == System.Numerics.Complex.Zero,
         _ => false,
     };
 }

--- a/src/Markout.Templates/TemplateBinding.cs
+++ b/src/Markout.Templates/TemplateBinding.cs
@@ -137,7 +137,6 @@ internal sealed class ObjectBinding(object? value) : TemplateBinding
         bool b => b,
         string s => s.Length > 0,
         System.Collections.ICollection c => c.Count > 0,
-        System.Collections.IEnumerable e => e.GetEnumerator().MoveNext(),
         _ => !IsZeroNumeric(value),
     };
 
@@ -154,6 +153,10 @@ internal sealed class ObjectBinding(object? value) : TemplateBinding
         float n => n == 0,
         double n => n == 0,
         decimal n => n == 0,
+        Half n => n == (Half)0,
+        nint n => n == 0,
+        nuint n => n == 0,
+        System.Numerics.BigInteger n => n.IsZero,
         _ => false,
     };
 }

--- a/src/Markout.Templates/TemplateBinding.cs
+++ b/src/Markout.Templates/TemplateBinding.cs
@@ -23,6 +23,7 @@ public abstract class TemplateBinding
 
 /// <summary>
 /// A binding for a simple string value. Used for inline substitution and conditional checks.
+/// An empty string is falsy so <c>{{#if key}}</c> can gate on presence of real content.
 /// </summary>
 internal sealed class StringBinding(string? value) : TemplateBinding
 {
@@ -34,7 +35,39 @@ internal sealed class StringBinding(string? value) : TemplateBinding
 
     public override string? RenderInline() => value;
 
-    public override bool IsTruthy => value is not null;
+    public override bool IsTruthy => !string.IsNullOrEmpty(value);
+}
+
+/// <summary>
+/// A binding for a boolean value, used to drive conditional sections.
+/// </summary>
+internal sealed class BoolBinding(bool value) : TemplateBinding
+{
+    public override void Render(MarkoutWriter writer)
+    {
+        // A bare bool has no block representation; it exists to gate {{#if}} sections.
+    }
+
+    public override string? RenderInline() => value ? "true" : "false";
+
+    public override bool IsTruthy => value;
+}
+
+/// <summary>
+/// A binding for a sequence of strings, rendered as a bullet list at a block placeholder
+/// (or joined with ", " inline). Empty and null sequences are falsy.
+/// </summary>
+internal sealed class ListBinding(string[]? items) : TemplateBinding
+{
+    public override void Render(MarkoutWriter writer)
+    {
+        if (items is { Length: > 0 })
+            writer.WriteList(items);
+    }
+
+    public override string? RenderInline() => items is null ? null : string.Join(", ", items);
+
+    public override bool IsTruthy => items is { Length: > 0 };
 }
 
 /// <summary>
@@ -98,5 +131,29 @@ internal sealed class ObjectBinding(object? value) : TemplateBinding
         _ => null
     };
 
-    public override bool IsTruthy => value is not null;
+    public override bool IsTruthy => value switch
+    {
+        null => false,
+        bool b => b,
+        string s => s.Length > 0,
+        System.Collections.ICollection c => c.Count > 0,
+        System.Collections.IEnumerable e => e.GetEnumerator().MoveNext(),
+        _ => !IsZeroNumeric(value),
+    };
+
+    private static bool IsZeroNumeric(object value) => value switch
+    {
+        sbyte n => n == 0,
+        byte n => n == 0,
+        short n => n == 0,
+        ushort n => n == 0,
+        int n => n == 0,
+        uint n => n == 0,
+        long n => n == 0,
+        ulong n => n == 0,
+        float n => n == 0,
+        double n => n == 0,
+        decimal n => n == 0,
+        _ => false,
+    };
 }

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -387,24 +387,41 @@ public static class TemplateParser
                 break;
             }
 
-            // Append text before the placeholder
-            result.Append(span[pos..(pos + openIndex)]);
+            int outerOpen = pos + openIndex;
 
-            int keyStart = pos + openIndex + OpenSymbol.Length;
+            // Append text before the placeholder
+            result.Append(span[pos..outerOpen]);
+
+            int keyStart = outerOpen + OpenSymbol.Length;
             int closeIndex = span[keyStart..].IndexOf(CloseSymbol);
 
             if (closeIndex < 0)
             {
                 // No closing — append remainder as-is
-                result.Append(span[(pos + openIndex)..]);
+                result.Append(span[outerOpen..]);
                 break;
             }
 
-            var key = span[keyStart..(keyStart + closeIndex)].Trim();
+            int closeAbs = keyStart + closeIndex;
+
+            // A nested "{{" before this close means these braces don't form a single placeholder
+            // token (e.g. "{{oops {{name}}"). Emit the malformed run up to the nested opener as
+            // literal and resume there, mirroring ResolveInlineConditionals, so a valid nested
+            // placeholder is still resolved rather than swallowed.
+            int nestedRel = span[keyStart..closeAbs].IndexOf(OpenSymbol);
+            if (nestedRel >= 0)
+            {
+                int nestedAbs = keyStart + nestedRel;
+                result.Append(span[outerOpen..nestedAbs]);
+                pos = nestedAbs;
+                continue;
+            }
+
+            var key = span[keyStart..closeAbs].Trim();
             var replacement = lookup(key.ToString());
             result.Append(replacement ?? $"{OpenSymbol}{key}{CloseSymbol}");
 
-            pos = keyStart + closeIndex + CloseSymbol.Length;
+            pos = closeAbs + CloseSymbol.Length;
         }
 
         return result.ToString();

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -222,6 +222,9 @@ public static class TemplateParser
                 var key = inner[4..].Trim();
                 if (key.Length > 0)
                 {
+                    if (key.IndexOf('{') >= 0 || key.IndexOf('}') >= 0)
+                        throw new FormatException(
+                            $"Conditional key '{key.ToString()}' contains an invalid brace character.");
                     node = new ConditionalStartNode(key.ToString());
                     return true;
                 }
@@ -254,6 +257,20 @@ public static class TemplateParser
         level = 0;
         text = "";
         return false;
+    }
+
+    /// <summary>
+    /// True when the run beginning at <paramref name="open"/> (a <c>{{</c>) is a reserved directive:
+    /// after the opener and any leading spaces the first character is <c>#</c> or <c>/</c>. Used to
+    /// distinguish a malformed/unterminated directive (which must throw) from an unterminated data
+    /// placeholder (which degrades gracefully to literal text).
+    /// </summary>
+    private static bool StartsWithReservedDirective(string text, int open)
+    {
+        int i = open + OpenSymbol.Length;
+        while (i < text.Length && text[i] == ' ')
+            i++;
+        return i < text.Length && (text[i] == '#' || text[i] == '/');
     }
 
     /// <summary>
@@ -315,6 +332,13 @@ public static class TemplateParser
 
             if (close < 0)
             {
+                // An unterminated run whose content is a reserved directive (a '#' or '/' right
+                // after "{{") is a malformed directive, not literal prose, and must be rejected
+                // rather than silently emitted. Normal unterminated placeholders stay graceful.
+                if (StartsWithReservedDirective(text, open))
+                    throw new FormatException(
+                        "Unterminated inline conditional directive: missing closing '}}'.");
+
                 if (nestedOpen >= 0)
                 {
                     // A nested "{{" precedes any close (e.g. "{{oops {{#if flag}}"): the run up to it
@@ -345,6 +369,9 @@ public static class TemplateParser
                 if (key.Length == 0)
                     throw new FormatException(
                         "Inline conditional '{{#if}}' requires a key.");
+                if (key.Contains('{') || key.Contains('}'))
+                    throw new FormatException(
+                        $"Inline conditional key '{key}' contains an invalid brace character.");
                 openDepth++;
                 if (skipDepth > 0)
                 {

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -93,10 +93,12 @@ public static class TemplateParser
     }
 
     /// <summary>
-    /// Verifies that block-level <c>{{#if}}</c> / <c>{{/if}}</c> directives are balanced. An
-    /// unclosed <c>{{#if}}</c> would otherwise silently drop the remainder of the document at render
-    /// time (data-dependent on the key's truthiness), and a stray <c>{{/if}}</c> indicates an
-    /// authoring error; both are surfaced eagerly as a <see cref="FormatException"/>.
+    /// Verifies that both block-level and inline <c>{{#if}}</c> / <c>{{/if}}</c> directives are
+    /// balanced. An unclosed <c>{{#if}}</c> would otherwise silently drop content at render time
+    /// (data-dependent on the key's truthiness), and a stray <c>{{/if}}</c> indicates an authoring
+    /// error; both are surfaced eagerly as a <see cref="FormatException"/>. Inline conditionals are
+    /// validated structurally here — independent of any binding and of whether the enclosing node is
+    /// rendered — so a malformed inline directive nested inside a falsy block section cannot escape.
     /// </summary>
     private static void ValidateConditionalBalance(List<TemplateNode> nodes)
     {
@@ -114,12 +116,33 @@ public static class TemplateParser
                             "Unbalanced template conditional: '{{/if}}' without a matching '{{#if}}'.");
                     depth--;
                     break;
+                case ParagraphNode paragraph:
+                    ValidateInlineConditionals(paragraph.Text);
+                    break;
+                case HeadingNode heading:
+                    ValidateInlineConditionals(heading.Text);
+                    break;
+                case TableNode table:
+                    foreach (var header in table.Headers)
+                        ValidateInlineConditionals(header);
+                    foreach (var row in table.Rows)
+                        foreach (var cell in row)
+                            ValidateInlineConditionals(cell);
+                    break;
             }
         }
         if (depth > 0)
             throw new FormatException(
                 "Unbalanced template conditional: an '{{#if}}' block is missing its '{{/if}}'.");
     }
+
+    /// <summary>
+    /// Runs the inline conditional resolver purely for its structural validation side effect:
+    /// with an always-true predicate it never skips content, so it walks every directive and
+    /// throws on any imbalance, stray <c>{{/if}}</c>, or empty-key <c>{{#if}}</c>.
+    /// </summary>
+    private static void ValidateInlineConditionals(string text) =>
+        ResolveInlineConditionals(text, static _ => true);
 
     private static void FlushParagraph(List<TemplateNode> nodes, ref List<string>? lines)
     {
@@ -251,7 +274,7 @@ public static class TemplateParser
         ArgumentNullException.ThrowIfNull(text);
         ArgumentNullException.ThrowIfNull(isTruthy);
 
-        if (text.IndexOf("{{#if ", StringComparison.Ordinal) < 0
+        if (text.IndexOf("{{#if", StringComparison.Ordinal) < 0
             && text.IndexOf("{{/if}}", StringComparison.Ordinal) < 0)
             return text;
 
@@ -284,7 +307,12 @@ public static class TemplateParser
 
             var inner = text.AsSpan((open + OpenSymbol.Length)..close).Trim();
 
-            if (inner.StartsWith("#if "))
+            if (inner.SequenceEqual("#if"))
+            {
+                throw new FormatException(
+                    "Inline conditional '{{#if}}' requires a key.");
+            }
+            else if (inner.StartsWith("#if "))
             {
                 var key = inner[4..].Trim().ToString();
                 if (key.Length == 0)
@@ -300,11 +328,6 @@ public static class TemplateParser
                     if (!isTruthy(key))
                         skipDepth = 1;
                 }
-            }
-            else if (inner.SequenceEqual("#if"))
-            {
-                throw new FormatException(
-                    "Inline conditional '{{#if}}' requires a key.");
             }
             else if (inner.SequenceEqual("/if"))
             {

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -268,7 +268,7 @@ public static class TemplateParser
     private static bool StartsWithReservedDirective(string text, int open)
     {
         int i = open + OpenSymbol.Length;
-        while (i < text.Length && text[i] == ' ')
+        while (i < text.Length && char.IsWhiteSpace(text[i]))
             i++;
         return i < text.Length && (text[i] == '#' || text[i] == '/');
     }
@@ -391,6 +391,14 @@ public static class TemplateParser
                 openDepth--;
                 if (skipDepth > 0)
                     skipDepth--;
+            }
+            else if (inner.Length > 0 && (inner[0] == '#' || inner[0] == '/'))
+            {
+                // A '#' or '/' prefix is reserved for directives. A closed token that starts with
+                // one but matches no valid directive form ("#if <key>" or "/if") is malformed —
+                // reject it rather than passing it through as a data placeholder.
+                throw new FormatException(
+                    $"Unrecognized reserved directive '{OpenSymbol}{inner.ToString()}{CloseSymbol}'.");
             }
             else if (skipDepth == 0)
             {

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -128,8 +128,15 @@ public static class TemplateParser
         {
             var inner = trimmed[2..^2].Trim();
 
-            // Must be a simple key (no spaces, no directives like #if)
-            if (inner.Length > 0 && !inner.Contains(' ') && inner[0] != '#' && inner[0] != '/')
+            // Must be a simple key (no spaces, no nested braces, no directives like #if).
+            // Nested braces mean this line carries inline content (e.g. "{{#if x}}{{y}}") and
+            // must fall through to a paragraph for inline resolution rather than being treated
+            // as a single block placeholder.
+            if (inner.Length > 0
+                && !inner.Contains(' ')
+                && inner.IndexOf(OpenSymbol) < 0
+                && inner.IndexOf(CloseSymbol) < 0
+                && inner[0] != '#' && inner[0] != '/')
             {
                 key = inner.ToString();
                 return true;
@@ -147,6 +154,15 @@ public static class TemplateParser
         if (trimmed.StartsWith(OpenSymbol) && trimmed.EndsWith(CloseSymbol))
         {
             var inner = trimmed[2..^2].Trim();
+
+            // A standalone block directive must be the only thing on the line. If it carries nested
+            // braces it is an inline conditional wrapping content (e.g. "{{#if x}}text{{/if}}") and
+            // is handled during inline resolution inside a paragraph, not as a block node.
+            if (inner.IndexOf(OpenSymbol) >= 0 || inner.IndexOf(CloseSymbol) >= 0)
+            {
+                node = default!;
+                return false;
+            }
 
             if (inner.StartsWith("#if "))
             {
@@ -188,11 +204,86 @@ public static class TemplateParser
     }
 
     /// <summary>
-    /// Resolves inline {{key}} placeholders in text using the provided lookup function.
+    /// Resolves inline <c>{{#if key}}…{{/if}}</c> conditionals within a single text run (a heading
+    /// or paragraph). Content inside a conditional is kept when <paramref name="isTruthy"/> returns
+    /// true for its key, and dropped otherwise. Conditionals may nest. Non-conditional
+    /// <c>{{key}}</c> placeholders are preserved verbatim for a later
+    /// <see cref="ResolveInlinePlaceholders"/> pass.
     /// </summary>
+    /// <remarks>
+    /// Inline conditionals must be balanced within the same text run. Author a self-contained
+    /// optional line as <c>{{#if key}}content{{/if}}</c> on one line so the surrounding lines stay
+    /// tight; use standalone <c>{{#if key}}</c> / <c>{{/if}}</c> directive lines for multi-line
+    /// block sections instead.
+    /// </remarks>
+    public static string ResolveInlineConditionals(string text, Func<string, bool> isTruthy)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(isTruthy);
+
+        if (text.IndexOf("{{#if ", StringComparison.Ordinal) < 0)
+            return text;
+
+        var result = new System.Text.StringBuilder(text.Length);
+        int pos = 0;
+        int skipDepth = 0;
+
+        while (pos < text.Length)
+        {
+            int open = text.IndexOf(OpenSymbol, pos, StringComparison.Ordinal);
+            if (open < 0)
+            {
+                if (skipDepth == 0)
+                    result.Append(text, pos, text.Length - pos);
+                break;
+            }
+
+            if (skipDepth == 0)
+                result.Append(text, pos, open - pos);
+
+            int close = text.IndexOf(CloseSymbol, open + OpenSymbol.Length, StringComparison.Ordinal);
+            if (close < 0)
+            {
+                // Unterminated braces — treat the remainder as literal.
+                if (skipDepth == 0)
+                    result.Append(text, open, text.Length - open);
+                break;
+            }
+
+            var inner = text.AsSpan((open + OpenSymbol.Length)..close).Trim();
+
+            if (inner.StartsWith("#if "))
+            {
+                if (skipDepth > 0)
+                {
+                    skipDepth++;
+                }
+                else
+                {
+                    var key = inner[4..].Trim().ToString();
+                    if (!isTruthy(key))
+                        skipDepth = 1;
+                }
+            }
+            else if (inner.SequenceEqual("/if"))
+            {
+                if (skipDepth > 0)
+                    skipDepth--;
+            }
+            else if (skipDepth == 0)
+            {
+                // A normal placeholder or other braces: keep verbatim for the placeholder pass.
+                result.Append(text, open, close + CloseSymbol.Length - open);
+            }
+
+            pos = close + CloseSymbol.Length;
+        }
+
+        return result.ToString();
+    }
+
     /// <summary>
     /// Resolves inline {{key}} placeholders in text using the provided lookup function.
-    /// Returns the text with all known keys replaced and unknown keys preserved.
     /// </summary>
     public static string ResolveInlinePlaceholders(string text, Func<string, string?> lookup)
     {

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -295,25 +295,41 @@ public static class TemplateParser
             if (skipDepth == 0)
                 result.Append(text, pos, open - pos);
 
-            int close = text.IndexOf(CloseSymbol, open + OpenSymbol.Length, StringComparison.Ordinal);
+            // Find the next nested opener (from open+1, to catch an overlapping "{{{") and the
+            // token's close. Only a close occurring BEFORE the next nested opener terminates this
+            // token; bounding the close search to that region keeps scanning linear on pathological
+            // input (many adjacent "{{") instead of repeatedly rescanning toward a distant "}}".
+            int nestedOpen = text.IndexOf(OpenSymbol, open + 1, StringComparison.Ordinal);
+            int close;
+            if (nestedOpen >= 0)
+            {
+                int region = nestedOpen - (open + OpenSymbol.Length);
+                close = region > 0
+                    ? text.IndexOf(CloseSymbol, open + OpenSymbol.Length, region, StringComparison.Ordinal)
+                    : -1;
+            }
+            else
+            {
+                close = text.IndexOf(CloseSymbol, open + OpenSymbol.Length, StringComparison.Ordinal);
+            }
+
             if (close < 0)
             {
+                if (nestedOpen >= 0)
+                {
+                    // A nested "{{" precedes any close (e.g. "{{oops {{#if flag}}"): the run up to it
+                    // isn't a token. Emit it as literal and resume at the nested opener so a real
+                    // directive can't be swallowed inside a malformed token.
+                    if (skipDepth == 0)
+                        result.Append(text, open, nestedOpen - open);
+                    pos = nestedOpen;
+                    continue;
+                }
+
                 // Unterminated braces — treat the remainder as literal.
                 if (skipDepth == 0)
                     result.Append(text, open, text.Length - open);
                 break;
-            }
-
-            // A nested "{{" before this close means these braces don't form a single token (e.g.
-            // "{{oops {{#if flag}}"). Treat the run up to the nested opener as literal and resume
-            // scanning there, so a structural directive can't be swallowed inside a malformed token.
-            int nestedOpen = text.IndexOf(OpenSymbol, open + OpenSymbol.Length, StringComparison.Ordinal);
-            if (nestedOpen >= 0 && nestedOpen < close)
-            {
-                if (skipDepth == 0)
-                    result.Append(text, open, nestedOpen - open);
-                pos = nestedOpen;
-                continue;
             }
 
             var inner = text.AsSpan((open + OpenSymbol.Length)..close).Trim();
@@ -393,28 +409,39 @@ public static class TemplateParser
             result.Append(span[pos..outerOpen]);
 
             int keyStart = outerOpen + OpenSymbol.Length;
-            int closeIndex = span[keyStart..].IndexOf(CloseSymbol);
 
-            if (closeIndex < 0)
+            // Next nested opener (from outerOpen+1, to catch an overlapping "{{{") and the token's
+            // close. Only a close before the nested opener terminates this token; bounding the close
+            // search there keeps scanning linear on pathological input, mirroring the conditional pass.
+            int nestedOpen = text.IndexOf(OpenSymbol, outerOpen + 1, StringComparison.Ordinal);
+            int closeAbs;
+            if (nestedOpen >= 0)
             {
+                int region = nestedOpen - keyStart;
+                closeAbs = region > 0
+                    ? text.IndexOf(CloseSymbol, keyStart, region, StringComparison.Ordinal)
+                    : -1;
+            }
+            else
+            {
+                closeAbs = text.IndexOf(CloseSymbol, keyStart, StringComparison.Ordinal);
+            }
+
+            if (closeAbs < 0)
+            {
+                if (nestedOpen >= 0)
+                {
+                    // A nested "{{" precedes any close (e.g. "{{oops {{name}}"): emit the malformed
+                    // run up to the nested opener as literal and resume there so a valid nested
+                    // placeholder is still resolved rather than swallowed.
+                    result.Append(span[outerOpen..nestedOpen]);
+                    pos = nestedOpen;
+                    continue;
+                }
+
                 // No closing — append remainder as-is
                 result.Append(span[outerOpen..]);
                 break;
-            }
-
-            int closeAbs = keyStart + closeIndex;
-
-            // A nested "{{" before this close means these braces don't form a single placeholder
-            // token (e.g. "{{oops {{name}}"). Emit the malformed run up to the nested opener as
-            // literal and resume there, mirroring ResolveInlineConditionals, so a valid nested
-            // placeholder is still resolved rather than swallowed.
-            int nestedRel = span[keyStart..closeAbs].IndexOf(OpenSymbol);
-            if (nestedRel >= 0)
-            {
-                int nestedAbs = keyStart + nestedRel;
-                result.Append(span[outerOpen..nestedAbs]);
-                pos = nestedAbs;
-                continue;
             }
 
             var key = span[keyStart..closeAbs].Trim();

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -88,7 +88,37 @@ public static class TemplateParser
 
         FlushTable(nodes, ref tableLines);
         FlushParagraph(nodes, ref paragraphLines);
+        ValidateConditionalBalance(nodes);
         return nodes;
+    }
+
+    /// <summary>
+    /// Verifies that block-level <c>{{#if}}</c> / <c>{{/if}}</c> directives are balanced. An
+    /// unclosed <c>{{#if}}</c> would otherwise silently drop the remainder of the document at render
+    /// time (data-dependent on the key's truthiness), and a stray <c>{{/if}}</c> indicates an
+    /// authoring error; both are surfaced eagerly as a <see cref="FormatException"/>.
+    /// </summary>
+    private static void ValidateConditionalBalance(List<TemplateNode> nodes)
+    {
+        int depth = 0;
+        foreach (var node in nodes)
+        {
+            switch (node)
+            {
+                case ConditionalStartNode:
+                    depth++;
+                    break;
+                case ConditionalEndNode:
+                    if (depth == 0)
+                        throw new FormatException(
+                            "Unbalanced template conditional: '{{/if}}' without a matching '{{#if}}'.");
+                    depth--;
+                    break;
+            }
+        }
+        if (depth > 0)
+            throw new FormatException(
+                "Unbalanced template conditional: an '{{#if}}' block is missing its '{{/if}}'.");
     }
 
     private static void FlushParagraph(List<TemplateNode> nodes, ref List<string>? lines)
@@ -221,12 +251,14 @@ public static class TemplateParser
         ArgumentNullException.ThrowIfNull(text);
         ArgumentNullException.ThrowIfNull(isTruthy);
 
-        if (text.IndexOf("{{#if ", StringComparison.Ordinal) < 0)
+        if (text.IndexOf("{{#if ", StringComparison.Ordinal) < 0
+            && text.IndexOf("{{/if}}", StringComparison.Ordinal) < 0)
             return text;
 
         var result = new System.Text.StringBuilder(text.Length);
         int pos = 0;
         int skipDepth = 0;
+        int openDepth = 0;
 
         while (pos < text.Length)
         {
@@ -254,19 +286,32 @@ public static class TemplateParser
 
             if (inner.StartsWith("#if "))
             {
+                var key = inner[4..].Trim().ToString();
+                if (key.Length == 0)
+                    throw new FormatException(
+                        "Inline conditional '{{#if}}' requires a key.");
+                openDepth++;
                 if (skipDepth > 0)
                 {
                     skipDepth++;
                 }
                 else
                 {
-                    var key = inner[4..].Trim().ToString();
                     if (!isTruthy(key))
                         skipDepth = 1;
                 }
             }
+            else if (inner.SequenceEqual("#if"))
+            {
+                throw new FormatException(
+                    "Inline conditional '{{#if}}' requires a key.");
+            }
             else if (inner.SequenceEqual("/if"))
             {
+                if (openDepth == 0)
+                    throw new FormatException(
+                        "Unbalanced inline conditional: '{{/if}}' without a matching '{{#if}}'.");
+                openDepth--;
                 if (skipDepth > 0)
                     skipDepth--;
             }
@@ -278,6 +323,10 @@ public static class TemplateParser
 
             pos = close + CloseSymbol.Length;
         }
+
+        if (openDepth > 0)
+            throw new FormatException(
+                "Unbalanced inline conditional: an '{{#if}}' is missing its '{{/if}}'.");
 
         return result.ToString();
     }

--- a/src/Markout.Templates/TemplateParser.cs
+++ b/src/Markout.Templates/TemplateParser.cs
@@ -181,14 +181,14 @@ public static class TemplateParser
         {
             var inner = trimmed[2..^2].Trim();
 
-            // Must be a simple key (no spaces, no nested braces, no directives like #if).
-            // Nested braces mean this line carries inline content (e.g. "{{#if x}}{{y}}") and
-            // must fall through to a paragraph for inline resolution rather than being treated
-            // as a single block placeholder.
+            // Must be a simple key (no spaces, no braces of any kind, no directives like #if).
+            // Any brace character means this line carries inline content (e.g. "{{#if x}}{{y}}"
+            // or a trailing "}" as in "{{name}}}") and must fall through to a paragraph for inline
+            // resolution rather than being treated as a single block placeholder.
             if (inner.Length > 0
                 && !inner.Contains(' ')
-                && inner.IndexOf(OpenSymbol) < 0
-                && inner.IndexOf(CloseSymbol) < 0
+                && inner.IndexOf('{') < 0
+                && inner.IndexOf('}') < 0
                 && inner[0] != '#' && inner[0] != '/')
             {
                 key = inner.ToString();
@@ -274,8 +274,7 @@ public static class TemplateParser
         ArgumentNullException.ThrowIfNull(text);
         ArgumentNullException.ThrowIfNull(isTruthy);
 
-        if (text.IndexOf("{{#if", StringComparison.Ordinal) < 0
-            && text.IndexOf("{{/if}}", StringComparison.Ordinal) < 0)
+        if (text.IndexOf(OpenSymbol, StringComparison.Ordinal) < 0)
             return text;
 
         var result = new System.Text.StringBuilder(text.Length);
@@ -303,6 +302,18 @@ public static class TemplateParser
                 if (skipDepth == 0)
                     result.Append(text, open, text.Length - open);
                 break;
+            }
+
+            // A nested "{{" before this close means these braces don't form a single token (e.g.
+            // "{{oops {{#if flag}}"). Treat the run up to the nested opener as literal and resume
+            // scanning there, so a structural directive can't be swallowed inside a malformed token.
+            int nestedOpen = text.IndexOf(OpenSymbol, open + OpenSymbol.Length, StringComparison.Ordinal);
+            if (nestedOpen >= 0 && nestedOpen < close)
+            {
+                if (skipDepth == 0)
+                    result.Append(text, open, nestedOpen - open);
+                pos = nestedOpen;
+                continue;
             }
 
             var inner = text.AsSpan((open + OpenSymbol.Length)..close).Trim();

--- a/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
+++ b/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
@@ -177,4 +177,48 @@ public class BindingSemanticsTests
             .Render();
         Assert.Contains("shown", result);
     }
+
+    // --- Fix F: generic-only collections and the AOT-safe truthiness contract ---
+
+    [Fact]
+    public void ObjectBinding_EmptyGenericOnlyCollection_IsTruthy_AotLimitation()
+    {
+        // HashSet<T> does not implement the non-generic ICollection, and counting it would need
+        // reflection (breaks AOT) or enumeration (consumes one-shot sequences). So BindObject treats
+        // a generic-only collection as truthy-when-non-null. Documented, intentional contract.
+        var result = MarkoutTemplate.Parse("{{#if items}}\nshown\n{{/if}}")
+            .BindObject("items", new HashSet<int>())
+            .Render();
+        Assert.Contains("shown", result);
+    }
+
+    [Fact]
+    public void ListBinding_MaterializesHashSet_EmptyIsFalsy()
+    {
+        // The recommended path for emptiness-driven truthiness on any sequence: Bind materializes it.
+        var result = MarkoutTemplate.Parse("{{#if items}}\nshown\n{{/if}}")
+            .Bind("items", new HashSet<string>())
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    // --- Fix G: Int128/UInt128 participate in zero-is-falsy ---
+
+    [Fact]
+    public void ObjectBinding_Int128Zero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", Int128.Zero)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_UInt128Zero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", UInt128.Zero)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
 }

--- a/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
+++ b/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
@@ -118,4 +118,63 @@ public class BindingSemanticsTests
             .Render();
         Assert.Contains("shown", result);
     }
+
+    // --- Fix C: truthiness must not consume a one-shot enumerable ---
+
+    [Fact]
+    public void ObjectBinding_OneShotEnumerable_IsNotConsumedByTruthinessProbe()
+    {
+        int enumerations = 0;
+        IEnumerable<int> OneShot()
+        {
+            enumerations++;
+            yield return 1;
+        }
+
+        var result = MarkoutTemplate.Parse("{{#if seq}}\nshown\n{{/if}}")
+            .BindObject("seq", OneShot())
+            .Render();
+
+        // A non-collection enumerable is truthy when non-null, without enumerating it.
+        Assert.Contains("shown", result);
+        Assert.Equal(0, enumerations);
+    }
+
+    // --- Fix D: additional numeric types participate in zero-is-falsy ---
+
+    [Fact]
+    public void ObjectBinding_HalfZero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", (Half)0)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_NIntZero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", (nint)0)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_BigIntegerZero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", System.Numerics.BigInteger.Zero)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_BigIntegerNonZero_IsTruthy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", new System.Numerics.BigInteger(7))
+            .Render();
+        Assert.Contains("shown", result);
+    }
 }

--- a/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
+++ b/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
@@ -1,0 +1,121 @@
+using Markout;
+using Markout.Templates;
+
+namespace Markout.Templates.Tests;
+
+public class BindingSemanticsTests
+{
+    // --- Falsy semantics for conditional sections ---
+
+    [Fact]
+    public void StringBinding_EmptyString_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if k}}\nshown\n{{/if}}")
+            .Bind("k", "")
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void StringBinding_NonEmpty_IsTruthy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if k}}\nshown\n{{/if}}")
+            .Bind("k", "x")
+            .Render();
+        Assert.Contains("shown", result);
+    }
+
+    [Fact]
+    public void BoolBinding_False_ExcludesSection()
+    {
+        var result = MarkoutTemplate.Parse("{{#if flag}}\nshown\n{{/if}}")
+            .Bind("flag", false)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void BoolBinding_True_IncludesSection()
+    {
+        var result = MarkoutTemplate.Parse("{{#if flag}}\nshown\n{{/if}}")
+            .Bind("flag", true)
+            .Render();
+        Assert.Contains("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_ZeroNumber_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", 0)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_NonZeroNumber_IsTruthy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", 5)
+            .Render();
+        Assert.Contains("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_EmptyCollection_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if items}}\nshown\n{{/if}}")
+            .BindObject("items", new List<string>())
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_NonEmptyObject_IsTruthy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if data}}\nshown\n{{/if}}")
+            .BindObject("data", new object())
+            .Render();
+        Assert.Contains("shown", result);
+    }
+
+    // --- List binding ---
+
+    [Fact]
+    public void ListBinding_RendersBullets()
+    {
+        var result = MarkoutTemplate.Parse("{{items}}")
+            .Bind("items", new[] { "alpha", "beta" })
+            .Render();
+        Assert.Contains("- alpha", result);
+        Assert.Contains("- beta", result);
+    }
+
+    [Fact]
+    public void ListBinding_Inline_JoinsWithComma()
+    {
+        var result = MarkoutTemplate.Parse("Tags: {{items}}")
+            .Bind("items", new[] { "alpha", "beta" })
+            .Render()
+            .TrimEnd();
+        Assert.Equal("Tags: alpha, beta", result);
+    }
+
+    [Fact]
+    public void ListBinding_Empty_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if items}}\nshown\n{{/if}}")
+            .Bind("items", Array.Empty<string>())
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ListBinding_NonEmpty_IsTruthy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if items}}\nshown\n{{/if}}")
+            .Bind("items", new[] { "one" })
+            .Render();
+        Assert.Contains("shown", result);
+    }
+}

--- a/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
+++ b/tests/Markout.Templates.Tests/BindingSemanticsTests.cs
@@ -221,4 +221,31 @@ public class BindingSemanticsTests
             .Render();
         Assert.DoesNotContain("shown", result);
     }
+
+    [Fact]
+    public void ObjectBinding_NFloatZero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", new System.Runtime.InteropServices.NFloat(0))
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_ComplexZero_IsFalsy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", System.Numerics.Complex.Zero)
+            .Render();
+        Assert.DoesNotContain("shown", result);
+    }
+
+    [Fact]
+    public void ObjectBinding_ComplexNonZero_IsTruthy()
+    {
+        var result = MarkoutTemplate.Parse("{{#if n}}\nshown\n{{/if}}")
+            .BindObject("n", new System.Numerics.Complex(0, 1))
+            .Render();
+        Assert.Contains("shown", result);
+    }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -133,4 +133,69 @@ public class InlineConditionalTests
 
         Assert.Equal("A: 1\nB: 2", result);
     }
+
+    // --- Fix A: bound multi-line values keep their own blank-line separators ---
+
+    [Fact]
+    public void Render_BoundMultilineValue_KeepsBlankLineSeparators()
+    {
+        // The conditional-emptied-line drop must not swallow blank lines that live *inside*
+        // a bound value (placeholders are expanded after the drop).
+        var text = "{{#if show}}Body: {{body}}{{/if}}";
+        var result = MarkoutTemplate.Parse(text)
+            .Bind("show", true)
+            .Bind("body", "alpha\n\nbeta")
+            .Render()
+            .TrimEnd();
+
+        Assert.Contains("alpha", result);
+        Assert.Contains("beta", result);
+        // The blank line between the two words survives the paragraph render.
+        Assert.Contains("alpha\n\nbeta", result);
+    }
+
+    // --- Fix B: unbalanced conditionals throw eagerly ---
+
+    [Fact]
+    public void Parse_BlockConditional_MissingEnd_Throws()
+    {
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.Parse("{{#if x}}\ncontent"));
+    }
+
+    [Fact]
+    public void Parse_BlockConditional_StrayEnd_Throws()
+    {
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.Parse("content\n{{/if}}"));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_MissingEnd_Throws()
+    {
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("A {{#if k}}B", _ => true));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_StrayEnd_Throws()
+    {
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("A{{/if}}B", _ => true));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_EmptyKey_Throws()
+    {
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("A{{#if }}B{{/if}}", _ => true));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_MissingEnd_ThrowsEvenWhenTruthy()
+    {
+        // Data-independent: an unclosed truthy #if is still an authoring error.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("A{{#if k}}B", _ => false));
+    }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -57,9 +57,9 @@ public class InlineConditionalTests
     }
 
     [Fact]
-    public void ResolveInlineConditionals_NoConditionals_ReturnsInput()
+    public void ResolveInlineConditionals_NoBraces_ReturnsSameInstance()
     {
-        var input = "plain {{placeholder}} text";
+        var input = "plain text with no tokens";
         Assert.Same(input, TemplateParser.ResolveInlineConditionals(input, _ => true));
     }
 
@@ -231,5 +231,44 @@ public class InlineConditionalTests
         // authoring error (fail fast), not rendered literally. There is no escape mechanism.
         Assert.Throws<FormatException>(() =>
             TemplateParser.Parse("Use {{/if}} to close a block."));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_SpacePaddedDirectives_AreRecognized()
+    {
+        // The parsers trim inner whitespace, so the guard must too: "{{ #if x }}" / "{{ /if }}"
+        // are real directives regardless of padding and drive the same drop as the unpadded form.
+        var result = TemplateParser.ResolveInlineConditionals(
+            "A {{ #if show }}B{{ /if }} C", _ => false);
+        Assert.Equal("A  C", result);
+    }
+
+    [Fact]
+    public void Parse_SpacePaddedStrayEndInProse_Throws()
+    {
+        // A space-padded stray {{/if }} must fail fast just like the exact spelling.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.Parse("Use {{/if }} here"));
+    }
+
+    [Fact]
+    public void Parse_NestedOpenerHidingDirective_Throws()
+    {
+        // A malformed "{{oops {{#if flag}}" must not swallow the nested structural directive; the
+        // unclosed {{#if}} is surfaced instead of silently accepted.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.Parse("before {{oops {{#if flag}} after"));
+    }
+
+    [Fact]
+    public void Render_PlaceholderFollowedByStrayBrace_RendersLiterally()
+    {
+        // "{{name}}}" must resolve the {{name}} placeholder and keep the trailing brace, not be
+        // misclassified as a block placeholder with key "name}".
+        var result = MarkoutTemplate.Parse("{{name}}}")
+            .Bind("name", "Alice")
+            .Render()
+            .TrimEnd();
+        Assert.Equal("Alice}", result);
     }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -314,7 +314,7 @@ public class InlineConditionalTests
     }
 
     [Fact]
-    public void ResolveInlinePlaceholders_ManyAdjacentOpeners_IsLinear()
+    public void ResolveInlineConditionals_ManyAdjacentOpeners_IsLinear()
     {
         // Guards against O(n^2) rescanning: many adjacent "{{" followed by one close must resolve
         // quickly. Under quadratic behavior this input takes seconds; linear it is milliseconds.
@@ -326,5 +326,40 @@ public class InlineConditionalTests
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
             $"Placeholder scan took {sw.Elapsed.TotalSeconds:F2}s — expected linear time.");
         Assert.EndsWith("{{x}}", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_BraceInInlineDirectiveKey_Throws()
+    {
+        // "{{#if x} }}" carries a stray '}' inside the key ("x}") — a malformed reserved directive
+        // that must be rejected, not silently evaluated against a phantom "x}" binding.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("A{{#if x} }}B{{/if}}C", _ => true));
+    }
+
+    [Fact]
+    public void Parse_BraceInBlockDirectiveKey_Throws()
+    {
+        // Block directive "{{#if x}}}" parses a stray '}' into the key ("x}") — reject it.
+        Assert.Throws<FormatException>(() =>
+            MarkoutTemplate.Parse("{{#if x}}}\nbody\n{{/if}}"));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_UnterminatedDirective_Throws()
+    {
+        // A reserved directive with no closing "}}" is malformed, not literal prose.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("{{#if show\nbody", _ => true));
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("text {{/if", _ => true));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_UnterminatedPlaceholder_StaysLiteral()
+    {
+        // A non-directive unterminated "{{" must still degrade gracefully to literal text.
+        var result = TemplateParser.ResolveInlineConditionals("keep {{name", _ => true);
+        Assert.Equal("keep {{name", result);
     }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -198,4 +198,38 @@ public class InlineConditionalTests
         Assert.Throws<FormatException>(() =>
             TemplateParser.ResolveInlineConditionals("A{{#if k}}B", _ => false));
     }
+
+    [Fact]
+    public void ResolveInlineConditionals_KeylessNoSpace_Throws()
+    {
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("A{{#if}}B{{/if}}", _ => true));
+    }
+
+    [Fact]
+    public void Parse_KeylessBlockIf_Throws()
+    {
+        // A standalone {{#if}} (no key, no space) must not silently render as literal text.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.Parse("{{#if}}\nbody\n{{/if}}"));
+    }
+
+    [Fact]
+    public void Parse_InlineErrorInsideFalsyBlock_ThrowsRegardlessOfBinding()
+    {
+        // The malformed inline {{#if inner}} lives inside a block section; parse-time validation is
+        // data-independent, so the template is rejected even though the block would be skipped when
+        // 'outer' is falsy. Previously this escaped both validators until 'outer' happened to be truthy.
+        var template = "{{#if outer}}\nsome {{#if inner}} text no close\n{{/if}}";
+        Assert.Throws<FormatException>(() => TemplateParser.Parse(template));
+    }
+
+    [Fact]
+    public void Parse_LiteralConditionalTokenInProse_Throws()
+    {
+        // Structural directive tokens are reserved: a bare {{/if}} in prose is treated as an
+        // authoring error (fail fast), not rendered literally. There is no escape mechanism.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.Parse("Use {{/if}} to close a block."));
+    }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -1,0 +1,136 @@
+using Markout.Templates;
+
+namespace Markout.Templates.Tests;
+
+public class InlineConditionalTests
+{
+    // --- TemplateParser.ResolveInlineConditionals ---
+
+    [Fact]
+    public void ResolveInlineConditionals_KeepsTruthyContent()
+    {
+        var result = TemplateParser.ResolveInlineConditionals(
+            "Ref: {{#if has}}{{ref}}{{/if}}", _ => true);
+        Assert.Equal("Ref: {{ref}}", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_DropsFalsyContent()
+    {
+        var result = TemplateParser.ResolveInlineConditionals(
+            "Ref: {{#if has}}{{ref}}{{/if}}done", _ => false);
+        Assert.Equal("Ref: done", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_PreservesPlaceholdersForLaterPass()
+    {
+        // Non-conditional placeholders must survive verbatim for ResolveInlinePlaceholders.
+        var result = TemplateParser.ResolveInlineConditionals("{{a}} and {{b}}", _ => true);
+        Assert.Equal("{{a}} and {{b}}", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_Nested_InnerFalsy()
+    {
+        var result = TemplateParser.ResolveInlineConditionals(
+            "A{{#if outer}}B{{#if inner}}C{{/if}}D{{/if}}E",
+            key => key == "outer");
+        Assert.Equal("ABDE", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_Nested_OuterFalsy_DropsAll()
+    {
+        var result = TemplateParser.ResolveInlineConditionals(
+            "A{{#if outer}}B{{#if inner}}C{{/if}}D{{/if}}E",
+            key => key == "inner");
+        Assert.Equal("AE", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_SpansNewlines()
+    {
+        var result = TemplateParser.ResolveInlineConditionals(
+            "one\n{{#if drop}}two\n{{/if}}three", _ => false);
+        Assert.Equal("one\nthree", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_NoConditionals_ReturnsInput()
+    {
+        var input = "plain {{placeholder}} text";
+        Assert.Same(input, TemplateParser.ResolveInlineConditionals(input, _ => true));
+    }
+
+    // --- Parser hardening: inline directives must not be misparsed as block nodes ---
+
+    [Fact]
+    public void Parse_InlineConditionalLine_IsParagraphNotBlockDirective()
+    {
+        // Regression: a line carrying an inline {{#if}}…{{/if}} must not be swallowed as a
+        // block ConditionalStartNode (which previously produced a garbage key and skipped to EOF).
+        var nodes = TemplateParser.Parse("Ref: {{#if has}}{{ref}}{{/if}}");
+        var para = Assert.IsType<ParagraphNode>(Assert.Single(nodes));
+        Assert.Equal("Ref: {{#if has}}{{ref}}{{/if}}", para.Text);
+    }
+
+    [Fact]
+    public void Parse_LineWithMultiplePlaceholders_IsParagraphNotBlockPlaceholder()
+    {
+        var nodes = TemplateParser.Parse("{{a}} {{b}}");
+        Assert.IsType<ParagraphNode>(Assert.Single(nodes));
+    }
+
+    [Fact]
+    public void Parse_StandaloneDirectivesStillWork()
+    {
+        var nodes = TemplateParser.Parse("{{#if x}}\ncontent\n{{/if}}");
+        Assert.Equal(new ConditionalStartNode("x"), nodes[0]);
+        Assert.IsType<ConditionalEndNode>(nodes[^1]);
+    }
+
+    // --- End-to-end render: tight optional lines ---
+
+    [Fact]
+    public void Render_InlineConditional_OmittedLineLeavesNoBlankGap()
+    {
+        var text = "Corpus: {{corpus}}\n{{#if ref}}Baseline ref: {{ref}}{{/if}}\nCoverage: {{cov}}";
+        var result = MarkoutTemplate.Parse(text)
+            .Bind("corpus", "8,000 methods")
+            .Bind("cov", "validity 2")
+            .Render()
+            .TrimEnd();
+
+        Assert.Equal("Corpus: 8,000 methods\nCoverage: validity 2", result);
+        Assert.DoesNotContain("Baseline ref", result);
+    }
+
+    [Fact]
+    public void Render_InlineConditional_PresentLineStaysTight()
+    {
+        var text = "Corpus: {{corpus}}\n{{#if ref}}Baseline ref: {{ref}}{{/if}}\nCoverage: {{cov}}";
+        var result = MarkoutTemplate.Parse(text)
+            .Bind("corpus", "8,000 methods")
+            .Bind("ref", "`abc123`")
+            .Bind("cov", "validity 2")
+            .Render()
+            .TrimEnd();
+
+        Assert.Equal("Corpus: 8,000 methods\nBaseline ref: `abc123`\nCoverage: validity 2", result);
+    }
+
+    [Fact]
+    public void Render_InlineConditional_DrivenByFalseBool_OmitsLine()
+    {
+        var text = "A: {{a}}\n{{#if risky}}Risk: {{msg}}{{/if}}\nB: {{b}}";
+        var result = MarkoutTemplate.Parse(text)
+            .Bind("a", "1").Bind("b", "2")
+            .Bind("risky", false)
+            .Bind("msg", "warning")
+            .Render()
+            .TrimEnd();
+
+        Assert.Equal("A: 1\nB: 2", result);
+    }
+}

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -362,4 +362,24 @@ public class InlineConditionalTests
         var result = TemplateParser.ResolveInlineConditionals("keep {{name", _ => true);
         Assert.Equal("keep {{name", result);
     }
+
+    [Fact]
+    public void ResolveInlineConditionals_TabPrefixedUnterminatedDirective_Throws()
+    {
+        // Reserved-directive detection must recognize any leading whitespace (not just spaces),
+        // matching the Trim() applied to terminated tokens.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("{{\t#if show\nbody", _ => true));
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_ClosedReservedPrefixNonDirective_Throws()
+    {
+        // A closed token beginning with reserved '/' or '#' that is not a valid directive form
+        // (e.g. a stray brace in "{{/if} }}") is malformed and must not pass through as data.
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("{{/if} }}", _ => true));
+        Assert.Throws<FormatException>(() =>
+            TemplateParser.ResolveInlineConditionals("{{#foo}}", _ => true));
+    }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -292,4 +292,39 @@ public class InlineConditionalTests
             .TrimEnd();
         Assert.Equal("before {{oops Alice after", result);
     }
+
+    [Fact]
+    public void ResolveInlinePlaceholders_OverlappingOpener_ResolvesInner()
+    {
+        // "{{{x}}" overlaps: the first brace is literal, then {{x}} resolves. The nested-opener
+        // search must start at outerOpen+1 to see the overlapping "{{".
+        var result = TemplateParser.ResolveInlinePlaceholders(
+            "{{{x}}", key => key == "x" ? "X" : null);
+        Assert.Equal("{X", result);
+    }
+
+    [Fact]
+    public void ResolveInlineConditionals_OverlappingOpenerBeforeDirective_Recognized()
+    {
+        // "{{{#if flag}}shown{{/if}}" — the leading brace is literal and the {{#if}} is a real
+        // directive, so a truthy flag keeps "shown" and it does not throw a stray-close error.
+        var result = TemplateParser.ResolveInlineConditionals(
+            "{{{#if flag}}shown{{/if}}", _ => true);
+        Assert.Equal("{shown", result);
+    }
+
+    [Fact]
+    public void ResolveInlinePlaceholders_ManyAdjacentOpeners_IsLinear()
+    {
+        // Guards against O(n^2) rescanning: many adjacent "{{" followed by one close must resolve
+        // quickly. Under quadratic behavior this input takes seconds; linear it is milliseconds.
+        const int n = 200_000;
+        var input = new string('{', 2 * n) + "x}}";
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = TemplateParser.ResolveInlinePlaceholders(input, _ => null);
+        sw.Stop();
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"Placeholder scan took {sw.Elapsed.TotalSeconds:F2}s — expected linear time.");
+        Assert.EndsWith("{{x}}", result);
+    }
 }

--- a/tests/Markout.Templates.Tests/InlineConditionalTests.cs
+++ b/tests/Markout.Templates.Tests/InlineConditionalTests.cs
@@ -271,4 +271,25 @@ public class InlineConditionalTests
             .TrimEnd();
         Assert.Equal("Alice}", result);
     }
+
+    [Fact]
+    public void ResolveInlinePlaceholders_NestedOpener_ResolvesInnerPlaceholder()
+    {
+        // A malformed "{{oops {{name}}" must not swallow the valid nested placeholder; the
+        // placeholder pass mirrors the conditional pass and resumes at the nested opener.
+        var result = TemplateParser.ResolveInlinePlaceholders(
+            "before {{oops {{name}} after",
+            key => key == "name" ? "Alice" : null);
+        Assert.Equal("before {{oops Alice after", result);
+    }
+
+    [Fact]
+    public void Render_PlaceholderWithNestedOpener_ResolvesInner()
+    {
+        var result = MarkoutTemplate.Parse("before {{oops {{name}} after")
+            .Bind("name", "Alice")
+            .Render()
+            .TrimEnd();
+        Assert.Equal("before {{oops Alice after", result);
+    }
 }


### PR DESCRIPTION
## Summary

Extends `Markout.Templates` so a prose-first document can host data-driven, glyph-bearing Markout content with **tight** optional lines — the shape needed to render report "cards" (heading + header fields + a metric table + conditional prose) entirely from an authored `.md` template rather than imperative writer calls.

## What changed

- **Inline conditionals** — new `TemplateParser.ResolveInlineConditionals` (nesting-aware). Wrap a single line as `{{#if key}}content{{/if}}` and, when the key is falsy, the line is dropped with no blank gap so neighbouring lines stay tight. Non-conditional `{{key}}` placeholders are preserved for the existing placeholder pass. Standalone `{{#if}}` / `{{/if}}` directive lines continue to gate multi-line blocks.
- **Parser hardening** — `{{#if}}` / `{{/if}}` / `{{key}}` are treated as *block* nodes only when they are the entire line with no nested braces. Fixes a silent-corruption bug where an inline directive produced a garbage key and skipped rendering to EOF.
- **Falsy semantics** — `{{#if}}` now treats `false`, empty string, empty collection, and numeric zero as falsy (in addition to unbound / `null`).
- **Convenience bindings** — `Bind(key, IEnumerable<string>)` renders a bullet list (joins with `, ` inline) and `Bind(key, bool)` gates a conditional section directly.

## Tests

Adds `InlineConditionalTests` and `BindingSemanticsTests` (25 cases). Full `Markout.Templates.Tests` suite: **84 pass, 0 fail**. Full solution builds clean.

## Versioning / docs

- Bumps `Markout.Templates` 0.2.0 → 0.3.0.
- Updates the README Templates capability list.

Motivated by migrating the dotnet-inspect decompiler quality diff card fully to Markout; a prototype validated the card rendering faithfully (tight header, glyph table, bullet lists, conditional sections) against these changes.
