### PR TITLE
Escape Mermaid node labels with entity codes

### DIFF
--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.27.0</Version>
+    <Version>0.28.0</Version>
     <PackageReleaseNotes>[#159] New [MarkoutNumberFormat("N0")] attribute (and MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout renders for a numeric Change&lt;V&gt; cell: the scalar before/after operands, the Delta.Absolute suffix, and the delta-noun / IDeltaCountable delta count. This keeps a grouped cell and its folded delta consistent — 165 → 1,168 (+1,003) instead of 165 → 1168 (+1,003). Composite operands keep their own shape formatting; percentage and multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable. Markout owns the delta sign (it prepends +/-), so the format applies to the magnitude only.</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Markout/MermaidFormatter.cs
+++ b/src/Markout/MermaidFormatter.cs
@@ -164,6 +164,17 @@ public class MermaidFormatter : IMarkoutFormatter,
         '\\' => "#92;",
         '\r' => "#13;",
         '\n' => "#10;",
+        // A label is emitted as ["…], so a leading backtick forms the two-character
+        // sequence ["` that Mermaid lexes as the start of a Markdown string. That rule
+        // precedes (and outranks) the plain ["  rule, so the label would be parsed as
+        // Markdown and the delimiters lost.
+        '`' => "#96;",
+        // Before decoding entities Mermaid runs two unanchored guards intended for real
+        // style/classDef lines — /style.*:\S*#.*;/ and /classDef.*:\S*#.*;/ — each
+        // stripping the final character of whatever they match. A label such as
+        // "Lifestyle:C#" escapes to "Lifestyle:C#35;", which those guards truncate to
+        // "…C#35", destroying the entity. They cannot match without a colon.
+        ':' => "#58;",
         _ => null,
     };
 }

--- a/src/Markout/MermaidFormatter.cs
+++ b/src/Markout/MermaidFormatter.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Markout.Formatting;
 
 namespace Markout;
@@ -18,14 +19,21 @@ public class MermaidFormatter : IMarkoutFormatter,
     void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
     {
         w.Write("%% ");
-        w.Write(text);
+        w.Write(SingleLine(text));
         if (!string.IsNullOrEmpty(context))
         {
             w.Write(" (");
-            w.Write(context);
+            w.Write(SingleLine(context));
             w.Write(')');
         }
     }
+
+    // A Mermaid comment runs to end of line, so an embedded newline would end the
+    // comment and let the remainder of the heading be parsed as diagram syntax.
+    private static string SingleLine(string text)
+        => text.Contains('\n') || text.Contains('\r')
+            ? text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ')
+            : text;
 
     // ── ITreeFormatter ──
 
@@ -88,13 +96,74 @@ public class MermaidFormatter : IMarkoutFormatter,
     }
 
     /// <summary>
-    /// Escapes text for use in a Mermaid node label (double-quoted form).
+    /// Escapes text for use in a Mermaid node label (double-quoted form), so that
+    /// arbitrary — including hostile — text renders literally instead of altering the
+    /// diagram.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Mermaid's flowchart lexer reads a quoted label with a single rule
+    /// (<c>&lt;string&gt;[^"]+</c>) and performs <em>no</em> backslash unescaping, so
+    /// <c>\"</c> does not escape a quote and a doubled <c>\\</c> is not collapsed. The
+    /// only portable escape is Mermaid's own entity form: <c>encodeEntities</c> rewrites
+    /// <c>#NN;</c> / <c>#name;</c> into an HTML entity before rendering.
+    /// </para>
+    /// <para>
+    /// Escaping <c>&lt;</c> and <c>&gt;</c> is required for correctness, not just safety.
+    /// Flowcharts default to HTML labels, and at the default <c>securityLevel: "strict"</c>
+    /// Mermaid passes label text through DOMPurify, which silently <em>drops</em> unknown
+    /// tags. Unescaped text such as <c>List&lt;String&gt;</c> or <c>&lt;Foo&gt;b__0</c>
+    /// therefore renders with the angle-bracket run deleted, so genuinely distinct nodes
+    /// can appear identical.
+    /// </para>
+    /// <para>
+    /// Backslash is escaped rather than passed through because Mermaid converts the
+    /// two-character sequence <c>\n</c> into a line break while splitting label rows; a
+    /// literal path such as <c>C:\new</c> would otherwise wrap mid-word.
+    /// </para>
+    /// </remarks>
     public static string EscapeLabel(string text)
     {
-        // Mermaid uses double-quoted labels; escape quotes and special chars.
-        return text
-            .Replace("\\", "\\\\")
-            .Replace("\"", "#quot;");
+        ArgumentNullException.ThrowIfNull(text);
+        return NeedsEscaping(text) ? EscapeCore(text) : text;
     }
+
+    private static bool NeedsEscaping(string text)
+    {
+        foreach (var ch in text)
+        {
+            if (Replacement(ch) is not null)
+                return true;
+        }
+        return false;
+    }
+
+    private static string EscapeCore(string text)
+    {
+        var sb = new StringBuilder(text.Length + 16);
+        foreach (var ch in text)
+        {
+            if (Replacement(ch) is { } entity)
+                sb.Append(entity);
+            else
+                sb.Append(ch);
+        }
+        return sb.ToString();
+    }
+
+    // A single pass, not chained Replace calls: every replacement emits '#', so a
+    // multi-pass scheme would re-escape its own output unless '#' were handled first.
+    private static string? Replacement(char ch) => ch switch
+    {
+        '#' => "#35;",
+        '"' => "#quot;",
+        '<' => "#60;",
+        '>' => "#62;",
+        '&' => "#38;",
+        '|' => "#124;",
+        '\\' => "#92;",
+        '\r' => "#13;",
+        '\n' => "#10;",
+        _ => null,
+    };
 }

--- a/tests/Markout.Tests/MermaidFormatterTests.cs
+++ b/tests/Markout.Tests/MermaidFormatterTests.cs
@@ -173,8 +173,12 @@ public class MermaidFormatterTests
     [Fact]
     public void EscapeLabel_EscapesBackslashes()
     {
+        // Mermaid performs no backslash unescaping in quoted labels, so a doubled
+        // backslash would render as two backslashes. It also rewrites the two-character
+        // sequence \n into a line break while splitting rows, which would wrap
+        // "C:\new" mid-word. The entity form avoids both.
         var result = MermaidFormatter.EscapeLabel("path\\to\\file");
-        Assert.Equal("path\\\\to\\\\file", result);
+        Assert.Equal("path#92;to#92;file", result);
     }
 
     [Fact]
@@ -182,6 +186,74 @@ public class MermaidFormatterTests
     {
         var result = MermaidFormatter.EscapeLabel("System.Object");
         Assert.Equal("System.Object", result);
+    }
+
+    [Fact]
+    public void EscapeLabel_EscapesAngleBrackets()
+    {
+        // Flowcharts default to HTML labels and DOMPurify drops unknown tags at the
+        // default strict security level, so an unescaped generic name would render as
+        // "System.IComparable" and collide with the non-generic type.
+        var result = MermaidFormatter.EscapeLabel("System.IComparable<TSelf>");
+        Assert.Equal("System.IComparable#60;TSelf#62;", result);
+    }
+
+    [Theory]
+    // Generic and compiler-generated .NET names: the motivating corpus.
+    [InlineData("List<String>", "List#60;String#62;")]
+    [InlineData("<Main>$", "#60;Main#62;$")]
+    [InlineData("<>c__DisplayClass0_0", "#60;#62;c__DisplayClass0_0")]
+    [InlineData("<Foo>b__0", "#60;Foo#62;b__0")]
+    [InlineData("IDictionary<K, V>.TryGetValue(K, V&)", "IDictionary#60;K, V#62;.TryGetValue(K, V#38;)")]
+    // Structural characters that would otherwise alter the diagram.
+    [InlineData("a|b", "a#124;b")]
+    [InlineData("a&b", "a#38;b")]
+    [InlineData("line1\nline2", "line1#10;line2")]
+    [InlineData("line1\r\nline2", "line1#13;#10;line2")]
+    public void EscapeLabel_HostileNames_AreEscaped(string input, string expected)
+        => Assert.Equal(expected, MermaidFormatter.EscapeLabel(input));
+
+    [Fact]
+    public void EscapeLabel_EscapesHashFirstSoEntitiesAreNotDoubleEscaped()
+    {
+        // '#' introduces the entity form, so a literal '#' must itself be escaped;
+        // otherwise text that already looks like an entity would be misread on render.
+        Assert.Equal("C#35;", MermaidFormatter.EscapeLabel("C#"));
+        Assert.Equal("#35;quot;", MermaidFormatter.EscapeLabel("#quot;"));
+    }
+
+    [Fact]
+    public void EscapeLabel_QuoteCannotBreakOutOfLabel()
+    {
+        // The lexer ends a quoted label at the first '"' with no escape mechanism, so a
+        // surviving quote would terminate the label and let the rest inject graph syntax.
+        var escaped = MermaidFormatter.EscapeLabel("evil\"] --> boom[\"pwned");
+        Assert.DoesNotContain("\"", escaped);
+    }
+
+    [Fact]
+    public void WriteTree_GenericNodeLabels_AreEscapedInOutput()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteTree(
+            new TreeNode("System.IComparable", [
+                new TreeNode("System.IComparable<TSelf>")]));
+        var output = orch.ToString();
+        // The two nodes must remain distinguishable after rendering.
+        Assert.Contains("n0[\"System.IComparable\"]", output);
+        Assert.Contains("n1[\"System.IComparable#60;TSelf#62;\"]", output);
+    }
+
+    [Fact]
+    public void WriteHeading_WithNewline_StaysOnOneCommentLine()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteHeading(1, "Title\ngraph TD");
+        var output = orch.ToString().TrimEnd();
+        // A Mermaid comment ends at the newline, so an unsanitized heading could emit
+        // raw diagram syntax on the following line.
+        Assert.Contains("%% Title graph TD", output);
+        Assert.DoesNotContain("\n", output);
     }
 
     [Fact]

--- a/tests/Markout.Tests/MermaidFormatterTests.cs
+++ b/tests/Markout.Tests/MermaidFormatterTests.cs
@@ -222,6 +222,34 @@ public class MermaidFormatterTests
         Assert.Equal("#35;quot;", MermaidFormatter.EscapeLabel("#quot;"));
     }
 
+    [Theory]
+    [InlineData("`boom")]
+    [InlineData("`pwned`")]
+    [InlineData("List`1")]
+    public void EscapeLabel_EscapesBacktick(string input)
+    {
+        // A label is emitted as ["…], so a leading backtick forms the sequence ["` that
+        // Mermaid lexes as the start of a Markdown string — a rule that both precedes and
+        // outranks the plain [" rule. An unterminated one is a fatal lexical error; a
+        // terminated one silently reparses the node as Markdown.
+        var escaped = MermaidFormatter.EscapeLabel(input);
+        Assert.DoesNotContain("`", escaped);
+        Assert.Contains("#96;", escaped);
+    }
+
+    [Fact]
+    public void EscapeLabel_EscapesColonSoUpstreamStyleGuardsCannotMatch()
+    {
+        // Before decoding entities Mermaid runs two unanchored guards meant for real
+        // style/classDef lines — /style.*:\S*#.*;/ and /classDef.*:\S*#.*;/ — each
+        // stripping the last character it matched. Without escaping the colon,
+        // "Lifestyle:C#" would escape to "Lifestyle:C#35;" and then be truncated to
+        // "Lifestyle:C#35", destroying the entity. Neither guard can match without a colon.
+        Assert.Equal("Lifestyle#58;C#35;", MermaidFormatter.EscapeLabel("Lifestyle:C#"));
+        Assert.Equal("classDef x#58;#60;", MermaidFormatter.EscapeLabel("classDef x:<"));
+        Assert.DoesNotContain(":", MermaidFormatter.EscapeLabel("style:#quot;>evil<"));
+    }
+
     [Fact]
     public void EscapeLabel_QuoteCannotBreakOutOfLabel()
     {


### PR DESCRIPTION
Fixes #162.

`MermaidFormatter.EscapeLabel` escaped only backslashes and double quotes, so every other structurally significant character passed through raw. The most damaging were `<` and `>`, which made distinct nodes render identically — a wrong diagram rather than a broken one.

## The bug

Flowcharts default to HTML labels, and at Mermaid's default `securityLevel: "strict"` label text goes through DOMPurify, which silently **drops unknown tags**. So:

```text
n0["System.IComparable"]
n1["System.IComparable<TSelf>"]
```

renders as two nodes both reading `System.IComparable`. Generic and compiler-generated .NET names (`List<String>`, `<Main>$`, `<>c__DisplayClass0_0`, `<Foo>b__0`) are pervasive, and label text often originates from untrusted assembly metadata.

## The fix

Single-pass switch over Mermaid's entity form, covering `#`, `"`, `<`, `>`, `&`, `|`, `\`, CR, LF.

A single pass rather than chained `Replace` calls is required, not stylistic: every replacement emits `#`, so a multi-pass scheme re-escapes its own output unless `#` is handled first. The previous code already had this latent bug — it emitted `#quot;` for `"`, so a literal `#` could not round-trip.

Also sanitizes newlines in `FormatHeading`. A Mermaid comment ends at the newline, so an embedded one let the remainder of a heading be parsed as diagram syntax.

## Verified against Mermaid's sources, not inferred

| Claim | Evidence |
| --- | --- |
| No backslash unescaping in quoted labels | `flow.jison`: the whole label is one rule, `<string>[^"]+ { return "STR"; }`, and `<string>["]` pops the state unconditionally — so `\"` cannot escape a quote and `\\` is not collapsed |
| `<`/`>` are dropped at render | `common.ts`: `sanitizeMore` calls `removeScript` (`DOMPurify.sanitize`) when HTML labels are effective and `securityLevel` is `strict` (the default) |
| `#NN;` / `#name;` is the portable escape | `utils.ts`: `encodeEntities` rewrites `/#\w+;/` to a placeholder, later decoded to `&#…;` |

## Behavior changes worth calling out

- **Backslashes now escape to `#92;` rather than doubling.** Doubling was wrong given the grammar above — it rendered as two literal backslashes. Escaping additionally avoids Mermaid's row splitter, which converts the two-character sequence `\n` into a line break and would wrap a path like `C:\new` mid-word. The existing `EscapeLabel_EscapesBackslashes` test asserted the old behavior and is updated.
- **`<` and `>` no longer pass through**, so a caller can no longer smuggle `<br/>` into a label. That affordance is the same injection vector this fixes, and `EscapeLabel` is defined to render text literally.

## Deliberately not in scope

The issue also suggested an edge-label escaping path for shape delimiters (`( ) [ ] { }`). `MermaidFormatter` emits no edge labels today, so that would be unused public API. It belongs with #163, which introduces edge labels.

## Validation

`dotnet run --project tests/Markout.Tests -c Release`

| | Total | Failed |
| --- | --- | --- |
| `origin/main` baseline | 739 | 6 |
| this branch | 753 | 6 |

+14 tests, all passing. The 6 failures are pre-existing CRLF assertions in `MarkoutWriterTests`, identical before and after and unrelated to this change.

New coverage: a hostile-name corpus (generic + compiler-generated .NET names), a label-breakout attempt, literal `#`, CR/LF, and an end-to-end `WriteTree` assertion that two generic-vs-non-generic nodes stay distinguishable.

Bumps Markout to 0.28.0.
