### PR TITLE
Add a graph shape primitive (WriteGraph) as a peer to WriteTree

### DIFF
--- a/docs/design/data-writer-model.md
+++ b/docs/design/data-writer-model.md
@@ -24,6 +24,7 @@ The `MarkoutShape` enum defines the vocabulary of data relationships:
 | **Tables** | Uniform columnar rows | Lists of records, comparison data |
 | **Lists** | Ordered/unordered items | Features, steps, options |
 | **Trees** | Hierarchical parent-child | Org charts, file structures |
+| **Graphs** | Directed relationships between deduplicated nodes | Call graphs, dependency graphs |
 | **Descriptions** | Term with explanation | Glossaries, definitions |
 | **Metrics** | Labeled measurements | Test counts, performance data |
 | **Breakdowns** | Proportional composition | Category distributions |

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -127,6 +127,7 @@ These add meaning beyond raw document structure. They represent specific data re
 | **Descriptions** | Description | `WriteDescriptions` | `Description` |
 | **Callouts** | Attention | `WriteCallout` | `Callout` |
 | **Trees** | Hierarchy | `WriteTree` | `TreeNode` |
+| **Graphs** | Directed relationship | `WriteGraph` | `Graph` |
 
 ### Tier 3: Data Visualizations
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -829,8 +829,8 @@ Each formatter renders the graph as whatever its format can express:
 | Formatter | Lowering |
 |---|---|
 | `MermaidFormatter` | `graph TD` flowchart; focus declared first, groups as subgraphs |
-| `MarkdownFormatter`, `TableFormatter` | edge table, one row per edge |
-| `PlainTextFormatter`, `DiagramFormatter`, `UnicodeFormatter` | tree rooted at the focus node |
+| `TableFormatter` | edge table, one row per edge |
+| `MarkdownFormatter`, `PlainTextFormatter`, `DiagramFormatter`, `UnicodeFormatter` | tree rooted at the focus node |
 
 `GraphLowering` exposes those projections directly, so a custom formatter can reuse them:
 
@@ -838,6 +838,9 @@ Each formatter renders the graph as whatever its format can express:
 var table = GraphLowering.ToEdgeTable(graph);   // headers + one row per edge
 var roots = GraphLowering.ToTree(graph);        // TreeNode[] rooted at the focus
 ```
+
+Both take an optional label selector, so a formatter can decorate node text — emphasizing
+`Emphasized` nodes, for example — without the lowering knowing what the decoration means.
 
 In the tree lowering a node is expanded the first time it is reached; a later arrival renders as a
 leaf prefixed with `↩`, which terminates cycles and keeps a shared node from being duplicated.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -788,6 +788,69 @@ new TreeNode("Warning") { Badge = "🟡" }
 
 > The [LatestCves](../samples/LatestCves/LatestCves.cs) sample uses trees with icons to display CVE severity.
 
+## Graphs
+
+A tree cannot express a relationship where the same entity is reached more than once — it has to
+repeat the node, which makes one entity look like several. `Graph` deduplicates node identity, so
+use it when edges may converge, diverge, or cycle:
+
+```csharp
+var graph = new Graph(
+    nodes:
+    [
+        new GraphNode("parse", "Parser.Parse"),
+        new GraphNode("lex", "Lexer.Next"),
+        new GraphNode("emit", "Emitter.Write"),
+        new GraphNode("log", "Log.Trace") { Group = "Diagnostics", Emphasized = true }
+    ],
+    edges:
+    [
+        new GraphEdge("parse", "lex"),
+        new GraphEdge("parse", "emit"),
+        new GraphEdge("lex", "log"),
+        new GraphEdge("emit", "log")
+    ],
+    focusKey: "parse");
+
+writer.WriteGraph(graph);
+```
+
+`GraphNode.Key` is opaque. It wires edges to nodes and is never written to the output — formatters
+allocate their own emitted identifiers, so caller data can only ever appear inside an escaped label.
+
+Direction is explicit and always points `From` → `To`. If you hold an inverted relationship such as
+"who calls me", invert it once when building the graph rather than leaving each formatter to
+reinterpret it.
+
+### Lowerings
+
+Each formatter renders the graph as whatever its format can express:
+
+| Formatter | Lowering |
+|---|---|
+| `MermaidFormatter` | `graph TD` flowchart; focus declared first, groups as subgraphs |
+| `MarkdownFormatter`, `TableFormatter` | edge table, one row per edge |
+| `PlainTextFormatter`, `DiagramFormatter`, `UnicodeFormatter` | tree rooted at the focus node |
+
+`GraphLowering` exposes those projections directly, so a custom formatter can reuse them:
+
+```csharp
+var table = GraphLowering.ToEdgeTable(graph);   // headers + one row per edge
+var roots = GraphLowering.ToTree(graph);        // TreeNode[] rooted at the focus
+```
+
+In the tree lowering a node is expanded the first time it is reached; a later arrival renders as a
+leaf prefixed with `↩`, which terminates cycles and keeps a shared node from being duplicated.
+Nodes unreachable from the root are appended as extra roots, so no part of the graph is dropped.
+
+`Group` clusters nodes — a Mermaid subgraph, or `From Group` / `To Group` columns in an edge table.
+`Emphasized` marks a node as noteworthy; it augments a node and never replaces information, so a
+sink with no way to express it renders the node unchanged.
+
+Construction is validated: a duplicate key, an edge naming a key with no node, or a `focusKey`
+naming no node all throw, so a malformed graph fails where it is built rather than rendering as a
+plausible-looking but wrong diagram.
+
 ## Links
 
 Use `[MarkoutLink]` to render a string property as a Markdown link:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -843,13 +843,31 @@ In the tree lowering a node is expanded the first time it is reached; a later ar
 leaf prefixed with `↩`, which terminates cycles and keeps a shared node from being duplicated.
 Nodes unreachable from the root are appended as extra roots, so no part of the graph is dropped.
 
+Every lowering shows every node. A node with no incident edge appears in no edge row, so the edge
+table lists it as a trailing row with an empty `To` rather than quietly shrinking the graph to its
+connected part.
+
+### Graphs in a serialized document
+
+A `Graph`-typed property is a section shape like any other, so a document modelled with
+`[MarkoutSerializable]` can carry one directly:
+
+```csharp
+[MarkoutSection(Name = "Call Graph", EmptyText = "No calls found.")]
+public Graph? CallGraph { get; set; }
+```
+
+The property renders through the same lowerings, so the one model produces a diagram, an edge
+table, or a tree depending only on the formatter. A null graph omits the section; an empty graph
+falls back to `EmptyText`.
+
 `Group` clusters nodes — a Mermaid subgraph, or `From Group` / `To Group` columns in an edge table.
 `Emphasized` marks a node as noteworthy; it augments a node and never replaces information, so a
 sink with no way to express it renders the node unchanged.
 
-Construction is validated: a duplicate key, an edge naming a key with no node, or a `focusKey`
-naming no node all throw, so a malformed graph fails where it is built rather than rendering as a
-plausible-looking but wrong diagram.
+Construction is validated: a null node or edge element, a duplicate key, an edge naming a key with
+no node, an empty node label, or a `focusKey` naming no node all throw, so a malformed graph fails
+where it is built rather than rendering as a plausible-looking but wrong diagram.
 
 ## Links
 

--- a/samples/Serialization/ShapeGallery.cs
+++ b/samples/Serialization/ShapeGallery.cs
@@ -100,6 +100,25 @@ public static class ShapeGallery
             new TreeNode("tests", [
                 new TreeNode("Markout.Tests")]));
 
+        // Relationships — graph. Unlike a tree, a node may be reached more than once, so identity
+        // is deduplicated by key rather than repeated. Each formatter lowers it: Mermaid draws a
+        // flowchart, Markdown an edge table, plain text a tree rooted at the focus node.
+        writer.WriteHeading(2, "Call Relationships");
+        writer.WriteGraph(new Graph(
+            nodes: [
+                new GraphNode("parse", "Parser.Parse"),
+                new GraphNode("lex", "Lexer.Next"),
+                new GraphNode("emit", "Emitter.Write"),
+                new GraphNode("log", "Log.Trace") { Group = "Diagnostics", Emphasized = true },
+            ],
+            edges: [
+                new GraphEdge("parse", "lex"),
+                new GraphEdge("parse", "emit"),
+                new GraphEdge("lex", "log"),
+                new GraphEdge("emit", "log"),
+            ],
+            focusKey: "parse"));
+
         // Quotation — code section
         writer.WriteHeading(2, "Quick Start");
         writer.WriteCodeStart("csharp");

--- a/src/Markout.Ansi.Spectre/SpectreFormatter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreFormatter.cs
@@ -258,6 +258,7 @@ public class SpectreFormatter : IMarkoutFormatter,
         Sgr(w, SgrDarkGray);
         w.Write(isLast ? "└─ " : "├─ ");
         SgrReset(w);
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, this));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -623,6 +623,18 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}}}");
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
+        else if (prop.Kind == PropertyKind.Graph)
+        {
+            // An empty graph is treated the same as an empty collection: it falls through to
+            // the section's empty text rather than emitting a heading over nothing.
+            sb.AppendLine($"{indent}if ({propAccess} != null && !{propAccess}.IsEmpty)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+            sb.AppendLine($"{indent}    writer.WriteGraph({propAccess});");
+            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+            sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
+        }
         else if (prop.Kind == PropertyKind.Metric)
         {
             if (prop.IsScalarShape)
@@ -836,6 +848,11 @@ internal static class SerializerEmitter
             case PropertyKind.Tree:
                 sb.AppendLine($"{indent}if ({propAccess} != null && {propAccess}.Count > 0)");
                 sb.AppendLine($"{indent}    writer.WriteTree(global::System.Runtime.InteropServices.CollectionsMarshal.AsSpan({propAccess}));");
+                break;
+
+            case PropertyKind.Graph:
+                sb.AppendLine($"{indent}if ({propAccess} != null && !{propAccess}.IsEmpty)");
+                sb.AppendLine($"{indent}    writer.WriteGraph({propAccess});");
                 break;
 
             case PropertyKind.Metric:
@@ -1104,6 +1121,8 @@ internal static class SerializerEmitter
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (labeled list)";
             if (prop.Kind == PropertyKind.CodeSection)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (code block)";
+            if (prop.Kind == PropertyKind.Graph)
+                return $"H{prop.SectionLevel} Section \"{sectionName}\" (graph)";
             if (prop.Kind == PropertyKind.Breakdown)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (distribution)";
             if (prop.Kind == PropertyKind.MetricChange)
@@ -1132,6 +1151,7 @@ internal static class SerializerEmitter
             PropertyKind.Metric => "Metric",
             PropertyKind.Description => "Description",
             PropertyKind.CodeSection => "Code",
+            PropertyKind.Graph => "Graph",
             PropertyKind.Callout => "Callout",
             PropertyKind.Breakdown => "Breakdown",
             PropertyKind.MetricChange => "MetricChange",

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -16,6 +16,9 @@ internal sealed class KnownTypeSymbols
     private INamedTypeSymbol? _treeNode;
     private bool _treeNodeResolved;
 
+    private INamedTypeSymbol? _graph;
+    private bool _graphResolved;
+
     private INamedTypeSymbol? _metric;
     private bool _metricResolved;
 
@@ -69,6 +72,7 @@ internal sealed class KnownTypeSymbols
 
     public INamedTypeSymbol? MarkoutField => Resolve(ref _markoutField, ref _markoutFieldResolved, "Markout.MarkoutField");
     public INamedTypeSymbol? TreeNode => Resolve(ref _treeNode, ref _treeNodeResolved, "Markout.TreeNode");
+    public INamedTypeSymbol? Graph => Resolve(ref _graph, ref _graphResolved, "Markout.Graph");
     public INamedTypeSymbol? Metric => Resolve(ref _metric, ref _metricResolved, "Markout.Metric");
     public INamedTypeSymbol? Description => Resolve(ref _description, ref _descriptionResolved, "Markout.Description");
     public INamedTypeSymbol? CodeSection => Resolve(ref _codeSection, ref _codeSectionResolved, "Markout.CodeSection");

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -515,6 +515,7 @@ internal enum PropertyKind
     NestedObject,
     FieldCollection,
     Tree,
+    Graph,
     Metric,
     Description,
     CodeSection,

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -678,6 +678,10 @@ internal static class TypeParser
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.CodeSection))
             return (PropertyKind.CodeSection, null, null, false, null, null, true, FieldLayoutKind.Table, false);
 
+        // Graph type - lowered by the writer into a diagram, edge table, or tree
+        if (knownTypes.Graph is not null && SymbolEqualityComparer.Default.Equals(type, knownTypes.Graph))
+            return (PropertyKind.Graph, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+
         // Callout type - renders as admonition block
         if (SymbolEqualityComparer.Default.Equals(type, knownTypes.Callout))
             return (PropertyKind.Callout, null, null, false, null, null, true, FieldLayoutKind.Table, false);
@@ -923,6 +927,7 @@ internal static class TypeParser
              p.Kind == PropertyKind.NestedObject ||
              (p.Kind == PropertyKind.ComplexArray && p.JoinSeparator == null) ||
              p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree ||
+             p.Kind == PropertyKind.Graph ||
              p.Kind == PropertyKind.Description || p.Kind == PropertyKind.Metric ||
              p.Kind == PropertyKind.CodeSection || p.Kind == PropertyKind.Breakdown ||
              p.Kind == PropertyKind.MetricChange || p.Kind == PropertyKind.MultiSource ||

--- a/src/Markout/DiagramFormatter.cs
+++ b/src/Markout/DiagramFormatter.cs
@@ -52,6 +52,7 @@ public class DiagramFormatter : IMarkoutFormatter,
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: false));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/DiagramFormatter.cs
+++ b/src/Markout/DiagramFormatter.cs
@@ -48,11 +48,11 @@ public class DiagramFormatter : IMarkoutFormatter,
         w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
-    private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
+    private void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
-        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: false));
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, this));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/DiagramFormatter.cs
+++ b/src/Markout/DiagramFormatter.cs
@@ -7,8 +7,20 @@ namespace Markout;
 /// Supports headings, trees, and metrics with plain-text rendering.
 /// </summary>
 public class DiagramFormatter : IMarkoutFormatter,
-    IHeadingFormatter, ITreeFormatter, IMetricsFormatter
+    IHeadingFormatter, ITreeFormatter, IMetricsFormatter, IGraphFormatter
 {
+    // ── IGraphFormatter ──
+
+    /// <summary>
+    /// Renders the graph as a tree rooted at the focus node.
+    /// </summary>
+    void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
+    {
+        if (graph.IsEmpty)
+            return;
+
+        ((ITreeFormatter)this).FormatTree(w, GraphLowering.ToTree(graph).AsSpan(), options);
+    }
     // ── IHeadingFormatter ──
 
     void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)

--- a/src/Markout/Formatting/IGraphFormatter.cs
+++ b/src/Markout/Formatting/IGraphFormatter.cs
@@ -1,0 +1,15 @@
+namespace Markout.Formatting;
+
+/// <summary>
+/// Capability interface for rendering a directed <see cref="Graph"/>.
+/// </summary>
+/// <remarks>
+/// Implementations lower the graph into whatever their format can express — a flowchart, an edge
+/// table, or a tree rooted at the focus node. <see cref="GraphLowering"/> provides the shared,
+/// format-neutral lowerings so an implementation only has to render, not re-derive.
+/// </remarks>
+public interface IGraphFormatter
+{
+    /// <summary>Renders a directed graph.</summary>
+    void FormatGraph(TextWriter writer, Graph graph, MarkoutWriterOptions options);
+}

--- a/src/Markout/Graph.cs
+++ b/src/Markout/Graph.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+
+namespace Markout;
+
+/// <summary>
+/// A directed graph shape, a peer to the tree shape. Hand Markout the graph and let each
+/// formatter lower it, instead of generating format-specific text per call site.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A tree cannot express this: the same entity may appear in more than one relationship, so node
+/// identity has to be deduplicated rather than repeated. <see cref="GraphNode.Key"/> carries that
+/// identity and is used for nothing else.
+/// </para>
+/// <para>
+/// The shape is validated on construction. Duplicate keys, an edge naming a key that has no node,
+/// and a <see cref="FocusKey"/> that names no node are all errors, so a malformed graph fails
+/// where it is built rather than rendering as a plausible-looking but wrong diagram.
+/// </para>
+/// </remarks>
+public sealed class Graph
+{
+    private readonly Dictionary<string, int> _indexByKey;
+
+    /// <summary>The nodes, in the order supplied.</summary>
+    public ImmutableArray<GraphNode> Nodes { get; }
+
+    /// <summary>The edges, in the order supplied. Parallel edges are preserved.</summary>
+    public ImmutableArray<GraphEdge> Edges { get; }
+
+    /// <summary>
+    /// The key of the node the graph is centred on, if any. A formatter uses it to decide where to
+    /// anchor a diagram, and a text lowering uses it to root a tree without having to guess.
+    /// </summary>
+    public string? FocusKey { get; }
+
+    /// <summary>Creates and validates a graph.</summary>
+    /// <param name="nodes">The nodes. Keys must be unique.</param>
+    /// <param name="edges">The edges. Every endpoint must name a node in <paramref name="nodes"/>.</param>
+    /// <param name="focusKey">Optional key of the focus node. Must name a node when supplied.</param>
+    /// <exception cref="ArgumentException">
+    /// A node key is duplicated, an edge names an unknown key, or <paramref name="focusKey"/> names
+    /// an unknown key.
+    /// </exception>
+    public Graph(IEnumerable<GraphNode> nodes, IEnumerable<GraphEdge> edges, string? focusKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentNullException.ThrowIfNull(edges);
+
+        Nodes = [.. nodes];
+        Edges = [.. edges];
+        FocusKey = focusKey;
+
+        _indexByKey = new Dictionary<string, int>(Nodes.Length, StringComparer.Ordinal);
+        for (var i = 0; i < Nodes.Length; i++)
+        {
+            var node = Nodes[i];
+            if (!_indexByKey.TryAdd(node.Key, i))
+                throw new ArgumentException($"Duplicate node key '{node.Key}'.", nameof(nodes));
+        }
+
+        foreach (var edge in Edges)
+        {
+            if (!_indexByKey.ContainsKey(edge.From))
+                throw new ArgumentException($"Edge references unknown node key '{edge.From}'.", nameof(edges));
+            if (!_indexByKey.ContainsKey(edge.To))
+                throw new ArgumentException($"Edge references unknown node key '{edge.To}'.", nameof(edges));
+        }
+
+        if (focusKey is not null && !_indexByKey.ContainsKey(focusKey))
+            throw new ArgumentException($"Focus references unknown node key '{focusKey}'.", nameof(focusKey));
+    }
+
+    /// <summary>Whether the graph has no nodes.</summary>
+    public bool IsEmpty => Nodes.Length == 0;
+
+    /// <summary>The focus node, or <c>null</c> when no focus was supplied.</summary>
+    public GraphNode? Focus => FocusKey is null ? null : Nodes[_indexByKey[FocusKey]];
+
+    /// <summary>Gets the node with <paramref name="key"/>.</summary>
+    /// <exception cref="KeyNotFoundException">No node has that key.</exception>
+    public GraphNode this[string key] => Nodes[_indexByKey[key]];
+
+    /// <summary>Gets the node with <paramref name="key"/>, if present.</summary>
+    public bool TryGetNode(string key, out GraphNode node)
+    {
+        if (key is not null && _indexByKey.TryGetValue(key, out var index))
+        {
+            node = Nodes[index];
+            return true;
+        }
+
+        node = null!;
+        return false;
+    }
+
+    /// <summary>The position of <paramref name="key"/> in <see cref="Nodes"/>, or <c>-1</c>.</summary>
+    public int IndexOf(string key)
+        => key is not null && _indexByKey.TryGetValue(key, out var index) ? index : -1;
+}

--- a/src/Markout/Graph.cs
+++ b/src/Markout/Graph.cs
@@ -39,8 +39,8 @@ public sealed class Graph
     /// <param name="edges">The edges. Every endpoint must name a node in <paramref name="nodes"/>.</param>
     /// <param name="focusKey">Optional key of the focus node. Must name a node when supplied.</param>
     /// <exception cref="ArgumentException">
-    /// A node key is duplicated, an edge names an unknown key, or <paramref name="focusKey"/> names
-    /// an unknown key.
+    /// A node or edge element is null, a node key is duplicated, an edge names an unknown key, or
+    /// <paramref name="focusKey"/> names an unknown key.
     /// </exception>
     public Graph(IEnumerable<GraphNode> nodes, IEnumerable<GraphEdge> edges, string? focusKey = null)
     {
@@ -55,12 +55,17 @@ public sealed class Graph
         for (var i = 0; i < Nodes.Length; i++)
         {
             var node = Nodes[i];
+            if (node is null)
+                throw new ArgumentException($"Node at index {i} is null.", nameof(nodes));
             if (!_indexByKey.TryAdd(node.Key, i))
                 throw new ArgumentException($"Duplicate node key '{node.Key}'.", nameof(nodes));
         }
 
-        foreach (var edge in Edges)
+        for (var i = 0; i < Edges.Length; i++)
         {
+            var edge = Edges[i];
+            if (edge is null)
+                throw new ArgumentException($"Edge at index {i} is null.", nameof(edges));
             if (!_indexByKey.ContainsKey(edge.From))
                 throw new ArgumentException($"Edge references unknown node key '{edge.From}'.", nameof(edges));
             if (!_indexByKey.ContainsKey(edge.To))

--- a/src/Markout/GraphEdge.cs
+++ b/src/Markout/GraphEdge.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// A directed edge between two <see cref="GraphNode"/> keys.
+/// </summary>
+/// <remarks>
+/// Direction is explicit and always points from <see cref="From"/> to <see cref="To"/>. A caller
+/// holding an inverted relationship (such as "who calls me") is responsible for inverting it once
+/// when building the graph, rather than leaving each formatter to reinterpret the direction.
+/// Parallel edges are preserved: two edges with the same endpoints are two edges.
+/// </remarks>
+public sealed class GraphEdge
+{
+    /// <summary>The <see cref="GraphNode.Key"/> the edge points away from.</summary>
+    public string From { get; }
+
+    /// <summary>The <see cref="GraphNode.Key"/> the edge points to.</summary>
+    public string To { get; }
+
+    /// <summary>Optional display text for the edge.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>Creates a directed edge.</summary>
+    public GraphEdge(string from, string to)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(from);
+        ArgumentException.ThrowIfNullOrEmpty(to);
+        From = from;
+        To = to;
+    }
+}

--- a/src/Markout/GraphLowering.cs
+++ b/src/Markout/GraphLowering.cs
@@ -1,0 +1,205 @@
+using System.Collections.Immutable;
+
+namespace Markout;
+
+/// <summary>
+/// The format-neutral lowerings of a <see cref="Graph"/> into shapes an existing formatter can
+/// already render: an edge table, or a tree rooted at the focus node.
+/// </summary>
+/// <remarks>
+/// These live here, once, rather than in each formatter, so that every sink agrees on which edges
+/// exist, which node roots a tree, and how a revisit is spelled. A formatter is then only
+/// responsible for its own syntax.
+/// </remarks>
+public static class GraphLowering
+{
+    /// <summary>The marker prefixed to a node that has already appeared earlier in a tree lowering.</summary>
+    public const string RevisitMarker = "\u21a9 ";
+
+    /// <summary>An edge list projected as a table.</summary>
+    /// <param name="Headers">Column headers. Optional columns are present only when the graph uses them.</param>
+    /// <param name="Rows">One row per edge, in graph order.</param>
+    public readonly record struct GraphEdgeTable(ImmutableArray<string> Headers, List<string[]> Rows);
+
+    /// <summary>
+    /// Projects the graph as one row per edge.
+    /// </summary>
+    /// <remarks>
+    /// Group columns appear only when at least one node has a <see cref="GraphNode.Group"/>, and the
+    /// label column only when at least one edge has a <see cref="GraphEdge.Label"/>, so a plain graph
+    /// produces a plain two-column table.
+    /// </remarks>
+    /// <param name="graph">The graph to project.</param>
+    /// <param name="label">
+    /// Optional per-node display selector, letting a sink that supports emphasis decorate a node.
+    /// Defaults to <see cref="GraphNode.Label"/>.
+    /// </param>
+    public static GraphEdgeTable ToEdgeTable(Graph graph, Func<GraphNode, string>? label = null)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        label ??= static n => n.Label;
+
+        var hasGroups = false;
+        foreach (var node in graph.Nodes)
+        {
+            if (!string.IsNullOrEmpty(node.Group))
+            {
+                hasGroups = true;
+                break;
+            }
+        }
+
+        var hasEdgeLabels = false;
+        foreach (var edge in graph.Edges)
+        {
+            if (!string.IsNullOrEmpty(edge.Label))
+            {
+                hasEdgeLabels = true;
+                break;
+            }
+        }
+
+        var headers = ImmutableArray.CreateBuilder<string>();
+        headers.Add("From");
+        if (hasGroups) headers.Add("From Group");
+        headers.Add("To");
+        if (hasGroups) headers.Add("To Group");
+        if (hasEdgeLabels) headers.Add("Label");
+
+        var rows = new List<string[]>(graph.Edges.Length);
+        foreach (var edge in graph.Edges)
+        {
+            var from = graph[edge.From];
+            var to = graph[edge.To];
+
+            var row = new string[headers.Count];
+            var i = 0;
+            row[i++] = label(from);
+            if (hasGroups) row[i++] = from.Group ?? "";
+            row[i++] = label(to);
+            if (hasGroups) row[i++] = to.Group ?? "";
+            if (hasEdgeLabels) row[i] = edge.Label ?? "";
+            rows.Add(row);
+        }
+
+        return new GraphEdgeTable(headers.ToImmutable(), rows);
+    }
+
+    /// <summary>
+    /// Projects the graph as a tree by following edge direction outward from a root.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The root is <see cref="Graph.FocusKey"/> when set. Otherwise every node with no inbound edge
+    /// is a root, which is the set a reader would consider a starting point. A graph whose nodes are
+    /// all inside cycles has no such node, so the first node is used rather than rendering nothing.
+    /// </para>
+    /// <para>
+    /// A node is expanded the first time it is reached; any later arrival renders as a leaf prefixed
+    /// with <see cref="RevisitMarker"/>. That terminates cycles and keeps a shared node from being
+    /// duplicated as though it were several distinct nodes.
+    /// </para>
+    /// <para>
+    /// Nodes not reachable from any root are appended as additional roots, so a lowering never
+    /// silently drops part of the graph.
+    /// </para>
+    /// </remarks>
+    public static ImmutableArray<TreeNode> ToTree(Graph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        if (graph.IsEmpty)
+            return [];
+
+        var outgoing = BuildAdjacency(graph);
+        var expanded = new HashSet<string>(StringComparer.Ordinal);
+        var roots = ImmutableArray.CreateBuilder<TreeNode>();
+
+        foreach (var key in RootKeys(graph))
+        {
+            if (expanded.Contains(key))
+                continue;
+            roots.Add(Expand(graph, outgoing, key, graph[key].Label, expanded));
+        }
+
+        // Anything left is unreachable from the chosen roots; surface it rather than lose it.
+        foreach (var node in graph.Nodes)
+        {
+            if (expanded.Contains(node.Key))
+                continue;
+            roots.Add(Expand(graph, outgoing, node.Key, node.Label, expanded));
+        }
+
+        return roots.ToImmutable();
+    }
+
+    private static IEnumerable<string> RootKeys(Graph graph)
+    {
+        if (graph.FocusKey is not null)
+        {
+            yield return graph.FocusKey;
+            yield break;
+        }
+
+        var hasInbound = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var edge in graph.Edges)
+        {
+            if (!string.Equals(edge.From, edge.To, StringComparison.Ordinal))
+                hasInbound.Add(edge.To);
+        }
+
+        var any = false;
+        foreach (var node in graph.Nodes)
+        {
+            if (hasInbound.Contains(node.Key))
+                continue;
+            any = true;
+            yield return node.Key;
+        }
+
+        if (!any)
+            yield return graph.Nodes[0].Key;
+    }
+
+    private static Dictionary<string, List<GraphEdge>> BuildAdjacency(Graph graph)
+    {
+        var outgoing = new Dictionary<string, List<GraphEdge>>(StringComparer.Ordinal);
+        foreach (var edge in graph.Edges)
+        {
+            if (!outgoing.TryGetValue(edge.From, out var list))
+            {
+                list = [];
+                outgoing[edge.From] = list;
+            }
+            list.Add(edge);
+        }
+        return outgoing;
+    }
+
+    private static TreeNode Expand(
+        Graph graph,
+        Dictionary<string, List<GraphEdge>> outgoing,
+        string key,
+        string text,
+        HashSet<string> expanded)
+    {
+        if (!expanded.Add(key))
+            return new TreeNode(RevisitMarker + text);
+
+        var node = new TreeNode(text);
+        if (!outgoing.TryGetValue(key, out var edges))
+            return node;
+
+        var children = new List<TreeNode>(edges.Count);
+        foreach (var edge in edges)
+        {
+            var target = graph[edge.To];
+            var childText = string.IsNullOrEmpty(edge.Label)
+                ? target.Label
+                : $"{target.Label} ({edge.Label})";
+            children.Add(Expand(graph, outgoing, edge.To, childText, expanded));
+        }
+
+        node.Children = children;
+        return node;
+    }
+}

--- a/src/Markout/GraphLowering.cs
+++ b/src/Markout/GraphLowering.cs
@@ -18,16 +18,26 @@ public static class GraphLowering
 
     /// <summary>An edge list projected as a table.</summary>
     /// <param name="Headers">Column headers. Optional columns are present only when the graph uses them.</param>
-    /// <param name="Rows">One row per edge, in graph order.</param>
+    /// <param name="Rows">
+    /// One row per edge, in graph order, followed by one row per isolated node so that a node with
+    /// no incident edge is still listed.
+    /// </param>
     public readonly record struct GraphEdgeTable(ImmutableArray<string> Headers, List<string[]> Rows);
 
     /// <summary>
-    /// Projects the graph as one row per edge.
+    /// Projects the graph as one row per edge, plus one row per isolated node.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Group columns appear only when at least one node has a <see cref="GraphNode.Group"/>, and the
     /// label column only when at least one edge has a <see cref="GraphEdge.Label"/>, so a plain graph
     /// produces a plain two-column table.
+    /// </para>
+    /// <para>
+    /// A node with no incident edge appears in no edge row, so it is emitted as a trailing row with
+    /// an empty <c>To</c>. A table lowering shows every node, the same guarantee the tree lowering
+    /// makes, rather than quietly shrinking the graph to its connected part.
+    /// </para>
     /// </remarks>
     /// <param name="graph">The graph to project.</param>
     /// <param name="label">
@@ -37,7 +47,11 @@ public static class GraphLowering
     public static GraphEdgeTable ToEdgeTable(Graph graph, Func<GraphNode, string>? label = null)
     {
         ArgumentNullException.ThrowIfNull(graph);
-        label ??= static n => n.Label;
+        // A caller-supplied selector is not trusted to be total; a null cell would fault the
+        // column-width pass in every table sink.
+        Func<GraphNode, string> select = label is null
+            ? static n => n.Label
+            : n => label(n) ?? "";
 
         var hasGroups = false;
         foreach (var node in graph.Nodes)
@@ -66,19 +80,37 @@ public static class GraphLowering
         if (hasGroups) headers.Add("To Group");
         if (hasEdgeLabels) headers.Add("Label");
 
+        var connected = new HashSet<string>(StringComparer.Ordinal);
         var rows = new List<string[]>(graph.Edges.Length);
         foreach (var edge in graph.Edges)
         {
             var from = graph[edge.From];
             var to = graph[edge.To];
+            connected.Add(edge.From);
+            connected.Add(edge.To);
 
             var row = new string[headers.Count];
             var i = 0;
-            row[i++] = label(from);
+            row[i++] = select(from);
             if (hasGroups) row[i++] = from.Group ?? "";
-            row[i++] = label(to);
+            row[i++] = select(to);
             if (hasGroups) row[i++] = to.Group ?? "";
             if (hasEdgeLabels) row[i] = edge.Label ?? "";
+            rows.Add(row);
+        }
+
+        foreach (var node in graph.Nodes)
+        {
+            if (connected.Contains(node.Key))
+                continue;
+
+            var row = new string[headers.Count];
+            var i = 0;
+            row[i++] = select(node);
+            if (hasGroups) row[i++] = node.Group ?? "";
+            row[i++] = "";
+            if (hasGroups) row[i++] = "";
+            if (hasEdgeLabels) row[i] = "";
             rows.Add(row);
         }
 
@@ -102,6 +134,11 @@ public static class GraphLowering
     /// <para>
     /// Nodes not reachable from any root are appended as additional roots, so a lowering never
     /// silently drops part of the graph.
+    /// </para>
+    /// <para>
+    /// The traversal uses an explicit stack rather than recursion, so graph depth is bounded by
+    /// memory rather than by the call stack. (The text tree renderers that consume the result still
+    /// recurse per level, so an extremely deep tree remains limited by them.)
     /// </para>
     /// </remarks>
     public static ImmutableArray<TreeNode> ToTree(Graph graph)
@@ -175,6 +212,12 @@ public static class GraphLowering
         return outgoing;
     }
 
+    /// <summary>
+    /// Expands <paramref name="key"/> depth-first with an explicit stack. The traversal order is
+    /// the same pre-order walk a recursive expansion performs — a node is marked expanded when it
+    /// is first reached, not when its subtree finishes — so which arrival wins and which becomes a
+    /// <see cref="RevisitMarker"/> leaf does not depend on the traversal being recursive.
+    /// </summary>
     private static TreeNode Expand(
         Graph graph,
         Dictionary<string, List<GraphEdge>> outgoing,
@@ -185,21 +228,46 @@ public static class GraphLowering
         if (!expanded.Add(key))
             return new TreeNode(RevisitMarker + text);
 
-        var node = new TreeNode(text);
-        if (!outgoing.TryGetValue(key, out var edges))
-            return node;
+        var root = new TreeNode(text);
+        var stack = new Stack<Frame>();
+        stack.Push(new Frame(root, outgoing.GetValueOrDefault(key)));
 
-        var children = new List<TreeNode>(edges.Count);
-        foreach (var edge in edges)
+        while (stack.Count > 0)
         {
+            var frame = stack.Peek();
+            if (frame.Edges is null || frame.Index >= frame.Edges.Count)
+            {
+                stack.Pop();
+                continue;
+            }
+
+            var edge = frame.Edges[frame.Index++];
             var target = graph[edge.To];
             var childText = string.IsNullOrEmpty(edge.Label)
                 ? target.Label
                 : $"{target.Label} ({edge.Label})";
-            children.Add(Expand(graph, outgoing, edge.To, childText, expanded));
+
+            if (!expanded.Add(edge.To))
+            {
+                frame.AddChild(new TreeNode(RevisitMarker + childText));
+                continue;
+            }
+
+            var child = new TreeNode(childText);
+            frame.AddChild(child);
+            stack.Push(new Frame(child, outgoing.GetValueOrDefault(edge.To)));
         }
 
-        node.Children = children;
-        return node;
+        return root;
+    }
+
+    private sealed class Frame(TreeNode node, List<GraphEdge>? edges)
+    {
+        public List<GraphEdge>? Edges { get; } = edges;
+        public int Index { get; set; }
+
+        // Children stay null until there is one, so a leaf is spelled the same way a caller-built
+        // leaf is.
+        public void AddChild(TreeNode child) => (node.Children ??= []).Add(child);
     }
 }

--- a/src/Markout/GraphLowering.cs
+++ b/src/Markout/GraphLowering.cs
@@ -141,12 +141,19 @@ public static class GraphLowering
     /// recurse per level, so an extremely deep tree remains limited by them.)
     /// </para>
     /// </remarks>
-    public static ImmutableArray<TreeNode> ToTree(Graph graph)
+    /// <param name="graph">The graph to project.</param>
+    /// <param name="label">
+    /// Optional node text selector, letting a formatter decorate labels — for example emphasizing
+    /// <see cref="GraphNode.Emphasized"/> nodes. Defaults to <see cref="GraphNode.Label"/>; a
+    /// selector returning <see langword="null"/> is treated as an empty string.
+    /// </param>
+    public static ImmutableArray<TreeNode> ToTree(Graph graph, Func<GraphNode, string>? label = null)
     {
         ArgumentNullException.ThrowIfNull(graph);
         if (graph.IsEmpty)
             return [];
 
+        Func<GraphNode, string> select = label is null ? static n => n.Label : n => label(n) ?? "";
         var outgoing = BuildAdjacency(graph);
         var expanded = new HashSet<string>(StringComparer.Ordinal);
         var roots = ImmutableArray.CreateBuilder<TreeNode>();
@@ -155,7 +162,7 @@ public static class GraphLowering
         {
             if (expanded.Contains(key))
                 continue;
-            roots.Add(Expand(graph, outgoing, key, graph[key].Label, expanded));
+            roots.Add(Expand(graph, outgoing, key, select(graph[key]), select, expanded));
         }
 
         // Anything left is unreachable from the chosen roots; surface it rather than lose it.
@@ -163,7 +170,7 @@ public static class GraphLowering
         {
             if (expanded.Contains(node.Key))
                 continue;
-            roots.Add(Expand(graph, outgoing, node.Key, node.Label, expanded));
+            roots.Add(Expand(graph, outgoing, node.Key, select(node), select, expanded));
         }
 
         return roots.ToImmutable();
@@ -223,6 +230,7 @@ public static class GraphLowering
         Dictionary<string, List<GraphEdge>> outgoing,
         string key,
         string text,
+        Func<GraphNode, string> select,
         HashSet<string> expanded)
     {
         if (!expanded.Add(key))
@@ -242,10 +250,10 @@ public static class GraphLowering
             }
 
             var edge = frame.Edges[frame.Index++];
-            var target = graph[edge.To];
+            var targetLabel = select(graph[edge.To]);
             var childText = string.IsNullOrEmpty(edge.Label)
-                ? target.Label
-                : $"{target.Label} ({edge.Label})";
+                ? targetLabel
+                : $"{targetLabel} ({edge.Label})";
 
             if (!expanded.Add(edge.To))
             {

--- a/src/Markout/GraphLowering.cs
+++ b/src/Markout/GraphLowering.cs
@@ -13,9 +13,6 @@ namespace Markout;
 /// </remarks>
 public static class GraphLowering
 {
-    /// <summary>The marker prefixed to a node that has already appeared earlier in a tree lowering.</summary>
-    public const string RevisitMarker = "\u21a9 ";
-
     /// <summary>An edge list projected as a table.</summary>
     /// <param name="Headers">Column headers. Optional columns are present only when the graph uses them.</param>
     /// <param name="Rows">
@@ -128,7 +125,7 @@ public static class GraphLowering
     /// </para>
     /// <para>
     /// A node is expanded the first time it is reached; any later arrival renders as a leaf prefixed
-    /// with <see cref="RevisitMarker"/>. That terminates cycles and keeps a shared node from being
+    /// with <see cref="TreeNodeState.Revisit"/>. That terminates cycles and keeps a shared node from being
     /// duplicated as though it were several distinct nodes.
     /// </para>
     /// <para>
@@ -223,7 +220,7 @@ public static class GraphLowering
     /// Expands <paramref name="key"/> depth-first with an explicit stack. The traversal order is
     /// the same pre-order walk a recursive expansion performs — a node is marked expanded when it
     /// is first reached, not when its subtree finishes — so which arrival wins and which becomes a
-    /// <see cref="RevisitMarker"/> leaf does not depend on the traversal being recursive.
+    /// <see cref="TreeNodeState.Revisit"/> leaf does not depend on the traversal being recursive.
     /// </summary>
     private static TreeNode Expand(
         Graph graph,
@@ -234,7 +231,7 @@ public static class GraphLowering
         HashSet<string> expanded)
     {
         if (!expanded.Add(key))
-            return new TreeNode(RevisitMarker + text);
+            return new TreeNode(text) { State = TreeNodeState.Revisit };
 
         var root = new TreeNode(text);
         var stack = new Stack<Frame>();
@@ -257,7 +254,7 @@ public static class GraphLowering
 
             if (!expanded.Add(edge.To))
             {
-                frame.AddChild(new TreeNode(RevisitMarker + childText));
+                frame.AddChild(new TreeNode(childText) { State = TreeNodeState.Revisit });
                 continue;
             }
 

--- a/src/Markout/GraphNode.cs
+++ b/src/Markout/GraphNode.cs
@@ -1,0 +1,58 @@
+namespace Markout;
+
+/// <summary>
+/// A node in a <see cref="Graph"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Key"/> is opaque to Markout: it wires edges to nodes and nothing else. It is
+/// never written to the output, and formatters allocate their own emitted identifiers, so
+/// caller data never reaches a structural position in the generated syntax.
+/// </para>
+/// <para>
+/// The type carries no status vocabulary — no "external", "truncated", or class names — and no
+/// free-form property bag. A domain that needs those should map them onto <see cref="Group"/>,
+/// <see cref="Emphasized"/>, and <see cref="Graph.FocusKey"/>, or render its own table, so that
+/// domain styling does not leak into a general-purpose serializer.
+/// </para>
+/// </remarks>
+public sealed class GraphNode
+{
+    /// <summary>
+    /// The caller's opaque identity for this node, used only to match <see cref="GraphEdge.From"/>
+    /// and <see cref="GraphEdge.To"/>. Never emitted.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>The display text for this node.</summary>
+    public string Label { get; }
+
+    /// <summary>
+    /// Optional grouping. Formatters that can cluster (Mermaid subgraphs) use it as a container;
+    /// formatters that cannot surface it as an extra column. Nodes sharing a value group together.
+    /// </summary>
+    public string? Group { get; init; }
+
+    /// <summary>
+    /// Marks this node as noteworthy. Emphasis augments a node, it never replaces information:
+    /// sinks without a way to express it render the node unchanged.
+    /// </summary>
+    public bool Emphasized { get; init; }
+
+    /// <summary>Creates a graph node.</summary>
+    /// <param name="key">Opaque identity used for edge wiring. Not emitted.</param>
+    /// <param name="label">Display text.</param>
+    public GraphNode(string key, string label)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(label);
+        Key = key;
+        Label = label;
+    }
+
+    /// <summary>Creates a graph node whose display text is also its key.</summary>
+    public GraphNode(string key)
+        : this(key, key)
+    {
+    }
+}

--- a/src/Markout/GraphNode.cs
+++ b/src/Markout/GraphNode.cs
@@ -41,11 +41,16 @@ public sealed class GraphNode
 
     /// <summary>Creates a graph node.</summary>
     /// <param name="key">Opaque identity used for edge wiring. Not emitted.</param>
-    /// <param name="label">Display text.</param>
+    /// <param name="label">Display text. Must be non-empty.</param>
+    /// <remarks>
+    /// An empty label is rejected rather than accepted and papered over: a diagram sink has no
+    /// syntax for a label-less node (Mermaid's grammar requires text between its delimiters), so an
+    /// empty label would silently produce output that does not parse.
+    /// </remarks>
     public GraphNode(string key, string label)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
-        ArgumentNullException.ThrowIfNull(label);
+        ArgumentException.ThrowIfNullOrEmpty(label);
         Key = key;
         Label = label;
     }

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -517,11 +517,11 @@ public class MarkdownFormatter : IMarkoutFormatter,
         w.WriteLine(text);
     }
 
-    private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
+    private void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
-        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: true));
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, this));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -490,21 +490,18 @@ public class MarkdownFormatter : IMarkoutFormatter,
     // ── IGraphFormatter ──
 
     /// <summary>
-    /// Renders the graph as an edge table — one row per edge. Markdown can express a table but not
-    /// a diagram, so the edge list is the lowering that keeps every edge addressable and diffable.
-    /// Emphasized nodes render bold, which augments the label without replacing it.
+    /// Renders the graph as a nested list, the same lowering the other prose formatters use.
+    /// Markdown can express both a nested list and a table; the list names each node once and keeps
+    /// reachability readable, where an edge table repeats every label on both sides of every edge.
+    /// The tabular formatters own the edge-table view for callers that want one row per edge.
     /// </summary>
     void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
-    {
-        if (graph.IsEmpty)
-            return;
-
-        var table = GraphLowering.ToEdgeTable(
-            graph,
-            node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
-
-        ((ITableFormatter)this).FormatTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, options);
-    }
+        => ((ITreeFormatter)this).FormatTree(
+            w,
+            GraphLowering.ToTree(
+                graph,
+                node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label).AsSpan(),
+            options);
 
     // ── ITreeFormatter ──
 

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -10,7 +10,7 @@ namespace Markout;
 /// ``` code fences, and trailing double-space hard line breaks.
 /// </summary>
 public class MarkdownFormatter : IMarkoutFormatter,
-    IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter, IGlyphFormatter, IEmphasisFormatter
+    IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter, IGlyphFormatter, IEmphasisFormatter, IGraphFormatter
 {
     private const int CellPadding = 2; // leading space + trailing space
     private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
@@ -485,6 +485,25 @@ public class MarkdownFormatter : IMarkoutFormatter,
             w.Write("- ");
             w.WriteLine(FormatHelper.RenderInlineMarkdown(item));
         }
+    }
+
+    // ── IGraphFormatter ──
+
+    /// <summary>
+    /// Renders the graph as an edge table — one row per edge. Markdown can express a table but not
+    /// a diagram, so the edge list is the lowering that keeps every edge addressable and diffable.
+    /// Emphasized nodes render bold, which augments the label without replacing it.
+    /// </summary>
+    void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
+    {
+        if (graph.IsEmpty)
+            return;
+
+        var table = GraphLowering.ToEdgeTable(
+            graph,
+            node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
+
+        ((ITableFormatter)this).FormatTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, options);
     }
 
     // ── ITreeFormatter ──

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -521,6 +521,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: true));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.28.0</Version>
+    <Version>0.29.0</Version>
     <PackageReleaseNotes>[#159] New [MarkoutNumberFormat("N0")] attribute (and MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout renders for a numeric Change&lt;V&gt; cell: the scalar before/after operands, the Delta.Absolute suffix, and the delta-noun / IDeltaCountable delta count. This keeps a grouped cell and its folded delta consistent — 165 → 1,168 (+1,003) instead of 165 → 1168 (+1,003). Composite operands keep their own shape formatting; percentage and multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable. Markout owns the delta sign (it prepends +/-), so the format applies to the magnitude only.</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Markout/MarkoutGlyphs.cs
+++ b/src/Markout/MarkoutGlyphs.cs
@@ -36,6 +36,12 @@ public sealed record MarkoutGlyphs
     /// <summary>Prefix glyph marking a <c>[MarkoutChild]</c> row as nested under the previous row. Default <c>↳</c>.</summary>
     public string Child { get; init; } = "\u21b3";
 
+    /// <summary>
+    /// Prefix glyph marking a <see cref="TreeNodeState.Revisit"/> node — one whose subtree is
+    /// elided because it already appeared earlier in the lowering. Default <c>↩</c>.
+    /// </summary>
+    public string Revisit { get; init; } = "\u21a9";
+
     /// <summary>The default glyph set: <c>↑</c>/<c>↓</c> goals, <c>✓</c>/<c>✗</c> polarity.</summary>
     public static MarkoutGlyphs Default { get; } = new();
 
@@ -56,4 +62,40 @@ public sealed record MarkoutGlyphs
         GateStatus.Neutral => StatusNeutral,
         _ => ""
     };
+
+    /// <summary>The glyph for a node state, or an empty string for <see cref="TreeNodeState.Normal"/>.</summary>
+    internal string ForNodeState(TreeNodeState state) => state switch
+    {
+        TreeNodeState.Revisit => Revisit,
+        _ => ""
+    };
+
+    /// <summary>
+    /// The stable word a sink without glyph support uses for a node state. Parenthesised for the
+    /// same reason the goal words are: it sits beside caller text and has to stay distinguishable
+    /// from it.
+    /// </summary>
+    internal static string WordForNodeState(TreeNodeState state) => state switch
+    {
+        TreeNodeState.Revisit => "(revisit)",
+        _ => ""
+    };
+
+    /// <summary>
+    /// The prefix a tree sink writes before a node, including its trailing space, or an empty
+    /// string when the node needs no marker.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="TreeNode.Badge"/> this is not gated by
+    /// <see cref="MarkoutWriterOptions.IncludeBadges"/>. A state is information about the shape of
+    /// the tree, not decoration: suppressing it would make an elided subtree indistinguishable
+    /// from a node that genuinely has no children.
+    /// </remarks>
+    internal static string NodeStatePrefix(TreeNodeState state, MarkoutWriterOptions options, bool glyphs)
+    {
+        if (state == TreeNodeState.Normal)
+            return "";
+        var marker = glyphs ? options.Glyphs.ForNodeState(state) : WordForNodeState(state);
+        return marker.Length == 0 ? "" : marker + " ";
+    }
 }

--- a/src/Markout/MarkoutGlyphs.cs
+++ b/src/Markout/MarkoutGlyphs.cs
@@ -100,10 +100,17 @@ public sealed record MarkoutGlyphs
     /// from a node that genuinely has no children.
     /// </para>
     /// <para>
-    /// Setting <see cref="Revisit"/> to an empty string does suppress the marker in a glyph sink.
-    /// That is deliberate and is not the same thing: it is a targeted statement about this one
-    /// marker, whereas <see cref="MarkoutWriterOptions.IncludeBadges"/> is a broad toggle whose
-    /// caller is asking to drop decoration and is not asking to lose tree structure.
+    /// Setting <see cref="Revisit"/> to an empty string suppresses the marker in a glyph sink only.
+    /// <see cref="MarkoutGlyphs"/> configures glyphs, so an empty entry is a targeted statement about
+    /// this one <em>glyph</em>; it is not the same thing as
+    /// <see cref="MarkoutWriterOptions.IncludeBadges"/>, a broad toggle whose caller is asking to drop
+    /// decoration and is not asking to lose tree structure.
+    /// </para>
+    /// <para>
+    /// A sink without glyph support keeps the stable word instead, exactly as a suppressed
+    /// <see cref="GoalLower"/> still renders the ASCII <c>(-)</c> marker and a suppressed
+    /// <see cref="StatusBad"/> still renders the <c>(bad)</c> word. The slug words are fixed so that
+    /// non-Unicode output stays meaningful; they are not reachable from the glyph table.
     /// </para>
     /// </remarks>
     public static string NodeStatePrefix(TreeNodeState state, MarkoutWriterOptions options, bool glyphs)

--- a/src/Markout/MarkoutGlyphs.cs
+++ b/src/Markout/MarkoutGlyphs.cs
@@ -83,19 +83,45 @@ public sealed record MarkoutGlyphs
 
     /// <summary>
     /// The prefix a tree sink writes before a node, including its trailing space, or an empty
-    /// string when the node needs no marker.
+    /// string when the node needs no marker. Prefer the overload taking the formatter, which
+    /// derives glyph support rather than trusting the caller to state it.
     /// </summary>
+    /// <param name="state">The node's state.</param>
+    /// <param name="options">The writer options supplying <see cref="MarkoutWriterOptions.Glyphs"/>.</param>
+    /// <param name="glyphs">
+    /// Whether the sink renders glyphs. Sinks that cannot get the answer from a formatter — the
+    /// standalone <see cref="TreeWriter"/> — pass it directly.
+    /// </param>
     /// <remarks>
+    /// <para>
     /// Unlike <see cref="TreeNode.Badge"/> this is not gated by
     /// <see cref="MarkoutWriterOptions.IncludeBadges"/>. A state is information about the shape of
     /// the tree, not decoration: suppressing it would make an elided subtree indistinguishable
     /// from a node that genuinely has no children.
+    /// </para>
+    /// <para>
+    /// Setting <see cref="Revisit"/> to an empty string does suppress the marker in a glyph sink.
+    /// That is deliberate and is not the same thing: it is a targeted statement about this one
+    /// marker, whereas <see cref="MarkoutWriterOptions.IncludeBadges"/> is a broad toggle whose
+    /// caller is asking to drop decoration and is not asking to lose tree structure.
+    /// </para>
     /// </remarks>
-    internal static string NodeStatePrefix(TreeNodeState state, MarkoutWriterOptions options, bool glyphs)
+    public static string NodeStatePrefix(TreeNodeState state, MarkoutWriterOptions options, bool glyphs)
     {
+        ArgumentNullException.ThrowIfNull(options);
         if (state == TreeNodeState.Normal)
             return "";
         var marker = glyphs ? options.Glyphs.ForNodeState(state) : WordForNodeState(state);
         return marker.Length == 0 ? "" : marker + " ";
+    }
+
+    /// <summary>
+    /// The prefix a tree sink writes before a node, deriving glyph support from
+    /// <paramref name="formatter"/> so a formatter cannot disagree with the capability it declares.
+    /// </summary>
+    public static string NodeStatePrefix(TreeNodeState state, MarkoutWriterOptions options, Formatting.IMarkoutFormatter formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+        return NodeStatePrefix(state, options, formatter is Formatting.IGlyphFormatter);
     }
 }

--- a/src/Markout/MarkoutShape.cs
+++ b/src/Markout/MarkoutShape.cs
@@ -50,6 +50,13 @@ public enum MarkoutShape
     /// <summary>Prose quotation blocks.</summary>
     Quotation = 8192,
 
+    /// <summary>
+    /// Directed graphs (<see cref="Graph"/>). Distinct from <see cref="Trees"/> because a node may
+    /// participate in more than one relationship, so node identity is deduplicated rather than
+    /// repeated.
+    /// </summary>
+    Graphs = 16384,
+
     /// <summary>All shapes supported.</summary>
-    All = Headings | Paragraphs | Fields | Tables | Lists | Trees | Code | Metrics | Descriptions | Callouts | Breakdowns | Quotation
+    All = Headings | Paragraphs | Fields | Tables | Lists | Trees | Code | Metrics | Descriptions | Callouts | Breakdowns | Quotation | Graphs
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -1644,6 +1644,30 @@ public class MarkoutWriter
         return true;
     }
 
+    // ── Graphs ──
+
+    /// <summary>
+    /// Writes a directed graph. Each formatter lowers the graph into what its format can express —
+    /// a flowchart, an edge table, or a tree rooted at the focus node.
+    /// </summary>
+    /// <returns><c>true</c> if rendered or filtered; <c>false</c> if the formatter does not support graphs.</returns>
+    public bool WriteGraph(Graph graph)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+
+        if (graph.IsEmpty || _sectionExcluded)
+            return true;
+
+        if (_formatter is not IGraphFormatter gf)
+            return false;
+
+        EnsureBlankLineIfNeeded();
+        gf.FormatGraph(_writer, graph, _options);
+        _needsBlankLine = true;
+        _hasContent = true;
+        return true;
+    }
+
     // ── Link definitions ──
 
     /// <summary>

--- a/src/Markout/MermaidFormatter.cs
+++ b/src/Markout/MermaidFormatter.cs
@@ -88,9 +88,9 @@ public class MermaidFormatter : IMarkoutFormatter,
         }
     }
 
-    private static string BuildLabel(TreeNode node, MarkoutWriterOptions options)
+    private string BuildLabel(TreeNode node, MarkoutWriterOptions options)
     {
-        var state = MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: false);
+        var state = MarkoutGlyphs.NodeStatePrefix(node.State, options, this);
         if (node.Badge != null && options.IncludeBadges)
             return $"{state}{node.Badge} {node.Text}";
         return state + node.Text;

--- a/src/Markout/MermaidFormatter.cs
+++ b/src/Markout/MermaidFormatter.cs
@@ -10,7 +10,7 @@ namespace Markout;
 /// <c>MarkdownFormatter</c> via code blocks for embedded mermaid in markdown.
 /// </summary>
 public class MermaidFormatter : IMarkoutFormatter,
-    IHeadingFormatter, ITreeFormatter
+    IHeadingFormatter, ITreeFormatter, IGraphFormatter
 {
     private int _nextNodeId;
 
@@ -93,6 +93,172 @@ public class MermaidFormatter : IMarkoutFormatter,
         if (node.Badge != null && options.IncludeBadges)
             return $"{node.Badge} {node.Text}";
         return node.Text;
+    }
+
+    // ── IGraphFormatter ──
+
+    private const string FocusClass = "markoutFocus";
+    private const string EmphasisClass = "markoutEmphasis";
+
+    /// <summary>
+    /// Renders the graph as a <c>graph TD</c> flowchart.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Emitted ids are allocated here (<c>n0</c>, <c>n1</c>, …) and never derived from
+    /// <see cref="GraphNode.Key"/>, so caller data cannot reach a structural position in the syntax
+    /// and can only ever appear inside an escaped label.
+    /// </para>
+    /// <para>
+    /// The focus node is declared first. Mermaid has no explicit "centre", but a flowchart ranks
+    /// roughly in declaration order, so declaring the focus first anchors the diagram on it. It is
+    /// also given its own class so it stays identifiable once laid out.
+    /// </para>
+    /// <para>
+    /// Groups become subgraphs. A node can belong to at most one subgraph, so grouped nodes are
+    /// declared inside their group and ungrouped nodes before them; edges are declared afterwards,
+    /// which Mermaid permits and which keeps cross-group edges out of either subgraph body.
+    /// </para>
+    /// </remarks>
+    void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
+    {
+        if (graph.IsEmpty)
+            return;
+
+        var order = DisplayOrder(graph);
+        var ids = new Dictionary<string, string>(graph.Nodes.Length, StringComparer.Ordinal);
+        for (var i = 0; i < order.Length; i++)
+            ids[graph.Nodes[order[i]].Key] = $"n{i}";
+
+        w.WriteLine("graph TD");
+
+        foreach (var index in order)
+        {
+            var node = graph.Nodes[index];
+            if (string.IsNullOrEmpty(node.Group))
+                WriteNode(w, ids[node.Key], node.Label, "    ");
+        }
+
+        var subgraphId = 0;
+        foreach (var group in DistinctGroups(graph, order))
+        {
+            w.Write("    subgraph sg");
+            w.Write(subgraphId++);
+            w.Write("[\"");
+            w.Write(EscapeLabel(group));
+            w.WriteLine("\"]");
+
+            foreach (var index in order)
+            {
+                var node = graph.Nodes[index];
+                if (string.Equals(node.Group, group, StringComparison.Ordinal))
+                    WriteNode(w, ids[node.Key], node.Label, "        ");
+            }
+
+            w.WriteLine("    end");
+        }
+
+        foreach (var edge in graph.Edges)
+        {
+            w.Write("    ");
+            w.Write(ids[edge.From]);
+            if (string.IsNullOrEmpty(edge.Label))
+            {
+                w.Write(" --> ");
+            }
+            else
+            {
+                // The quoted edge-label form puts the text in the same lexer state as a node label
+                // (<string>, which consumes everything up to the closing quote), so the node-label
+                // escape set covers it. The pipe delimiter is already escaped, so the label cannot
+                // close its own edge.
+                w.Write(" -->|\"");
+                w.Write(EscapeLabel(edge.Label));
+                w.Write("\"| ");
+            }
+            w.WriteLine(ids[edge.To]);
+        }
+
+        WriteClasses(w, graph, ids, order);
+    }
+
+    private static void WriteNode(TextWriter w, string id, string label, string indent)
+    {
+        w.Write(indent);
+        w.Write(id);
+        w.Write("[\"");
+        w.Write(EscapeLabel(label));
+        w.WriteLine("\"]");
+    }
+
+    private static void WriteClasses(TextWriter w, Graph graph, Dictionary<string, string> ids, int[] order)
+    {
+        var focus = graph.Focus;
+
+        var emphasized = new List<string>();
+        foreach (var index in order)
+        {
+            var node = graph.Nodes[index];
+            if (node.Emphasized && !ReferenceEquals(node, focus))
+                emphasized.Add(ids[node.Key]);
+        }
+
+        if (focus is not null)
+        {
+            // No '#' appears in these declarations: Mermaid pre-scans for style/classDef lines
+            // containing a colour literal and strips their final character, which would corrupt them.
+            w.Write("    classDef ");
+            w.Write(FocusClass);
+            w.WriteLine(" stroke-width:3px;");
+            w.Write("    class ");
+            w.Write(ids[focus.Key]);
+            w.Write(' ');
+            w.Write(FocusClass);
+            w.WriteLine(";");
+        }
+
+        if (emphasized.Count > 0)
+        {
+            w.Write("    classDef ");
+            w.Write(EmphasisClass);
+            w.WriteLine(" stroke-dasharray:4 2;");
+            w.Write("    class ");
+            w.Write(string.Join(',', emphasized));
+            w.Write(' ');
+            w.Write(EmphasisClass);
+            w.WriteLine(";");
+        }
+    }
+
+    private static int[] DisplayOrder(Graph graph)
+    {
+        var focusIndex = graph.FocusKey is null ? -1 : graph.IndexOf(graph.FocusKey);
+        var order = new int[graph.Nodes.Length];
+        var next = 0;
+
+        if (focusIndex >= 0)
+            order[next++] = focusIndex;
+
+        for (var i = 0; i < graph.Nodes.Length; i++)
+        {
+            if (i != focusIndex)
+                order[next++] = i;
+        }
+
+        return order;
+    }
+
+    private static List<string> DistinctGroups(Graph graph, int[] order)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var groups = new List<string>();
+        foreach (var index in order)
+        {
+            var group = graph.Nodes[index].Group;
+            if (!string.IsNullOrEmpty(group) && seen.Add(group))
+                groups.Add(group);
+        }
+        return groups;
     }
 
     /// <summary>

--- a/src/Markout/MermaidFormatter.cs
+++ b/src/Markout/MermaidFormatter.cs
@@ -90,9 +90,10 @@ public class MermaidFormatter : IMarkoutFormatter,
 
     private static string BuildLabel(TreeNode node, MarkoutWriterOptions options)
     {
+        var state = MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: false);
         if (node.Badge != null && options.IncludeBadges)
-            return $"{node.Badge} {node.Text}";
-        return node.Text;
+            return $"{state}{node.Badge} {node.Text}";
+        return state + node.Text;
     }
 
     // ── IGraphFormatter ──

--- a/src/Markout/PlainTextFormatter.cs
+++ b/src/Markout/PlainTextFormatter.cs
@@ -207,11 +207,11 @@ public class PlainTextFormatter : IMarkoutFormatter,
         w.WriteLine(text);
     }
 
-    private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
+    private void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
-        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: false));
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, this));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/PlainTextFormatter.cs
+++ b/src/Markout/PlainTextFormatter.cs
@@ -9,8 +9,22 @@ namespace Markout;
 /// </summary>
 public class PlainTextFormatter : IMarkoutFormatter,
     IHeadingFormatter, IFieldFormatter, IBlockFormatter,
-    IListFormatter, ITableFormatter, ICodeBlockFormatter, ITreeFormatter
+    IListFormatter, ITableFormatter, ICodeBlockFormatter, ITreeFormatter, IGraphFormatter
 {
+    // ── IGraphFormatter ──
+
+    /// <summary>
+    /// Renders the graph as a tree rooted at the focus node. Plain text has no way to draw a
+    /// diagram, and an edge table loses the sense of walking outward from the node under
+    /// examination, which is the thing a text reader is usually after.
+    /// </summary>
+    void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
+    {
+        if (graph.IsEmpty)
+            return;
+
+        ((ITreeFormatter)this).FormatTree(w, GraphLowering.ToTree(graph).AsSpan(), options);
+    }
     private const int ColumnGap = 2;
 
     // ── IHeadingFormatter ──

--- a/src/Markout/PlainTextFormatter.cs
+++ b/src/Markout/PlainTextFormatter.cs
@@ -211,6 +211,7 @@ public class PlainTextFormatter : IMarkoutFormatter,
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: false));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -10,8 +10,22 @@ namespace Markout;
 /// Formatter for compact tabular output. It can render normalized TSV or a pretty
 /// space-padded table from the same row/column projection.
 /// </summary>
-public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter, ICompositeCellFormatter
+public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter, ICompositeCellFormatter, IGraphFormatter
 {
+    // ── IGraphFormatter ──
+
+    /// <summary>
+    /// Renders the graph as an edge table — one row per edge — which is the only graph lowering a
+    /// tabular sink can express without losing edges.
+    /// </summary>
+    void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
+    {
+        if (graph.IsEmpty)
+            return;
+
+        var table = GraphLowering.ToEdgeTable(graph);
+        ((ITableFormatter)this).FormatTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, options);
+    }
     private const int ColumnGap = 2;
 
     /// <summary>Structured output decomposes composite cells into typed columns.</summary>

--- a/src/Markout/TreeNode.cs
+++ b/src/Markout/TreeNode.cs
@@ -25,6 +25,17 @@ public class TreeNode
     public List<TreeNode>? Children { get; set; }
 
     /// <summary>
+    /// Why this node renders as it does within a tree lowering. Defaults to
+    /// <see cref="TreeNodeState.Normal"/>.
+    /// </summary>
+    /// <remarks>
+    /// Carried structurally rather than baked into <see cref="Text"/> so each sink picks its own
+    /// spelling: rich sinks render the configurable glyph from <see cref="MarkoutGlyphs"/>, while
+    /// plain and machine-readable sinks keep a stable word.
+    /// </remarks>
+    public TreeNodeState State { get; set; }
+
+    /// <summary>
     /// Creates a tree node. Pass <paramref name="children"/> (a list, array, or
     /// collection expression) to add child nodes, or omit for a leaf. Set
     /// <see cref="Badge"/> via an object initializer if needed.

--- a/src/Markout/TreeNodeState.cs
+++ b/src/Markout/TreeNodeState.cs
@@ -1,0 +1,31 @@
+namespace Markout;
+
+/// <summary>
+/// The structural status of a <see cref="TreeNode"/> within a tree lowering — why the node renders
+/// the way it does, not what kind of thing the node represents.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a single axis and its members are mutually exclusive: a node is unexpanded for exactly
+/// one reason. Domain classification is a separate concern and does not belong here. A graph node's
+/// grouping and emphasis are carried by <see cref="GraphNode.Group"/> and
+/// <see cref="GraphNode.Emphasized"/>, which can co-occur with any state.
+/// </para>
+/// <para>
+/// The state is deliberately structural rather than presentational: it is set by the lowering and
+/// each sink chooses its own spelling, so rich sinks can render a glyph while plain and
+/// machine-readable sinks keep a stable word.
+/// </para>
+/// </remarks>
+public enum TreeNodeState
+{
+    /// <summary>The node is expanded normally. The default.</summary>
+    Normal = 0,
+
+    /// <summary>
+    /// The node's subtree is elided because the node already appeared earlier in this lowering.
+    /// The node is still named, so a shared or cyclic reference stays visible rather than being
+    /// silently dropped or duplicated as though it were a distinct node.
+    /// </summary>
+    Revisit
+}

--- a/src/Markout/TreeWriter.cs
+++ b/src/Markout/TreeWriter.cs
@@ -35,6 +35,7 @@ public class TreeWriter(TextWriter writer, MarkoutWriterOptions? options = null)
     {
         writer.Write(prefix);
         writer.Write(isLast ? "└─ " : "├─ ");
+        writer.Write(MarkoutGlyphs.NodeStatePrefix(node.State, _options, glyphs: true));
         if (node.Badge != null && _options.IncludeBadges)
         {
             writer.Write(node.Badge);

--- a/src/Markout/TreeWriter.cs
+++ b/src/Markout/TreeWriter.cs
@@ -35,7 +35,7 @@ public class TreeWriter(TextWriter writer, MarkoutWriterOptions? options = null)
     {
         writer.Write(prefix);
         writer.Write(isLast ? "└─ " : "├─ ");
-        writer.Write(MarkoutGlyphs.NodeStatePrefix(node.State, _options, glyphs: true));
+        writer.Write(MarkoutGlyphs.NodeStatePrefix(node.State, _options, glyphs: false));
         if (node.Badge != null && _options.IncludeBadges)
         {
             writer.Write(node.Badge);

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -244,11 +244,11 @@ public class UnicodeFormatter : IMarkoutFormatter,
         w.WriteLine(FormatHelper.RenderInlinePlainText(text));
     }
 
-    private static void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
+    private void FormatTreeNodeRecursive(TextWriter w, TreeNode node, string prefix, bool isLast, MarkoutWriterOptions options)
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
-        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: true));
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, this));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -248,6 +248,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
     {
         w.Write(prefix);
         w.Write(isLast ? "└─ " : "├─ ");
+        w.Write(MarkoutGlyphs.NodeStatePrefix(node.State, options, glyphs: true));
         if (node.Badge != null && options.IncludeBadges)
         {
             w.Write(node.Badge);

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -8,8 +8,21 @@ namespace Markout;
 /// Uses ─│├└╭╮╰╯ for borders, █▆▄▂ for bars, and other Unicode decorations.
 /// </summary>
 public class UnicodeFormatter : IMarkoutFormatter,
-    IDocumentFormatter, IMetricsFormatter, IGlyphFormatter
+    IDocumentFormatter, IMetricsFormatter, IGlyphFormatter, IGraphFormatter
 {
+    // ── IGraphFormatter ──
+
+    /// <summary>
+    /// Renders the graph as a tree rooted at the focus node, drawn with the same box-drawing
+    /// connectors as <see cref="ITreeFormatter.FormatTree"/>.
+    /// </summary>
+    void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
+    {
+        if (graph.IsEmpty)
+            return;
+
+        ((ITreeFormatter)this).FormatTree(w, GraphLowering.ToTree(graph).AsSpan(), options);
+    }
     private const int ColumnGap = 2;
     private int _consoleWidth = 80;
 

--- a/tests/Markout.Tests/GeneratedGraphTests.cs
+++ b/tests/Markout.Tests/GeneratedGraphTests.cs
@@ -40,9 +40,9 @@ public class GeneratedGraphTests
         var mdf = MarkoutSerializer.Serialize(Sample(), GraphContext.Default);
 
         Assert.Contains("## Call Graph", mdf, StringComparison.Ordinal);
-        // Markdown lowers a graph to its edge table.
-        Assert.Contains("| From | To |", mdf, StringComparison.Ordinal);
-        Assert.Contains("| A | B |", mdf, StringComparison.Ordinal);
+        // Markdown lowers a graph to its tree projection.
+        Assert.Contains("└─ B", mdf, StringComparison.Ordinal);
+        Assert.Contains("A", mdf, StringComparison.Ordinal);
         Assert.DoesNotContain("No calls found.", mdf, StringComparison.Ordinal);
     }
 

--- a/tests/Markout.Tests/GeneratedGraphTests.cs
+++ b/tests/Markout.Tests/GeneratedGraphTests.cs
@@ -1,0 +1,95 @@
+using Markout;
+using Markout.Formatting;
+
+namespace Markout.Tests;
+
+[MarkoutSerializable]
+public class GraphContainer
+{
+    public string? Member { get; set; }
+
+    [MarkoutSection(Name = "Call Graph", EmptyText = "No calls found.")]
+    public Graph? CallGraph { get; set; }
+}
+
+[MarkoutContext(typeof(GraphContainer))]
+public partial class GraphContext : MarkoutSerializerContext
+{
+}
+
+/// <summary>
+/// The declarative path: a <see cref="Graph"/>-typed section property must reach
+/// <see cref="MarkoutWriter.WriteGraph"/> through the generated serializer, the same way a
+/// <see cref="TreeNode"/> list reaches <c>WriteTree</c>. Without this a host that models its
+/// document with <c>[MarkoutSerializable]</c> cannot use the graph shape at all.
+/// </summary>
+public class GeneratedGraphTests
+{
+    private static GraphContainer Sample() => new()
+    {
+        Member = "Run",
+        CallGraph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b")],
+            focusKey: "a"),
+    };
+
+    [Fact]
+    public void GraphProperty_RendersAsASectionInMarkdown()
+    {
+        var mdf = MarkoutSerializer.Serialize(Sample(), GraphContext.Default);
+
+        Assert.Contains("## Call Graph", mdf, StringComparison.Ordinal);
+        // Markdown lowers a graph to its edge table.
+        Assert.Contains("| From | To |", mdf, StringComparison.Ordinal);
+        Assert.Contains("| A | B |", mdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("No calls found.", mdf, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GraphProperty_RendersAsADiagramWhenTheSinkDrawsOne()
+    {
+        var sink = new StringWriter();
+        MarkoutSerializer.Serialize(Sample(), sink, new MermaidFormatter(), GraphContext.Default);
+        var output = sink.ToString();
+
+        Assert.Contains("graph TD", output, StringComparison.Ordinal);
+        Assert.Contains("n0[\"A\"]", output, StringComparison.Ordinal);
+        Assert.Contains("n0 --> n1", output, StringComparison.Ordinal);
+        // The caller's opaque keys never reach the output.
+        Assert.DoesNotContain("\"a\"", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GraphProperty_RendersAsATreeWhenTheSinkDrawsOne()
+    {
+        var sink = new StringWriter();
+        MarkoutSerializer.Serialize(Sample(), sink, new PlainTextFormatter(), GraphContext.Default);
+        var output = sink.ToString();
+
+        Assert.Contains("A", output, StringComparison.Ordinal);
+        Assert.Contains("B", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmptyGraph_FallsBackToTheSectionEmptyTextRatherThanAnEmptyHeading()
+    {
+        var model = new GraphContainer { Member = "Run", CallGraph = new Graph([], []) };
+
+        var mdf = MarkoutSerializer.Serialize(model, GraphContext.Default);
+
+        Assert.Contains("## Call Graph", mdf, StringComparison.Ordinal);
+        Assert.Contains("No calls found.", mdf, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullGraph_OmitsTheSectionEntirely()
+    {
+        var model = new GraphContainer { Member = "Run", CallGraph = null };
+
+        var mdf = MarkoutSerializer.Serialize(model, GraphContext.Default);
+
+        Assert.DoesNotContain("Call Graph", mdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("No calls found.", mdf, StringComparison.Ordinal);
+    }
+}

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -521,6 +521,238 @@ public class GraphTests
         Assert.True(MarkoutShape.All.HasFlag(MarkoutShape.Graphs));
     }
 
+    // ── Regression coverage from adversarial review of #163 ──
+
+    [Fact]
+    public void Graph_RejectsANullNodeElementNamingTheParameterAndIndex()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new Graph(
+            [new GraphNode("a", "A"), null!],
+            []));
+        Assert.Equal("nodes", ex.ParamName);
+        Assert.Contains("index 1", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Graph_RejectsANullEdgeElementNamingTheParameterAndIndex()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new Graph(
+            [new GraphNode("a", "A")],
+            [null!]));
+        Assert.Equal("edges", ex.ParamName);
+        Assert.Contains("index 0", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GraphNode_RejectsAnEmptyLabelBecauseNoDiagramSyntaxCanSpellOne()
+    {
+        Assert.Throws<ArgumentException>(() => new GraphNode("a", ""));
+    }
+
+    [Fact]
+    public void Graph_TryGetNode_FindsAKnownKeyAndRejectsAnUnknownOne()
+    {
+        var graph = SimpleChain();
+
+        Assert.True(graph.TryGetNode("b", out var found));
+        Assert.Equal("B", found.Label);
+        Assert.False(graph.TryGetNode("zzz", out var missing));
+        Assert.Null(missing);
+        Assert.False(graph.TryGetNode(null!, out _));
+    }
+
+    [Fact]
+    public void Graph_IndexOf_ReturnsThePositionOrMinusOne()
+    {
+        var graph = SimpleChain();
+
+        Assert.Equal(0, graph.IndexOf("a"));
+        Assert.Equal(2, graph.IndexOf("c"));
+        Assert.Equal(-1, graph.IndexOf("zzz"));
+        Assert.Equal(-1, graph.IndexOf(null!));
+    }
+
+    [Fact]
+    public void EdgeTable_ListsAnIsolatedNodeSoTheTableStillSeesEveryNode()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B"), new GraphNode("lonely", "Lonely")],
+            [new GraphEdge("a", "b")]);
+
+        var table = GraphLowering.ToEdgeTable(graph);
+
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal(["A", "B"], table.Rows[0]);
+        // The isolated node is a From with no To rather than a row that never appears.
+        Assert.Equal(["Lonely", ""], table.Rows[1]);
+    }
+
+    [Fact]
+    public void EdgeTable_IsolatedNodeRowFillsEveryOptionalColumn()
+    {
+        var graph = new Graph(
+            [
+                new GraphNode("a", "A") { Group = "Core" },
+                new GraphNode("b", "B") { Group = "Core" },
+                new GraphNode("lonely", "Lonely") { Group = "Edge" },
+            ],
+            [new GraphEdge("a", "b") { Label = "calls" }]);
+
+        var table = GraphLowering.ToEdgeTable(graph);
+
+        Assert.Equal(["From", "From Group", "To", "To Group", "Label"], table.Headers);
+        Assert.Equal(["A", "Core", "B", "Core", "calls"], table.Rows[0]);
+        Assert.Equal(["Lonely", "Edge", "", "", ""], table.Rows[1]);
+        Assert.All(table.Rows, row => Assert.Equal(table.Headers.Length, row.Length));
+    }
+
+    [Fact]
+    public void EdgeTable_ANodeThatIsOnlyEverATargetIsNotTreatedAsIsolated()
+    {
+        var graph = SimpleChain();
+
+        var table = GraphLowering.ToEdgeTable(graph);
+
+        // "c" only ever appears as a target, so it needs no synthetic row.
+        Assert.Equal(2, table.Rows.Count);
+    }
+
+    [Fact]
+    public void EdgeTable_ASelectorThatReturnsNullYieldsAnEmptyCellNotANullCell()
+    {
+        var graph = SimpleChain();
+
+        var table = GraphLowering.ToEdgeTable(graph, _ => null!);
+
+        Assert.All(table.Rows, row => Assert.All(row, Assert.NotNull));
+    }
+
+    [Fact]
+    public void MarkdownGraph_RendersAnIsolatedNode()
+    {
+        var graph = new Graph([new GraphNode("lonely", "Lonely")], []);
+
+        var writer = MarkoutWriter.Create(new MarkdownFormatter());
+        writer.WriteGraph(graph);
+
+        Assert.Contains("Lonely", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Tree_HandlesADeepChainWithoutExhaustingTheCallStack()
+    {
+        // The lowering walks with an explicit stack, so depth is bounded by memory. A depth this
+        // large overflowed the stack while the traversal was recursive.
+        const int Depth = 50_000;
+        var nodes = new GraphNode[Depth];
+        var edges = new GraphEdge[Depth - 1];
+        for (var i = 0; i < Depth; i++)
+            nodes[i] = new GraphNode(i.ToString(), "m" + i);
+        for (var i = 0; i < Depth - 1; i++)
+            edges[i] = new GraphEdge(i.ToString(), (i + 1).ToString());
+
+        var roots = GraphLowering.ToTree(new Graph(nodes, edges));
+
+        var root = Assert.Single(roots);
+        var depth = 0;
+        for (var node = root; node is not null; node = node.Children is [var only, ..] ? only : null)
+            depth++;
+        Assert.Equal(Depth, depth);
+    }
+
+    [Fact]
+    public void Tree_ExpandsASelfLoopAsASingleRevisitChild()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A")],
+            [new GraphEdge("a", "a")],
+            focusKey: "a");
+
+        var root = Assert.Single(GraphLowering.ToTree(graph));
+
+        Assert.Equal("A", root.Text);
+        var child = Assert.Single(root.Children!);
+        Assert.Equal(GraphLowering.RevisitMarker + "A", child.Text);
+        Assert.Null(child.Children);
+    }
+
+    [Fact]
+    public void Tree_ALeafHasNoChildrenListRatherThanAnEmptyOne()
+    {
+        var root = Assert.Single(GraphLowering.ToTree(SimpleChain()));
+
+        var last = root.Children![0].Children![0];
+        Assert.Equal("C", last.Text);
+        Assert.Null(last.Children);
+    }
+
+    [Fact]
+    public void Mermaid_EscapesAGroupTitleThatTriesToCloseItsOwnSubgraph()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A") { Group = "evil\"]\nend\ngraph TD\n" }],
+            []);
+
+        var writer = MarkoutWriter.Create(new MermaidFormatter());
+        writer.WriteGraph(graph);
+        var lines = Normalize(writer.ToString()).Split('\n');
+
+        // The payload survives as inert text inside the quoted title; what must not happen is it
+        // becoming structure. Exactly one flowchart header line and one `end` line, and the whole
+        // title stays on a single line because its newlines are escaped.
+        Assert.Equal(1, lines.Count(line => line.Trim() == "graph TD"));
+        Assert.Equal(1, lines.Count(line => line.Trim() == "end"));
+        Assert.Equal(1, lines.Count(line => line.Contains("subgraph", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Mermaid_KeepsRepeatedGroupsTogetherInFirstSeenOrder()
+    {
+        var graph = new Graph(
+            [
+                new GraphNode("a", "A") { Group = "Second" },
+                new GraphNode("b", "B") { Group = "First" },
+                new GraphNode("c", "C") { Group = "Second" },
+            ],
+            []);
+
+        var writer = MarkoutWriter.Create(new MermaidFormatter());
+        writer.WriteGraph(graph);
+        var output = Normalize(writer.ToString());
+
+        // "Second" is declared once, at the position of its first member, and holds both nodes.
+        Assert.Equal(1, CountOccurrences(output, "\"Second\""));
+        Assert.True(output.IndexOf("\"Second\"", StringComparison.Ordinal) < output.IndexOf("\"First\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EmptyGraph_EveryLoweringAndFormatterHandlesItDirectly()
+    {
+        // WriteGraph short-circuits an empty graph, so exercise the lowerings and the formatters
+        // themselves rather than relying on the writer's guard.
+        var empty = new Graph([], []);
+
+        Assert.Empty(GraphLowering.ToTree(empty));
+        Assert.Empty(GraphLowering.ToEdgeTable(empty).Rows);
+
+        IMarkoutFormatter[] formatters =
+        [
+            new MermaidFormatter(),
+            new MarkdownFormatter(),
+            new TableFormatter(),
+            new PlainTextFormatter(),
+            new DiagramFormatter(),
+            new UnicodeFormatter(),
+        ];
+
+        foreach (var formatter in formatters)
+        {
+            var sink = new StringWriter();
+            ((IGraphFormatter)formatter).FormatGraph(sink, empty, new MarkoutWriterOptions());
+            Assert.Equal("", sink.ToString());
+        }
+    }
+
     private sealed class GraphlessFormatter : IMarkoutFormatter, IHeadingFormatter
     {
         void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -193,7 +193,8 @@ public class GraphTests
         Assert.Equal("D", Assert.Single(viaB.Children!).Text);
 
         var viaA = root.Children[1];
-        Assert.Equal(GraphLowering.RevisitMarker + "C", viaA.Text);
+        Assert.Equal("C", viaA.Text);
+        Assert.Equal(TreeNodeState.Revisit, viaA.State);
         Assert.Null(viaA.Children);
     }
 
@@ -209,7 +210,8 @@ public class GraphTests
         var b = Assert.Single(root.Children!);
         var back = Assert.Single(b.Children!);
 
-        Assert.Equal(GraphLowering.RevisitMarker + "A", back.Text);
+        Assert.Equal("A", back.Text);
+        Assert.Equal(TreeNodeState.Revisit, back.State);
         Assert.Null(back.Children);
     }
 
@@ -688,7 +690,8 @@ public class GraphTests
 
         Assert.Equal("A", root.Text);
         var child = Assert.Single(root.Children!);
-        Assert.Equal(GraphLowering.RevisitMarker + "A", child.Text);
+        Assert.Equal("A", child.Text);
+        Assert.Equal(TreeNodeState.Revisit, child.State);
         Assert.Null(child.Children);
     }
 

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -1,0 +1,543 @@
+using Markout;
+using Markout.Formatting;
+
+namespace Markout.Tests;
+
+[Collection("ConsoleError")]
+public class GraphTests
+{
+    private static Graph SimpleChain() => new(
+        [new GraphNode("a", "A"), new GraphNode("b", "B"), new GraphNode("c", "C")],
+        [new GraphEdge("a", "b"), new GraphEdge("b", "c")]);
+
+    // ── Shape validation ──
+
+    [Fact]
+    public void Graph_RejectsDuplicateNodeKeys()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new Graph(
+            [new GraphNode("a", "First"), new GraphNode("a", "Second")],
+            []));
+        Assert.Contains("'a'", ex.Message);
+    }
+
+    [Fact]
+    public void Graph_RejectsEdgeWithUnknownSource()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new Graph(
+            [new GraphNode("a")],
+            [new GraphEdge("ghost", "a")]));
+        Assert.Contains("'ghost'", ex.Message);
+    }
+
+    [Fact]
+    public void Graph_RejectsEdgeWithUnknownTarget()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new Graph(
+            [new GraphNode("a")],
+            [new GraphEdge("a", "ghost")]));
+        Assert.Contains("'ghost'", ex.Message);
+    }
+
+    [Fact]
+    public void Graph_RejectsFocusThatNamesNoNode()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new Graph(
+            [new GraphNode("a")],
+            [],
+            focusKey: "ghost"));
+        Assert.Contains("'ghost'", ex.Message);
+    }
+
+    [Fact]
+    public void Graph_PreservesParallelEdges()
+    {
+        var graph = new Graph(
+            [new GraphNode("a"), new GraphNode("b")],
+            [new GraphEdge("a", "b"), new GraphEdge("a", "b")]);
+
+        Assert.Equal(2, graph.Edges.Length);
+    }
+
+    [Fact]
+    public void Graph_PreservesNodeOrder()
+    {
+        var graph = new Graph(
+            [new GraphNode("z", "Z"), new GraphNode("a", "A")],
+            []);
+
+        Assert.Equal(["Z", "A"], graph.Nodes.Select(n => n.Label));
+    }
+
+    [Fact]
+    public void Graph_FocusResolvesToTheNode()
+    {
+        var graph = new Graph([new GraphNode("a", "A"), new GraphNode("b", "B")], [], focusKey: "b");
+        Assert.Equal("B", graph.Focus!.Label);
+    }
+
+    [Fact]
+    public void Graph_WithoutFocus_HasNullFocus()
+    {
+        Assert.Null(SimpleChain().Focus);
+    }
+
+    [Fact]
+    public void Graph_AllowsSelfLoop()
+    {
+        var graph = new Graph([new GraphNode("a")], [new GraphEdge("a", "a")]);
+        Assert.Single(graph.Edges);
+    }
+
+    // ── Edge table lowering ──
+
+    [Fact]
+    public void EdgeTable_PlainGraph_HasOnlyFromAndTo()
+    {
+        var table = GraphLowering.ToEdgeTable(SimpleChain());
+
+        Assert.Equal(["From", "To"], table.Headers);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal(["A", "B"], table.Rows[0]);
+        Assert.Equal(["B", "C"], table.Rows[1]);
+    }
+
+    [Fact]
+    public void EdgeTable_AddsGroupColumnsOnlyWhenAGroupIsPresent()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A") { Group = "Lib" }, new GraphNode("b", "B")],
+            [new GraphEdge("a", "b")]);
+
+        var table = GraphLowering.ToEdgeTable(graph);
+
+        Assert.Equal(["From", "From Group", "To", "To Group"], table.Headers);
+        Assert.Equal(["A", "Lib", "B", ""], table.Rows[0]);
+    }
+
+    [Fact]
+    public void EdgeTable_AddsLabelColumnOnlyWhenAnEdgeIsLabelled()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b") { Label = "3x" }]);
+
+        var table = GraphLowering.ToEdgeTable(graph);
+
+        Assert.Equal(["From", "To", "Label"], table.Headers);
+        Assert.Equal(["A", "B", "3x"], table.Rows[0]);
+    }
+
+    [Fact]
+    public void EdgeTable_UsesTheSuppliedLabelSelector()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A") { Emphasized = true }, new GraphNode("b", "B")],
+            [new GraphEdge("a", "b")]);
+
+        var table = GraphLowering.ToEdgeTable(graph, n => n.Emphasized ? $"**{n.Label}**" : n.Label);
+
+        Assert.Equal(["**A**", "B"], table.Rows[0]);
+    }
+
+    [Fact]
+    public void EdgeTable_KeepsARowPerParallelEdge()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b"), new GraphEdge("a", "b")]);
+
+        Assert.Equal(2, GraphLowering.ToEdgeTable(graph).Rows.Count);
+    }
+
+    // ── Tree lowering ──
+
+    [Fact]
+    public void Tree_RootsAtTheFocusNode()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B"), new GraphNode("c", "C")],
+            [new GraphEdge("b", "a"), new GraphEdge("b", "c")],
+            focusKey: "b");
+
+        var tree = GraphLowering.ToTree(graph);
+
+        var root = Assert.Single(tree);
+        Assert.Equal("B", root.Text);
+        Assert.Equal(["A", "C"], root.Children!.Select(c => c.Text));
+    }
+
+    [Fact]
+    public void Tree_WithoutFocus_RootsAtNodesWithNoInboundEdge()
+    {
+        var tree = GraphLowering.ToTree(SimpleChain());
+
+        var root = Assert.Single(tree);
+        Assert.Equal("A", root.Text);
+        Assert.Equal("B", root.Children![0].Text);
+        Assert.Equal("C", root.Children[0].Children![0].Text);
+    }
+
+    [Fact]
+    public void Tree_MarksARevisitInsteadOfExpandingItAgain()
+    {
+        // A -> B, A -> C, B -> C. C is reached twice; the second arrival must not re-expand.
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B"), new GraphNode("c", "C"), new GraphNode("d", "D")],
+            [new GraphEdge("a", "b"), new GraphEdge("a", "c"), new GraphEdge("b", "c"), new GraphEdge("c", "d")]);
+
+        var root = Assert.Single(GraphLowering.ToTree(graph));
+
+        var viaB = root.Children![0].Children![0];
+        Assert.Equal("C", viaB.Text);
+        Assert.Equal("D", Assert.Single(viaB.Children!).Text);
+
+        var viaA = root.Children[1];
+        Assert.Equal(GraphLowering.RevisitMarker + "C", viaA.Text);
+        Assert.Null(viaA.Children);
+    }
+
+    [Fact]
+    public void Tree_TerminatesOnACycle()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b"), new GraphEdge("b", "a")],
+            focusKey: "a");
+
+        var root = Assert.Single(GraphLowering.ToTree(graph));
+        var b = Assert.Single(root.Children!);
+        var back = Assert.Single(b.Children!);
+
+        Assert.Equal(GraphLowering.RevisitMarker + "A", back.Text);
+        Assert.Null(back.Children);
+    }
+
+    [Fact]
+    public void Tree_AllNodesInACycleAndNoFocus_StillRendersFromTheFirstNode()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b"), new GraphEdge("b", "a")]);
+
+        var root = Assert.Single(GraphLowering.ToTree(graph));
+        Assert.Equal("A", root.Text);
+    }
+
+    [Fact]
+    public void Tree_SurfacesNodesUnreachableFromTheFocus()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B"), new GraphNode("orphan", "Orphan")],
+            [new GraphEdge("a", "b")],
+            focusKey: "a");
+
+        var tree = GraphLowering.ToTree(graph);
+
+        Assert.Equal(2, tree.Length);
+        Assert.Equal("A", tree[0].Text);
+        Assert.Equal("Orphan", tree[1].Text);
+    }
+
+    [Fact]
+    public void Tree_QualifiesAChildWithItsEdgeLabel()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b") { Label = "2x" }],
+            focusKey: "a");
+
+        var root = Assert.Single(GraphLowering.ToTree(graph));
+        Assert.Equal("B (2x)", Assert.Single(root.Children!).Text);
+    }
+
+    [Fact]
+    public void Tree_EmptyGraphProducesNoRoots()
+    {
+        Assert.Empty(GraphLowering.ToTree(new Graph([], [])));
+    }
+
+    // ── Mermaid lowering ──
+
+    [Fact]
+    public void Mermaid_RendersAFlowchart()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var expected =
+            "graph TD\n" +
+            "    n0[\"A\"]\n" +
+            "    n1[\"B\"]\n" +
+            "    n2[\"C\"]\n" +
+            "    n0 --> n1\n" +
+            "    n1 --> n2";
+
+        Assert.Equal(expected, Normalize(orch.ToString()));
+    }
+
+    [Fact]
+    public void Mermaid_DeclaresTheFocusNodeFirstAndClassesIt()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b")],
+            focusKey: "b");
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+        var output = Normalize(orch.ToString());
+
+        // Focus takes id n0 despite being second in node order.
+        Assert.Contains("    n0[\"B\"]\n    n1[\"A\"]\n", output);
+        Assert.Contains("    n1 --> n0\n", output);
+        Assert.Contains("class n0 markoutFocus;", output);
+    }
+
+    [Fact]
+    public void Mermaid_NeverEmitsTheCallerSuppliedKey()
+    {
+        var graph = new Graph(
+            [new GraphNode("n0[\"pwned\"]", "Safe")],
+            []);
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+
+        Assert.DoesNotContain("pwned", orch.ToString());
+    }
+
+    [Fact]
+    public void Mermaid_EscapesNodeLabels()
+    {
+        var graph = new Graph([new GraphNode("a", "List<T>")], []);
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+
+        Assert.Contains("n0[\"List#60;T#62;\"]", orch.ToString());
+    }
+
+    [Fact]
+    public void Mermaid_EscapesEdgeLabelsSoTheyCannotCloseTheirOwnEdge()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b") { Label = "\"| n0 --> n1 |\"" }]);
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+        var output = orch.ToString();
+
+        // The quote and pipe delimiters are escaped, and '>' is escaped too, so the injected
+        // arrow cannot survive as syntax.
+        Assert.Contains("-->|\"#quot;#124; n0 --#62; n1 #124;#quot;\"|", output);
+        Assert.Equal(1, CountOccurrences(output, "-->"));
+    }
+
+    [Fact]
+    public void Mermaid_EscapesGroupNames()
+    {
+        var graph = new Graph([new GraphNode("a", "A") { Group = "Sys<T>" }], []);
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+
+        Assert.Contains("subgraph sg0[\"Sys#60;T#62;\"]", orch.ToString());
+    }
+
+    [Fact]
+    public void Mermaid_PutsGroupedNodesInSubgraphsAndEdgesOutside()
+    {
+        var graph = new Graph(
+            [
+                new GraphNode("a", "A") { Group = "One" },
+                new GraphNode("b", "B") { Group = "Two" },
+                new GraphNode("c", "C"),
+            ],
+            [new GraphEdge("a", "b")]);
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+
+        var expected =
+            "graph TD\n" +
+            "    n2[\"C\"]\n" +
+            "    subgraph sg0[\"One\"]\n" +
+            "        n0[\"A\"]\n" +
+            "    end\n" +
+            "    subgraph sg1[\"Two\"]\n" +
+            "        n1[\"B\"]\n" +
+            "    end\n" +
+            "    n0 --> n1";
+
+        Assert.Equal(expected, Normalize(orch.ToString()));
+    }
+
+    [Fact]
+    public void Mermaid_ClassesEmphasizedNodesTogether()
+    {
+        var graph = new Graph(
+            [
+                new GraphNode("a", "A") { Emphasized = true },
+                new GraphNode("b", "B"),
+                new GraphNode("c", "C") { Emphasized = true },
+            ],
+            []);
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+
+        Assert.Contains("class n0,n2 markoutEmphasis;", Normalize(orch.ToString()));
+    }
+
+    [Fact]
+    public void Mermaid_StyleDeclarationsCarryNoHashSoMermaidsGuardCannotTruncateThem()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A") { Emphasized = true }],
+            [],
+            focusKey: "a");
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+
+        foreach (var line in Normalize(orch.ToString()).Split('\n'))
+        {
+            if (line.Contains("classDef") || line.TrimStart().StartsWith("style", StringComparison.Ordinal))
+                Assert.DoesNotContain('#', line);
+        }
+    }
+
+    [Fact]
+    public void Mermaid_FocusOutranksEmphasisForTheSameNode()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A") { Emphasized = true }],
+            [],
+            focusKey: "a");
+
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        orch.WriteGraph(graph);
+        var output = Normalize(orch.ToString());
+
+        Assert.Contains("class n0 markoutFocus;", output);
+        Assert.DoesNotContain("markoutEmphasis", output);
+    }
+
+    // ── Cross-formatter behavior ──
+
+    [Fact]
+    public void Markdown_RendersAnEdgeTable()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = orch.ToString();
+        Assert.Contains("| From | To |", output);
+        Assert.Contains("| A | B |", output);
+        Assert.Contains("| B | C |", output);
+    }
+
+    [Fact]
+    public void Markdown_EmphasizesANodeWithoutReplacingIt()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A") { Emphasized = true }, new GraphNode("b", "B")],
+            [new GraphEdge("a", "b")]);
+
+        var orch = MarkoutWriter.Create(new MarkdownFormatter());
+        orch.WriteGraph(graph);
+
+        Assert.Contains("**A**", orch.ToString());
+    }
+
+    [Fact]
+    public void PlainText_RendersATreeRootedAtTheFocus()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b")],
+            focusKey: "a");
+
+        var orch = MarkoutWriter.Create(new PlainTextFormatter());
+        Assert.True(orch.WriteGraph(graph));
+
+        var output = orch.ToString();
+        Assert.Contains("A", output);
+        Assert.Contains("B", output);
+        Assert.DoesNotContain("graph TD", output);
+    }
+
+    [Fact]
+    public void EveryLoweringSeesEveryNode()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "Alpha"), new GraphNode("b", "Beta"), new GraphNode("c", "Gamma")],
+            [new GraphEdge("a", "b"), new GraphEdge("c", "b")]);
+
+        foreach (var formatter in new IMarkoutFormatter[]
+        {
+            new MermaidFormatter(), new MarkdownFormatter(), new PlainTextFormatter(),
+            new DiagramFormatter(), new UnicodeFormatter(), new TableFormatter(),
+        })
+        {
+            var orch = MarkoutWriter.Create(formatter);
+            Assert.True(orch.WriteGraph(graph), $"{formatter.GetType().Name} did not render a graph.");
+
+            var output = orch.ToString();
+            foreach (var label in new[] { "Alpha", "Beta", "Gamma" })
+                Assert.True(output.Contains(label), $"{formatter.GetType().Name} dropped '{label}'.");
+        }
+    }
+
+    // ── Writer integration ──
+
+    [Fact]
+    public void WriteGraph_EmptyGraphIsANoOpAndStillReportsSuccess()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        Assert.True(orch.WriteGraph(new Graph([], [])));
+        Assert.Equal("", orch.ToString());
+    }
+
+    [Fact]
+    public void WriteGraph_ReturnsFalseWhenTheFormatterCannotRenderGraphs()
+    {
+        var orch = MarkoutWriter.Create(new GraphlessFormatter());
+        Assert.False(orch.WriteGraph(SimpleChain()));
+    }
+
+    [Fact]
+    public void WriteGraph_RejectsNull()
+    {
+        var orch = MarkoutWriter.Create(new MermaidFormatter());
+        Assert.Throws<ArgumentNullException>(() => orch.WriteGraph(null!));
+    }
+
+    [Fact]
+    public void MarkoutShape_AllIncludesGraphs()
+    {
+        Assert.True(MarkoutShape.All.HasFlag(MarkoutShape.Graphs));
+    }
+
+    private sealed class GraphlessFormatter : IMarkoutFormatter, IHeadingFormatter
+    {
+        void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
+            => w.Write(text);
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n");
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -428,15 +428,31 @@ public class GraphTests
     // ── Cross-formatter behavior ──
 
     [Fact]
-    public void Markdown_RendersAnEdgeTable()
+    public void Markdown_RendersATree()
     {
         var orch = MarkoutWriter.Create(new MarkdownFormatter());
         Assert.True(orch.WriteGraph(SimpleChain()));
 
         var output = orch.ToString();
-        Assert.Contains("| From | To |", output);
-        Assert.Contains("| A | B |", output);
-        Assert.Contains("| B | C |", output);
+        Assert.Contains("A", output);
+        Assert.Contains("└─ B", output);
+        Assert.Contains("└─ C", output);
+        // The tree lowering names each node once; it is not the edge-table lowering.
+        Assert.DoesNotContain("| From | To |", output);
+    }
+
+    [Fact]
+    public void Table_RendersAnEdgeTable()
+    {
+        var orch = MarkoutWriter.Create(new TableFormatter());
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = orch.ToString();
+        Assert.Contains("From", output);
+        Assert.Contains("To", output);
+        Assert.Contains("A", output);
+        Assert.Contains("B", output);
+        Assert.Contains("C", output);
     }
 
     [Fact]

--- a/tests/Markout.Tests/Markout.Tests.csproj
+++ b/tests/Markout.Tests/Markout.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Markout\Markout.csproj" />
+    <ProjectReference Include="..\..\src\Markout.Ansi.Spectre\Markout.Ansi.Spectre.csproj" />
     <ProjectReference Include="..\..\src\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />

--- a/tests/Markout.Tests/SpectreTreeStateTests.cs
+++ b/tests/Markout.Tests/SpectreTreeStateTests.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+using Markout;
+using Markout.Ansi.Spectre;
+using Spectre.Console;
+
+namespace Markout.Tests;
+
+/// <summary>
+/// <see cref="SpectreFormatter"/> lives in its own assembly and declares
+/// <see cref="Markout.Formatting.IGlyphFormatter"/>, so it has to render
+/// <see cref="TreeNodeState"/> like the other glyph sinks. It previously had no test coverage at
+/// all, which is how it was missed when the state was introduced.
+/// </summary>
+public partial class SpectreTreeStateTests
+{
+    [Fact]
+    public void RendersTheRevisitGlyph()
+    {
+        Assert.Contains("└─ \u21a9 B", Render(new MarkoutWriterOptions()));
+    }
+
+    [Fact]
+    public void HonoursAConfiguredGlyph()
+    {
+        var options = new MarkoutWriterOptions { Glyphs = MarkoutGlyphs.Default with { Revisit = "[seen]" } };
+
+        Assert.Contains("└─ [seen] B", Render(options));
+    }
+
+    [Fact]
+    public void ANormalNodeGetsNoPrefix()
+    {
+        var output = Render(new MarkoutWriterOptions(), TreeNodeState.Normal);
+
+        Assert.Contains("└─ B", output);
+        Assert.DoesNotContain("\u21a9", output);
+    }
+
+    [Fact]
+    public void TheStatePrecedesTheBadge()
+    {
+        Assert.Contains("└─ \u21a9 📁 B", Render(new MarkoutWriterOptions(), badge: "📁"));
+    }
+
+    /// <summary>
+    /// The state is structure, not decoration, so dropping badges must not drop it.
+    /// </summary>
+    [Fact]
+    public void IncludeBadgesDoesNotSuppressTheState()
+    {
+        var output = Render(new MarkoutWriterOptions { IncludeBadges = false }, badge: "📁");
+
+        Assert.Contains("└─ \u21a9 B", output);
+        Assert.DoesNotContain("📁", output);
+    }
+
+    private static string Render(
+        MarkoutWriterOptions options,
+        TreeNodeState state = TreeNodeState.Revisit,
+        string? badge = null)
+    {
+        var writer = MarkoutWriter.Create(NewFormatter(), options);
+        writer.WriteTree(new TreeNode("A", [new TreeNode("B") { State = state, Badge = badge }]));
+
+        // Spectre wraps the connector in SGR escapes; strip them so assertions read as text.
+        return AnsiEscape().Replace(writer.ToString(), "").Replace("\r\n", "\n");
+    }
+
+    private static SpectreFormatter NewFormatter()
+        => new(AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(TextWriter.Null)
+        }));
+
+    [GeneratedRegex("\u001b\\[[0-9;]*m")]
+    private static partial Regex AnsiEscape();
+}

--- a/tests/Markout.Tests/TreeNodeStateTests.cs
+++ b/tests/Markout.Tests/TreeNodeStateTests.cs
@@ -73,7 +73,7 @@ public class TreeNodeStateTests
     }
 
     [Fact]
-    public void AnEmptyGlyphSuppressesTheMarker()
+    public void AnEmptyGlyphSuppressesTheMarkerInAGlyphSink()
     {
         var options = new MarkoutWriterOptions();
         options.Glyphs = MarkoutGlyphs.Default with { Revisit = "" };
@@ -84,6 +84,36 @@ public class TreeNodeStateTests
 
         Assert.Contains("└─ B", output);
         Assert.DoesNotContain("\u21a9", output);
+    }
+
+    /// <summary>
+    /// <see cref="MarkoutGlyphs"/> configures glyphs, so an empty entry reaches glyph sinks only. A
+    /// sink without glyph support keeps the stable slug word, exactly as a suppressed
+    /// <see cref="MarkoutGlyphs.GoalLower"/> still renders the ASCII <c>(-)</c> marker. This test
+    /// pins both halves together: the revisit marker must not become the one concept in the glyph
+    /// table whose empty entry also silences plain text.
+    /// </summary>
+    [Fact]
+    public void AnEmptyGlyphDoesNotSuppressTheWordInANonGlyphSink()
+    {
+        var options = new MarkoutWriterOptions();
+        options.Glyphs = MarkoutGlyphs.Default with { Revisit = "", GoalLower = "" };
+
+        var tree = MarkoutWriter.Create(new PlainTextFormatter(), options);
+        tree.WriteTree(Revisited());
+        var treeOutput = Normalize(tree.ToString());
+
+        Assert.Contains("└─ (revisit) B", treeOutput);
+        Assert.DoesNotContain("\u21a9", treeOutput);
+
+        // The shipped goal marker behaves identically; if this half ever changes, the revisit half
+        // has to change with it.
+        var metrics = MarkoutWriter.Create(new PlainTextFormatter(), options);
+        metrics.WriteMetricChangeTable([new MetricChange<int>("Failures", 0, 7) { Goal = Goal.Lower }]);
+        var metricsOutput = metrics.ToString();
+
+        Assert.Contains("Failures (-)", metricsOutput);
+        Assert.DoesNotContain("\u2193", metricsOutput);
     }
 
     /// <summary>

--- a/tests/Markout.Tests/TreeNodeStateTests.cs
+++ b/tests/Markout.Tests/TreeNodeStateTests.cs
@@ -134,6 +134,32 @@ public class TreeNodeStateTests
         Assert.Equal(TreeNodeState.Revisit, back.State);
     }
 
+    /// <summary>
+    /// <see cref="TreeWriter"/> has no formatter to declare a capability, so it takes the stable
+    /// word rather than assuming the caller can render a glyph.
+    /// </summary>
+    [Fact]
+    public void TreeWriter_RendersAWordInsteadOfTheGlyph()
+    {
+        var sw = new StringWriter();
+        new TreeWriter(sw).WriteTree(Revisited());
+        var output = Normalize(sw.ToString());
+
+        Assert.Contains("└─ (revisit) B", output);
+        Assert.DoesNotContain("\u21a9", output);
+    }
+
+    [Fact]
+    public void Diagram_RendersAWordInsteadOfTheGlyph()
+    {
+        var writer = MarkoutWriter.Create(new DiagramFormatter());
+        writer.WriteTree(Revisited());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("(revisit) B", output);
+        Assert.DoesNotContain("\u21a9", output);
+    }
+
     private static TreeNode Revisited()
         => new("A", [new TreeNode("B") { State = TreeNodeState.Revisit }]);
 

--- a/tests/Markout.Tests/TreeNodeStateTests.cs
+++ b/tests/Markout.Tests/TreeNodeStateTests.cs
@@ -1,0 +1,141 @@
+using Markout;
+
+namespace Markout.Tests;
+
+/// <summary>
+/// <see cref="TreeNodeState"/> is structural: the lowering records why a node is unexpanded and
+/// each sink chooses its own spelling. These tests pin that separation.
+/// </summary>
+public class TreeNodeStateTests
+{
+    [Fact]
+    public void Markdown_RendersTheRevisitGlyph()
+    {
+        var writer = MarkoutWriter.Create(new MarkdownFormatter());
+        writer.WriteTree(Revisited());
+
+        Assert.Contains("└─ \u21a9 B", Normalize(writer.ToString()));
+    }
+
+    [Fact]
+    public void Unicode_RendersTheRevisitGlyph()
+    {
+        var writer = MarkoutWriter.Create(new UnicodeFormatter());
+        writer.WriteTree(Revisited());
+
+        Assert.Contains("└─ \u21a9 B", Normalize(writer.ToString()));
+    }
+
+    [Fact]
+    public void PlainText_RendersAWordInsteadOfTheGlyph()
+    {
+        var writer = MarkoutWriter.Create(new PlainTextFormatter());
+        writer.WriteTree(Revisited());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("└─ (revisit) B", output);
+        Assert.DoesNotContain("\u21a9", output);
+    }
+
+    [Fact]
+    public void Mermaid_CarriesTheStateInTheNodeLabel()
+    {
+        var writer = MarkoutWriter.Create(new MermaidFormatter());
+        writer.WriteTree(Revisited());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("(revisit) B", output);
+        Assert.DoesNotContain("\u21a9", output);
+    }
+
+    [Fact]
+    public void ANormalNodeGetsNoPrefixInAnySink()
+    {
+        var writer = MarkoutWriter.Create(new MarkdownFormatter());
+        writer.WriteTree(new TreeNode("A", [new TreeNode("B")]));
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("└─ B", output);
+        Assert.DoesNotContain("\u21a9", output);
+        Assert.DoesNotContain("(revisit)", output);
+    }
+
+    [Fact]
+    public void TheGlyphIsConfigurable()
+    {
+        var options = new MarkoutWriterOptions();
+        options.Glyphs = MarkoutGlyphs.Default with { Revisit = "[seen]" };
+
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        writer.WriteTree(Revisited());
+
+        Assert.Contains("└─ [seen] B", Normalize(writer.ToString()));
+    }
+
+    [Fact]
+    public void AnEmptyGlyphSuppressesTheMarker()
+    {
+        var options = new MarkoutWriterOptions();
+        options.Glyphs = MarkoutGlyphs.Default with { Revisit = "" };
+
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        writer.WriteTree(Revisited());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("└─ B", output);
+        Assert.DoesNotContain("\u21a9", output);
+    }
+
+    /// <summary>
+    /// A state is information about the shape of the tree, not decoration. Suppressing badges must
+    /// not suppress it, or an elided subtree becomes indistinguishable from a genuine leaf.
+    /// </summary>
+    [Fact]
+    public void IncludeBadgesDoesNotSuppressTheState()
+    {
+        var options = new MarkoutWriterOptions();
+        options.IncludeBadges = false;
+
+        var node = new TreeNode("B") { State = TreeNodeState.Revisit, Badge = "📁" };
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        writer.WriteTree(new TreeNode("A", [node]));
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("└─ \u21a9 B", output);
+        Assert.DoesNotContain("📁", output);
+    }
+
+    [Fact]
+    public void TheStatePrecedesTheBadge()
+    {
+        var node = new TreeNode("B") { State = TreeNodeState.Revisit, Badge = "📁" };
+        var writer = MarkoutWriter.Create(new MarkdownFormatter());
+        writer.WriteTree(new TreeNode("A", [node]));
+
+        Assert.Contains("└─ \u21a9 📁 B", Normalize(writer.ToString()));
+    }
+
+    /// <summary>
+    /// The state travels on the node, so the text stays exactly what the caller supplied and a
+    /// consumer can match on it without stripping a marker first.
+    /// </summary>
+    [Fact]
+    public void TheLoweringLeavesNodeTextUntouched()
+    {
+        var graph = new Graph(
+            [new GraphNode("a", "A"), new GraphNode("b", "B")],
+            [new GraphEdge("a", "b"), new GraphEdge("b", "a")],
+            focusKey: "a");
+
+        var root = Assert.Single(GraphLowering.ToTree(graph));
+        var back = Assert.Single(Assert.Single(root.Children!).Children!);
+
+        Assert.Equal("A", back.Text);
+        Assert.Equal(TreeNodeState.Revisit, back.State);
+    }
+
+    private static TreeNode Revisited()
+        => new("A", [new TreeNode("B") { State = TreeNodeState.Revisit }]);
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n");
+}


### PR DESCRIPTION
Closes #163.

## What this adds

A generic `Graph` shape primitive — nodes and edges with opaque keys — as a peer
to Markout''s existing `Tree` and `Table` shapes. `MarkoutWriter.WriteGraph(graph)`
dispatches to `IGraphFormatter`, and each formatter lowers the graph to whatever
its format can express:

| Formatter | Lowering |
| --- | --- |
| `MermaidFormatter` | `graph TD` flowchart; focus first, groups as subgraphs |
| `TableFormatter` | edge table, one row per edge |
| `MarkdownFormatter`, `PlainTextFormatter`, `DiagramFormatter`, `UnicodeFormatter` | tree rooted at the focus |

`GraphLowering` exposes `ToEdgeTable(graph, label?)` and `ToTree(graph, label?)`
directly, so a custom formatter can reuse a projection. Both take an optional
label selector, letting a formatter decorate node text — emphasizing `Emphasized`
nodes, for example — without the lowering knowing what the decoration means.

The point of the shape is that the *caller* models a graph once and every sink
gets the best rendering it can produce. `GraphNode.Key` is opaque and never
written to output; `Group` clusters nodes; `Emphasized` augments a node and never
replaces information, so a sink with no way to express it renders the node
unchanged.

The source generator also gained support for a `Graph`-typed `[MarkoutSection]`
property, so a declarative `[MarkoutSerializable]` document can carry a graph
section (`PropertyKind.Graph`, `KnownTypeSymbols.Graph`, `TypeParser`,
`SerializerEmitter`). A null graph omits the section; an empty graph renders
`EmptyText`.

## Commits

1. `2fd5e6f` — the primitive.
2. `e7c90f1` — adversarial review fixes (below).
3. `1e59fa3` — Markdown lowers graphs to a tree, not an edge table.

## Review fixes in `e7c90f1`

| Finding | Resolution |
| --- | --- |
| Edge-table lowering silently dropped isolated nodes | `ToEdgeTable` appends a trailing row per isolated node with an empty `To`. Every lowering now shows every node. |
| `ToTree` stack-overflowed on deep chains | `Expand` is an explicit `Stack<Frame>` walk, preserving the recursive version''s pre-order marking so revisit semantics are unchanged. |
| Empty node labels emitted unparseable `n0[""]` | `GraphNode` rejects null-or-empty labels at construction, keeping the failure at the call site. |
| Null elements in the nodes/edges arrays caused an NRE | The constructor validates elements, naming the parameter and index. |
| A null-returning label selector produced null cells | The selector is coalesced to `""`. |

**Deliberate non-action:** `MarkoutWriter.WriteTree` omits the `_needsBlankLine`
handling its peers have. That is pre-existing on `main` and affects every existing
tree caller, so fixing it inside a graph PR would change unrelated shipped
behavior. Filed separately.

**Documented, not fixed:** the text tree renderers still recurse per level, so an
extremely deep tree remains limited by them. Verified empirically on `main`
before this PR: `PlainTextFormatter` survives depth 4,000 and overflows at 20,000.
`ToTree` was made iterative anyway because it is strictly better.

## Why Markdown lowers to a tree (`1e59fa3`)

The original choice of the edge table for Markdown was not forced by the format —
Markdown expresses both a nested list and a table. Downstream validation in
`richlander/dotnet-inspect` showed it was the wrong one: a 25-node call graph
rendered as an edge table repeated every ~200-character member signature on both
sides of every edge, where the tree names each node once and shows reachability
directly. `TableFormatter` keeps the edge table, so `--table`/`--tsv`/`--jsonl`
consumers that want one row per edge are unaffected.

## Downstream validation

Consumed from `richlander/dotnet-inspect` (PR richlander/dotnet-inspect#3312) via
a locally packed 0.29.0. That consumption is what found **both** the missing
source-generator support (without it the entire declarative path was unusable
downstream) and the Markdown edge-table problem — neither was visible from inside
markout.

## Validation

- `dotnet build Markout.sln -c Release` — succeeded, 0 warnings.
- `dotnet run --project tests/Markout.Tests -c Release` — 819 total, 6 failed.
  All six are the pre-existing CRLF-vs-LF assertions also failing on `main`
  (baseline before this PR: 757 total, the same 6 failed).
- `GraphTests` 40 → 56; new `GeneratedGraphTests` (5) covers the generator path.
- `markdownlint` clean on `docs/user-guide.md`.
