### PR TITLE
Ship the consumer skill shelf inside the NuGet package (0.30.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,14 +48,32 @@ Keep maintainer guidance and consumer grounding separate:
 - **`skills/`** holds the **consumer** grounding for **agents using the Markout package** —
   the source-generated serializer API, attributes, the required `MarkoutSerializerContext`
   pattern, and the higher-value rendering workflows. These are authored as invokable
-  `SKILL.md` skills (a brief base skill plus discrete domain-workflow skills), delivered by
-  skill acquisition rather than packed into the nupkg.
+  `SKILL.md` skills (a brief base skill plus discrete domain-workflow skills).
 
 This mirrors dotnet-inspect's maintainer/consumer split, and now the *delivery form* matches
 too: both projects surface consumer grounding as invokable *skills* (`skills/<name>/SKILL.md`).
-Markout previously shipped a packed `grounding/markout/AGENTS.md` at the nupkg root; that has
-been retired in favor of skills, so the package ships no agent-facing doc of its own — the
-human `README.md` remains the packaged readme.
+Markout previously shipped a packed `grounding/markout/AGENTS.md` at the nupkg root; that prose
+doc has been retired in favor of skills, and the package ships no agent-facing *doc* of its own —
+the human `README.md` remains the packaged readme.
+
+### Shipping the shelf
+
+The skill shelf **is** packed into `Markout.nupkg`, at `skills/<name>/` in the package root
+(`src/Markout/Markout.csproj`). This is the *package skill* delivery route from
+[dotnet-package-skills](https://github.com/richlander/dotnet-package-skills): the shelf restores
+to `~/.nuget/packages/markout/<version>/skills/`, and a package-skill installer copies the skills
+a consumer wants into their repo's `.github/skills/<name>/`, where they persist as ordinary
+in-repo skills — checked in, reviewable, deletable. Packing the shelf pins the grounding to the
+package version that produced it; it does not push anything into a consumer's context, because
+installation stays an explicit, visible act.
+
+Consequences for maintainers:
+
+- The `version:` stamp in every `skills/*/SKILL.md` and in `skills/plugin.json` tracks the
+  **Markout package version**. Bump them together with `<Version>` in `Markout.csproj`, or the
+  shipped shelf misstates which release it describes.
+- `skills/` is globbed into the package, so **any file added there ships**. Keep it to skills.
+- Only `Markout` carries the shelf. `Markout.Templates` and `MarkdownTable.Formatting` do not.
 
 ## Markdown Linting
 

--- a/skills/built-in-shapes/SKILL.md
+++ b/skills/built-in-shapes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: built-in-shapes
-version: 0.22.0
+version: 0.30.0
 description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn

--- a/skills/composite-cells-cards/SKILL.md
+++ b/skills/composite-cells-cards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: composite-cells-cards
-version: 0.22.0
+version: 0.30.0
 description: >-
   Use when a single value must render dense in Markdown but decompose into typed columns in
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas

--- a/skills/conditional-composition/SKILL.md
+++ b/skills/conditional-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conditional-composition
-version: 0.22.0
+version: 0.30.0
 description: >-
   Use when a Markout report must adapt to its data — show or hide whole sections, drop table
   columns that are empty/uniform, filter output to a chosen set of sections, or render one

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout
-version: 0.22.0
+version: 0.30.0
 description: >-
   Use when generating Markdown or other structured output (plain text, ANSI, pretty tables,
   TSV/JSONL) from C# objects instead of hand-built strings — CLIs, tools, reports, agent

--- a/skills/output-formats/SKILL.md
+++ b/skills/output-formats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: output-formats
-version: 0.22.0
+version: 0.30.0
 description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
-  "version": "0.22.0",
+  "version": "0.30.0",
   "description": "Markout workflow skills: a compact base skill plus four domain workflow skills (conditional-composition, output-formats, built-in-shapes, composite-cells-cards). Install all together so an agent can pull whichever a task needs.",
   "skills": ["."]
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Markout</RootNamespace>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.29.0</Version>
-    <PackageReleaseNotes>[#159] New [MarkoutNumberFormat("N0")] attribute (and MarkoutCellFormat.NumberFormat) applies a .NET numeric format string to the numbers Markout renders for a numeric Change&lt;V&gt; cell: the scalar before/after operands, the Delta.Absolute suffix, and the delta-noun / IDeltaCountable delta count. This keeps a grouped cell and its folded delta consistent — 165 → 1,168 (+1,003) instead of 165 → 1168 (+1,003). Composite operands keep their own shape formatting; percentage and multiple deltas are unaffected; structured (TSV/JSONL) output stays raw and ungrouped so it remains machine-parseable. Markout owns the delta sign (it prepends +/-), so the format applies to the magnitude only.</PackageReleaseNotes>
+    <Version>0.30.0</Version>
+    <PackageReleaseNotes>The Markout consumer skill shelf now ships inside the package. Five skills — the base `markout` pattern plus `conditional-composition`, `output-formats`, `built-in-shapes`, and `composite-cells-cards` — are packed at `skills/&lt;name&gt;/SKILL.md` and restore to `~/.nuget/packages/markout/&lt;version&gt;/skills/`, where a package-skill installer can copy them into a consuming repo's `.github/skills/`. This pins the grounding to the package version that produced it, so an agent using Markout gets the current idioms without decompiling the assembly or searching the web. No API or behavior changes.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +33,18 @@
     <None Include="$(MSBuildThisFileDirectory)..\..\README.md"
           Pack="true"
           PackagePath="\" />
+  </ItemGroup>
+
+  <!--
+    Pack the consumer skill shelf at skills/<name>/ in the nupkg. It restores to
+    ~/.nuget/packages/markout/<version>/skills/ and is installed into a consuming repo's
+    .github/skills/ by a package-skill installer. See AGENTS.md "Package grounding".
+  -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\skills\**\*"
+          Pack="true"
+          PackagePath="skills\"
+          Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## The gap

The five consumer skills lived only at the repo root and were referenced by **no project**, so `Markout.nupkg` shipped `README.md`, the analyzer, and the library — and nothing else. Anyone taking a dependency on Markout got no grounding at all.

This is the `.nupkg` half of the open question in [dotnet-package-skills#21](https://github.com/richlander/dotnet-package-skills/issues/21):

> **Where in the package?** A convention is needed for where a shelf lives inside the `.nupkg` [...] Markout currently publishes `skills/` at its repo root and, since richlander/markout#148, ships no doc in the nupkg at all.

## The change

Pack the shelf at `skills/<name>/` in the package root — the *package skill* route from [`dotnet-package-skills/README.md`](https://github.com/richlander/dotnet-package-skills#readme):

| Delivery vehicle | Installed location | Who gets it |
| --- | --- | --- |
| `skills/<name>/` in the `.nupkg` | `.github/skills/<name>/` | every developer in one repo |

The shelf restores to `~/.nuget/packages/markout/<version>/skills/`, and an installer copies the skills a consumer wants into their repo's `.github/skills/<name>/`, where they persist as ordinary in-repo skills — checked in, reviewable, deletable. Row 3 collapses to row 2.

Packing pins the grounding to the package version that produced it. It does **not** push anything into a consumer's context: installation stays an explicit, visible act.

### Not a reversal of #148

\#148 retired the packed grounding **doc** (`grounding/markout/AGENTS.md` at the nupkg root). That decision stands — the package still ships no agent-facing prose of its own, and `README.md` remains the packaged readme. What ships here is the invokable shelf, which a consumer selects from rather than receives wholesale.

### Version stamps

Every `SKILL.md` and `skills/plugin.json` read `version: 0.22.0` while the package was at `0.29.0`. A shelf that ships *with* the package cannot misstate which release it describes, so they move to `0.30.0` and `AGENTS.md` now records that they track the package version and must be bumped alongside `<Version>`.

### Scope

Only `Markout` carries the shelf. `Markout.Templates` and `MarkdownTable.Formatting` are unchanged. `grounding/` (eval fixtures + results) is untouched.

## Package contents

```
README.md
analyzers/dotnet/cs/Markout.SourceGeneration.dll
lib/net10.0/Markout.dll
skills/built-in-shapes/SKILL.md
skills/composite-cells-cards/SKILL.md
skills/conditional-composition/SKILL.md
skills/markout/SKILL.md
skills/output-formats/SKILL.md
skills/plugin.json
```

## Verification

- `dotnet pack -c Release` emits the layout above. An initial attempt using `PackagePath="skills\%(RecursiveDir)"` produced doubled directories (`skills/markout/markout/SKILL.md`) — NuGet appends `%(RecursiveDir)` itself for globbed items, so the metadata is omitted.
- Restored into a scratch project from a local feed; shelf lands on disk at `~/.nuget/packages/markout/0.30.0/skills/<name>/SKILL.md` with the `0.30.0` stamp.
- `dotnet run --project tests/Markout.Tests -c Release -p:ExcludeAnsi=true` — 837 passed, 0 failed.
- `markdownlint` clean on all changed markdown.

No API or behavior changes.