### PR TITLE
Enforce the shelf invariants #168 wrote down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ Consequences for maintainers:
 - The `version:` stamp in every `skills/*/SKILL.md` and in `skills/plugin.json` tracks the
   **Markout package version**. `dotnet pack` **fails** if they disagree with `<Version>` in
   `Markout.csproj`, because the shipped shelf must not misstate which release it describes.
-- `skills/` is globbed into the package, so **any file added there ships**. Keep it to skills;
-  the pack excludes dotfiles and editor backups, not stray content.
+- `skills/` is globbed into the package, so **any file committed there ships**. Releases pack
+  a clean CI checkout, so what is in git is exactly what consumers get. Keep it to skills.
 - Only `Markout` carries the shelf. `Markout.Templates` and `MarkdownTable.Formatting` do not.
 
 ## Markdown Linting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,10 @@ installation stays an explicit, visible act.
 Consequences for maintainers:
 
 - The `version:` stamp in every `skills/*/SKILL.md` and in `skills/plugin.json` tracks the
-  **Markout package version**. Bump them together with `<Version>` in `Markout.csproj`, or the
-  shipped shelf misstates which release it describes.
-- `skills/` is globbed into the package, so **any file added there ships**. Keep it to skills.
+  **Markout package version**. `dotnet pack` **fails** if they disagree with `<Version>` in
+  `Markout.csproj`, because the shipped shelf must not misstate which release it describes.
+- `skills/` is globbed into the package, so **any file added there ships**. Keep it to skills;
+  the pack excludes dotfiles and editor backups, not stray content.
 - Only `Markout` carries the shelf. `Markout.Templates` and `MarkdownTable.Formatting` do not.
 
 ## Markdown Linting

--- a/grounding/markout/results.md
+++ b/grounding/markout/results.md
@@ -11,13 +11,16 @@ a single pass/fail. The rungs: **Fails < Satisfies < Delivers** — *Fails* = no
 hand-rolled around the taught surface; *Delivers* = *Satisfies* **and** done the idiomatic taught way
 (the full-price rung yield counts; Stage 1 proxies `Delivers ≡ Satisfies` — see caveats).
 
-- **Harness:** `richlander/dotnet-package-grounding` + `skill-validator@cb9e32a` (per-run
+- **Harness:** `richlander/dotnet-package-grounding` +
+  [`skill-validator@cb9e32a`](https://github.com/richlander/skills/tree/published-markout-ct24) (per-run
   capture; graded-yield quality card via `analyze --view ladder` — beta-binomial posterior + nested
   bootstrap bands on both per-dollar IET and per-day duration, plus the ≥20% economic gate). All four
   legs ran on the **same** validator build; all four columns were **re-rendered in a single pass** on
-  one harness build, so the bands are mutually comparable.
-- **Package:** Markout `0.23.0`; shelf `skills/markout-consumer@f14fec3` (MVV-free). Provenance is
-  identical across all four legs — `docContentHash sha256:e35d12a6e562295a`,
+  one harness build, so the bands are mutually comparable. That commit is not on `dotnet/skills` main
+  — holistic eval mode was never upstreamed — so it is preserved on the `published-markout-ct24` tag.
+- **Package:** Markout `0.23.0`; shelf
+  [`skills/@f14fec3`](https://github.com/richlander/markout/tree/f14fec3/skills) (MVV-free).
+  Provenance is identical across all four legs — `docContentHash sha256:e35d12a6e562295a`,
   `fixtureHash sha256:83617c5cf63fd96c` — so the only variable is the model.
 - **Arms:** `baseline` (no grounding) → `SKILL.md` (the shelf, agent self-selects). **Eval mode:**
   holistic (baseline vs plugin; isolated arm skipped). IET model `anthropic`.

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -39,13 +39,9 @@
     Pack the consumer skill shelf at skills/<name>/ in the nupkg. It restores to
     ~/.nuget/packages/markout/<version>/skills/ and is installed into a consuming repo's
     .github/skills/ by a package-skill installer. See AGENTS.md "Package grounding".
-
-    The glob ships whatever is in skills/, so exclude the files a working tree collects
-    (macOS .DS_Store, editor backups) rather than trusting nobody ever leaves one there.
   -->
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\skills\**\*"
-          Exclude="$(MSBuildThisFileDirectory)..\..\skills\**\.*;$(MSBuildThisFileDirectory)..\..\skills\**\*~;$(MSBuildThisFileDirectory)..\..\skills\**\*.bak;$(MSBuildThisFileDirectory)..\..\skills\**\*.orig"
           Pack="true"
           PackagePath="skills\"
           Visible="false" />

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -39,12 +39,32 @@
     Pack the consumer skill shelf at skills/<name>/ in the nupkg. It restores to
     ~/.nuget/packages/markout/<version>/skills/ and is installed into a consuming repo's
     .github/skills/ by a package-skill installer. See AGENTS.md "Package grounding".
+
+    The glob ships whatever is in skills/, so exclude the files a working tree collects
+    (macOS .DS_Store, editor backups) rather than trusting nobody ever leaves one there.
   -->
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\skills\**\*"
+          Exclude="$(MSBuildThisFileDirectory)..\..\skills\**\.*;$(MSBuildThisFileDirectory)..\..\skills\**\*~;$(MSBuildThisFileDirectory)..\..\skills\**\*.bak;$(MSBuildThisFileDirectory)..\..\skills\**\*.orig"
           Pack="true"
           PackagePath="skills\"
           Visible="false" />
   </ItemGroup>
+
+  <!--
+    The shelf ships inside the package, so its version stamps describe the release a
+    consumer restored. They drifted before (0.22.0 while the package shipped 0.29.0, across
+    seven releases) because keeping them in sync was a rule someone had to remember. Fail
+    the pack instead.
+  -->
+  <Target Name="ValidateShelfVersionStamps" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_ShelfSkill Include="$(MSBuildThisFileDirectory)..\..\skills\**\SKILL.md" />
+    </ItemGroup>
+    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Contains('%0Aversion: $(Version)%0A'))"
+           Text="skills/%(_ShelfSkill.RecursiveDir)SKILL.md does not carry 'version: $(Version)'. The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
+    <Error Condition="!$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\skills\plugin.json').Contains('&quot;version&quot;: &quot;$(Version)&quot;'))"
+           Text="skills/plugin.json does not carry version $(Version). The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Follow-up to #168, which shipped the shelf inside the package and recorded two rules
in `AGENTS.md`: keep the `version:` stamps in step with `<Version>`, and keep `skills/`
to skills. Both were left to memory. The first had already failed that way once,
sitting at `0.22.0` while the package shipped `0.29.0` across seven releases, which is
what #168 had to repair.

## Fail the pack instead of remembering

A shelf that ships *with* the package cannot misstate which release it describes, so
`ValidateShelfVersionStamps` runs before `GenerateNuspec` and errors when any
`skills/*/SKILL.md` or `skills/plugin.json` disagrees with `<Version>`.

Rehearsed by bumping `<Version>` to `0.31.0` without touching the shelf:

```
error : skills/built-in-shapes/SKILL.md does not carry 'version: 0.31.0'.
        The packed shelf would misstate which release it describes.
```

`dotnet pack` succeeds unchanged, and `dotnet run --project tests/Markout.Tests -c
Release -p:ExcludeAnsi=true` reports 837 passed, 0 failed.

The second rule needs no code. Releases publish artifacts downloaded from a CI run,
and CI packs a fresh checkout on `ubuntu-latest`, so what is committed to `skills/` is
exactly what consumers get: no `.DS_Store` can exist there, and a `.bak` or `.orig`
would have to be committed, which is a bad merge that review catches. `AGENTS.md` now
says that rather than implying a stray file could slip through.

## Link the provenance in the CT-24 results

`grounding/markout/results.md` cited its harness as a bare short SHA, `skill-validator@cb9e32a`.
That commit is **not** on `dotnet/skills` main: holistic eval mode was never upstreamed, and
until today it survived only as an unreferenced object. It is now preserved on the
[`published-markout-ct24`](https://github.com/richlander/skills/tree/published-markout-ct24)
tag and linked from the report, along with the shelf tree the run actually graded.
The shelf was also cited at a path that no longer exists (`skills/markout-consumer@f14fec3`);
it now links to `skills/` at that commit.
