### PR TITLE
Make the shipped skills standalone

### DIFF
--- a/skills/built-in-shapes/SKILL.md
+++ b/skills/built-in-shapes/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn
   ASCII or manual Markdown. Markout ships these as data types (Metric, Breakdown/Slice, Callout,
-  TreeNode, Description, CodeSection) you attach as model properties. Requires the base `markout`
-  pattern. Don't decompile the assembly or web-search the API — the shape types are here.
+  TreeNode, Description, CodeSection) you attach as model properties.
+  Don't decompile the assembly or web-search the API — the shape types are here.
 ---
 
 # Built-in shapes — declare the meaning, get the visual

--- a/skills/built-in-shapes/SKILL.md
+++ b/skills/built-in-shapes/SKILL.md
@@ -15,6 +15,21 @@ Attach these types as properties; the formatter draws the right visual. The anti
 building bars/trees by hand (`new string('█', n)`, indented dashes). Say *what the data is* — a
 measurement, a breakdown, an alert — not *how to draw it*.
 
+## Required setup
+
+Markout has **no reflection fallback**. Every report needs an annotated model, a partial context
+registering each model type, and a `Serialize` call that passes it — there is no `Serialize(obj)`
+overload, and omitting the context does not compile.
+
+```csharp
+using Markout;
+
+[MarkoutContext(typeof(Dashboard))]   // your model types only — the shape types below are built in
+public partial class DashboardContext : MarkoutSerializerContext { }
+
+MarkoutSerializer.Serialize(dashboard, Console.Out, DashboardContext.Default);
+```
+
 ## The shapes
 
 ```csharp
@@ -45,9 +60,10 @@ public class Dashboard
     [MarkoutSection(Name = "Glossary"), MarkoutIgnoreInTable]
     public List<Description>? Glossary { get; set; }    // new Description("API", "Application ...")
 
-    // Code block.
-    [MarkoutIgnoreInTable]
-    public CodeSection? Snippet { get; set; }           // new CodeSection("csharp", "class Foo { }")
+    // Code block. Like Callout it is a value type, so pair it with [MarkoutSkipDefault]
+    // rather than making it nullable — the generator cannot unwrap a CodeSection?.
+    [MarkoutIgnoreInTable, MarkoutSkipDefault]
+    public CodeSection Snippet { get; set; }            // new CodeSection("csharp", "class Foo { }")
 }
 ```
 
@@ -62,7 +78,8 @@ public class Dashboard
   terminal formatter this shows the group label + `█` bar, not per-slice table rows.
 - **Children go in a collection expression**, never as trailing constructor arguments:
   `new TreeNode("root", [new TreeNode("leaf")])`. `Badge` is an optional object-initializer property.
-- **`Callout` is a value type** — pair it with `[MarkoutSkipDefault]` so an unset callout disappears.
+- **`Callout` and `CodeSection` are value types** — declare them non-nullable and pair with
+  `[MarkoutSkipDefault]` so an unset one disappears. `Callout?` / `CodeSection?` does not compile.
 - Do not hand-draw bars/trees; if you're building glyphs by hand you're using the wrong tool.
 
 ## Shape cheat-sheet

--- a/skills/composite-cells-cards/SKILL.md
+++ b/skills/composite-cells-cards/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas
   and goal polarity — or when building metric / role-matrix / verdict cards from one model
   (Change<V>, Fraction, Share, Percent, Segments, Delta/Goal, MetricChange<T>, MultiSourceRow,
-  Verdict). This is Markout's most advanced tier. Requires the base `markout` pattern.
+  Verdict). This is Markout's most advanced tier.
   Don't decompile the assembly or web-search the API — these composite types are here.
 ---
 

--- a/skills/composite-cells-cards/SKILL.md
+++ b/skills/composite-cells-cards/SKILL.md
@@ -17,6 +17,21 @@ a row: Markdown renders a dense human value, and `TableFormatter` (TSV/JSONL) de
 cell into typed columns — no pre-stringifying, one declaration serves both. This replaces
 pre-formatting numbers into strings (which loses the machine-readable form).
 
+## Required setup
+
+Markout has **no reflection fallback**. Every report needs an annotated model, a partial context
+registering each model type, and a `Serialize` call that passes it — there is no `Serialize(obj)`
+overload, and omitting the context does not compile.
+
+```csharp
+using Markout;
+
+[MarkoutContext(typeof(QualityCard))]   // register every model type you serialize
+public partial class QualityCardContext : MarkoutSerializerContext { }
+
+MarkoutSerializer.Serialize(card, Console.Out, QualityCardContext.Default);
+```
+
 ## Composite cell primitives
 
 | Shape | Dense Markdown | Decomposed columns |

--- a/skills/conditional-composition/SKILL.md
+++ b/skills/conditional-composition/SKILL.md
@@ -6,8 +6,7 @@ description: >-
   columns that are empty/uniform, filter output to a chosen set of sections, or render one
   model into several shapes ("one model, many views"). This is Markout's highest-value idiom:
   declare the conditions with attributes instead of hand-writing if/else + StringBuilder.
-  Requires the base `markout` pattern (model + context + Serialize). Don't decompile the
-  assembly or web-search the API — the conditional idioms are here.
+  Don't decompile the assembly or web-search the API — the conditional idioms are here.
 ---
 
 # Conditional composition — one model, many views

--- a/skills/conditional-composition/SKILL.md
+++ b/skills/conditional-composition/SKILL.md
@@ -15,6 +15,24 @@ The trap this skill prevents: hand-rolling `if (hasErrors) sb.AppendLine("## Err
 column arithmetic. In Markout you **declare** the condition on the model; the generator renders the
 right shape. This keeps one source of truth and makes the same model serve quiet/detail/export modes.
 
+## Required setup
+
+Markout has **no reflection fallback**. Every report needs an annotated model, a partial context
+registering each model type, and a `Serialize` call that passes it — there is no `Serialize(obj)`
+overload, and omitting the context does not compile.
+
+```csharp
+using Markout;
+
+[MarkoutContext(typeof(Inspection))]    // the model AND every user element type of a List<T>
+[MarkoutContext(typeof(FailureRow))]
+[MarkoutContext(typeof(WarnRow))]
+[MarkoutContext(typeof(MatchRow))]
+public partial class InspectionContext : MarkoutSerializerContext { }
+
+var ctx = InspectionContext.Default;    // the `ctx` passed in the examples below
+```
+
 ## Conditional sections
 
 ```csharp

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -8,8 +8,9 @@ description: >-
   source-gen but the rules differ (NO reflection fallback), so it needs a generated
   MarkoutSerializerContext and Markout-specific attributes. Covers the required pattern:
   annotated models, the partial context, scalar field shaping (title, description,
-  per-value formatting), and serializing through the context. Don't decompile the Markout
-  assembly or web-search its API — every idiom you need is here.
+  per-value formatting), and serializing through the context. Conditional composition, output
+  formats, built-in shapes, and composite cells are covered separately. Don't decompile the
+  Markout assembly or web-search its API — every idiom you need is in the Markout skills.
 ---
 
 # Markout — structured output from objects
@@ -18,8 +19,10 @@ Package `Markout` (the source generator ships in it — no extra package). Defau
 Markdown. Reach for Markout whenever a tool would otherwise build strings with
 `Console.WriteLine` / `StringBuilder`.
 
-> **Everything you need is here.** Do NOT `web_search` / `web_fetch` for Markout usage —
-> this skill is authoritative and version-matched to the package.
+> **Everything you need is in the Markout skills.** Do NOT `web_search` / `web_fetch` for
+> Markout usage — they are authoritative and version-matched to the package. This skill covers
+> the core pattern; conditional composition, output formats, built-in shapes, and composite
+> cells are covered separately.
 
 ## The required pattern (3 parts — all mandatory)
 
@@ -100,4 +103,4 @@ serialize. Keep the JSON DTO and the Markout model separate; project between the
 
 Describe the data and let the type plus attributes drive the output. Conditional sections and
 columns, alternate output formats, visual shapes, and composite cells are all declared on the
-model — do NOT hand-roll `if`/`StringBuilder` for them.
+model — do NOT hand-roll `if`/`StringBuilder` for them. Each of those is covered separately.

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -6,10 +6,10 @@ description: >-
   TSV/JSONL) from C# objects instead of hand-built strings — CLIs, tools, reports, agent
   output. Markout is a source-generated .NET serializer: it looks like System.Text.Json
   source-gen but the rules differ (NO reflection fallback), so it needs a generated
-  MarkoutSerializerContext and Markout-specific attributes. Start here for the required
-  pattern; branch to the domain skills for conditional reports, multi-view/verbosity,
-  output formats, built-in shapes, and composite cells/cards. Don't decompile the Markout
-  assembly or web-search its API — every idiom you need is in these skills.
+  MarkoutSerializerContext and Markout-specific attributes. Covers the required pattern:
+  annotated models, the partial context, scalar field shaping (title, description,
+  per-value formatting), and serializing through the context. Don't decompile the Markout
+  assembly or web-search its API — every idiom you need is here.
 ---
 
 # Markout — structured output from objects
@@ -18,9 +18,8 @@ Package `Markout` (the source generator ships in it — no extra package). Defau
 Markdown. Reach for Markout whenever a tool would otherwise build strings with
 `Console.WriteLine` / `StringBuilder`.
 
-> **Everything you need is in these skills.** Do NOT `web_search` / `web_fetch` for Markout usage —
-> this base skill plus the domain skills below are authoritative and version-matched to the package.
-> If an idiom isn't here, pull the matching domain skill (listed at the end); don't go to the web.
+> **Everything you need is here.** Do NOT `web_search` / `web_fetch` for Markout usage —
+> this skill is authoritative and version-matched to the package.
 
 ## The required pattern (3 parts — all mandatory)
 
@@ -97,14 +96,8 @@ public class Component
 Fetch JSON, project to a Markout model (a plain data model is fine — no separate visual layer),
 serialize. Keep the JSON DTO and the Markout model separate; project between them with LINQ.
 
-## Which skill for what
+## Author declaratively
 
-Author declaratively — describe the data, let the type/attributes drive output. Do NOT hand-roll
-`if`/`StringBuilder` for things below. Pull the matching skill:
-
-- **conditional-composition** — show/hide sections & columns from the data; filter to sections;
-  one model, many shapes (`ShowWhenProperty`, `IgnoreColumnWhen`, `IncludeSections`, same-name sections).
-- **output-formats** — plain text, ANSI/Spectre, pretty tables, TSV/JSONL, multi-format dispatch.
-- **built-in-shapes** — `Metric`, `Breakdown`, `Callout`, `TreeNode`, `Description`, `CodeSection`.
-- **composite-cells-cards** — dense-Markdown-cell ↔ decomposed-column data (`Change<V>`, `Fraction`,
-  `Share`, `Percent`, `Segments`, `Delta`/`Goal`) and metric/role/verdict cards.
+Describe the data and let the type plus attributes drive the output. Conditional sections and
+columns, alternate output formats, visual shapes, and composite cells are all declared on the
+model — do NOT hand-roll `if`/`StringBuilder` for them.

--- a/skills/output-formats/SKILL.md
+++ b/skills/output-formats/SKILL.md
@@ -15,6 +15,32 @@ Default `Serialize(...)` emits Markdown. Pass a **formatter** (and optional `Mar
 to get other formats. The anti-pattern is per-format string building (`string.Join("\t", ...)`); let
 Markout project the same model to each format so columns/headers stay consistent.
 
+## Required setup
+
+Markout has **no reflection fallback**. Every report needs an annotated model, a partial context
+registering each model type, and a `Serialize` call that passes it — there is no `Serialize(obj)`
+overload, and omitting the context does not compile.
+
+```csharp
+using Markout;
+
+[MarkoutSerializable(TitleProperty = nameof(Title))]
+public class Report
+{
+    public string Title { get; set; } = "";
+    [MarkoutSection(Name = "Rows")] public List<Row>? Rows { get; set; }
+}
+
+[MarkoutSerializable]
+public class Row { public string Name { get; set; } = ""; public int Count { get; set; } }
+
+[MarkoutContext(typeof(Report))]
+[MarkoutContext(typeof(Row))]          // every user element type of a List<T>, too
+public partial class ReportContext : MarkoutSerializerContext { }
+
+var ctx = ReportContext.Default;       // the `ctx` passed in the examples below
+```
+
 ## Formatters
 
 ```csharp
@@ -48,7 +74,7 @@ MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), ctx, opts
 
 - `MarkoutTableMode.Pretty` — columns aligned to a uniform start position.
 - `MarkoutTableMode.Tsv` — stable `snake_case` headers; never emits embedded tabs/newlines in cells.
-- `MarkoutTableMode.Jsonl` — one record per row (heterogeneous keys; see composite-cells-cards).
+- `MarkoutTableMode.Jsonl` — one record per row, carrying only that row's keys (heterogeneous).
 - `MaxItems = N` caps EVERY table to N rows and appends `... and {count} more`; works with any formatter,
   so a Markdown view can show the first N rows while TSV/JSONL export them all. (Or per-property:
   `[MarkoutMaxItems(3)]`, with an optional `EllipsisFormat`.)

--- a/skills/output-formats/SKILL.md
+++ b/skills/output-formats/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several
   formats from a single render path (a CLI `--format` switch). Pick the format with a formatter
-  + MarkoutWriterOptions; never hand-build TSV/JSONL. Requires the base `markout` pattern.
+  + MarkoutWriterOptions; never hand-build TSV/JSONL.
   Don't decompile the assembly or web-search the API — the TSV/JSONL/formatter idioms are all here.
 ---
 

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
   "version": "0.31.0",
-  "description": "Markout workflow skills: a compact base skill plus four domain workflow skills (conditional-composition, output-formats, built-in-shapes, composite-cells-cards). Install all together so an agent can pull whichever a task needs.",
+  "description": "Markout workflow skills: five standalone skills (markout, conditional-composition, output-formats, built-in-shapes, composite-cells-cards). Each stands on its own and is selected by its own description; install any or all.",
   "skills": ["."]
 }

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
   "version": "0.31.0",
-  "description": "Markout workflow skills: five standalone skills (markout, conditional-composition, output-formats, built-in-shapes, composite-cells-cards). Each stands on its own and is selected by its own description; install any or all.",
+  "description": "Markout library skills: one base skill, markout; four workflow-specific skills, conditional-composition, output-formats, built-in-shapes, composite-cells-cards. The workflow-specific skills assume the basic working knowledge of the library captured in the base skill.",
   "skills": ["."]
 }

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
   "version": "0.31.0",
-  "description": "Markout library skills: one base skill, markout; four workflow-specific skills, conditional-composition, output-formats, built-in-shapes, composite-cells-cards. The workflow-specific skills assume the basic working knowledge of the library captured in the base skill.",
+  "description": "Markout library skills: one base skill, markout; four workflow-specific skills, conditional-composition, output-formats, built-in-shapes, composite-cells-cards. Each workflow-specific skill carries the required serializer-context setup so it works on its own; the base skill is the fuller treatment of the library.",
   "skills": ["."]
 }


### PR DESCRIPTION
Make the four workflow skills usable on their own, and stop the base skill from claiming to be complete.

## What changed

- Each workflow skill gains a **Required setup** section carrying the partial `MarkoutSerializerContext` declaration for its own example types. Previously that pattern appeared in exactly one file on the shelf — the base skill — and Markout has no reflection fallback, so a workflow skill read on its own did not give you code that compiles.
- The base skill drops its routing table and its four outbound pointers.
- The base skill **states its scope** — "this skill covers the core pattern; conditional composition, output formats, built-in shapes, and composite cells are covered separately" — naming topics but **no skill directories**, so nothing dangles when an installer writes a subset.
- Fixes found while compiling the skills' own examples: `built-in-shapes` declared `CodeSection? Snippet`, but `CodeSection` is a `readonly record struct` and the generator emits `.Content`/`.Language` on the `Nullable<T>` — the skill's own example never compiled. `output-formats` still cross-referenced `composite-cells-cards`.

All four Required-setup blocks were verified by extracting them plus their models into one project built against `src/Markout` with the generator running.

## Why the scope sentence is there

The first version of this PR removed the routing table *and* rewrote the guardrail from "everything you need is in these skills / this base skill **plus the domain skills below**" to "everything you need is **here** / **this skill** is authoritative". For a domain task that claim is false, and it turned out to be load-bearing.

Measured on CT-24, `claude-haiku-4.5`, 5 runs × 26 scenarios = 130 runs per leg, one pinned baseline shared across all three legs, each leg in its own results dir.

| | hub (`main`) | standalone (first pass) | this PR |
|---|---|---|---|
| overall pass | 84.6% | 78.5% | **87.7%** |
| CT07+ runs stuck on base skill alone | 1/100 | 25/100 | 8/100 |
| runs using a workflow skill with **no** base skill | 0 | 21 | **36** (91.7% pass) |
| pluginScore | 0.084 (sig) | 0.140 (n.s.) | **0.180 (sig)** |

- First pass vs this PR: **+9.2 pts, p=0.047**.
- This PR vs `main`: +3.1 pts, **not significant** — indistinguishable from the routing shelf on correctness, while 27.7% of runs now work from a workflow skill with no base skill at all (vs zero on `main`, p<0.0001).

The regression in the first pass was one population: agents on a domain task that opened the base skill, read "everything you need is here", and stopped. Those runs went 1/100 → 25/100 and passed 48% against the shelf's ~85%. On the basics (CT01–06), where reading only the base skill is the right answer, every version passes 100%.

The scope sentence does not make those runs better — it makes them rarer (25 → 8). One sentence controls whether the agent keeps looking.

Residual, stated plainly: 8 stuck runs vs `main`'s 1 (p=0.017). A scope statement is a weaker dispatcher than an explicit router because it deliberately does not instruct. That is the price of being safe under subset installation, and at this sample size it does not reach overall pass rate.

## Caveat on the numbers

The baseline arm is **not** ungrounded here: 47 of 130 baseline sessions read `~/.nuget/packages/markout/0.30.0/skills/*/SKILL.md`, because Markout ships its skills inside the package. That inflates the baseline and understates uplift in all three legs equally, so the comparison between legs stands, but the absolute uplift figures are conservative. Tracking separately.

About 10% of skilled sessions also read that cached copy, which is *hub* content in every leg — biasing the two later legs toward the old shelf, so their true effect is if anything slightly larger than measured.
