### PR TITLE
Ship XML documentation in the NuGet packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,23 @@ Consequences for maintainers:
   a clean CI checkout, so what is in git is exactly what consumers get. Keep it to skills.
 - Only `Markout` carries the shelf. `Markout.Templates` and `MarkdownTable.Formatting` do not.
 
+## XML documentation
+
+The five shipping libraries — `Markout`, `Markout.Templates`, `MarkdownTable.Formatting`,
+`MarkdownTable.Query`, and `Markout.Ansi.Spectre` — set `GenerateDocumentationFile`, so
+`dotnet pack` puts `lib/<tfm>/<Assembly>.xml` next to the DLL and consumers get IntelliSense
+and agent-readable API grounding from the package itself.
+
+Combined with the repo-wide `TreatWarningsAsErrors`, this means **every new public member
+needs a doc comment** — CS1591 is a build error, not a warning. Malformed comments and
+broken `cref` targets (CS1570/CS1574/CS1734) fail the build too, so `<see cref="..."/>` must
+point at something that actually resolves from the *referencing* project. `Markout` cannot
+`cref` into `Markout.Templates`, for example, because the dependency runs the other way;
+use `<c>...</c>` for those. Use `<inheritdoc/>` when an interface member already carries
+the documentation.
+
+Tests, samples, tools, and `Markout.Demo` are not packed and do not generate a doc file.
+
 ## Markdown Linting
 
 All markdown files must pass `markdownlint` before committing. When there are lint errors, run the auto-fixer first:

--- a/skills/built-in-shapes/SKILL.md
+++ b/skills/built-in-shapes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: built-in-shapes
-version: 0.30.0
+version: 0.31.0
 description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn

--- a/skills/composite-cells-cards/SKILL.md
+++ b/skills/composite-cells-cards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: composite-cells-cards
-version: 0.30.0
+version: 0.31.0
 description: >-
   Use when a single value must render dense in Markdown but decompose into typed columns in
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas

--- a/skills/conditional-composition/SKILL.md
+++ b/skills/conditional-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conditional-composition
-version: 0.30.0
+version: 0.31.0
 description: >-
   Use when a Markout report must adapt to its data — show or hide whole sections, drop table
   columns that are empty/uniform, filter output to a chosen set of sections, or render one

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout
-version: 0.30.0
+version: 0.31.0
 description: >-
   Use when generating Markdown or other structured output (plain text, ANSI, pretty tables,
   TSV/JSONL) from C# objects instead of hand-built strings — CLIs, tools, reports, agent

--- a/skills/output-formats/SKILL.md
+++ b/skills/output-formats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: output-formats
-version: 0.30.0
+version: 0.31.0
 description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Markout workflow skills: a compact base skill plus four domain workflow skills (conditional-composition, output-formats, built-in-shapes, composite-cells-cards). Install all together so an agent can pull whichever a task needs.",
   "skills": ["."]
 }

--- a/src/MarkdownTable.Formatting/CompactMode.cs
+++ b/src/MarkdownTable.Formatting/CompactMode.cs
@@ -6,13 +6,28 @@ namespace MarkdownTable.Formatting;
 /// </summary>
 public class CompactMode : IFormatterMode, IFormatterModeInfo
 {
+    /// <summary>
+    /// Percentile threshold for column width calculation (0.0–1.0). Default: 0.2.
+    /// </summary>
     public double Percentile { get; set; } = 0.2;
+
+    /// <summary>
+    /// Multiplier applied to the percentile width (0.0–10.0). Default: 1.0.
+    /// </summary>
     public double Tolerance { get; set; } = 1.0;
+
+    /// <summary>
+    /// Columns narrower than this use max-width instead of statistics. Default: 4.
+    /// </summary>
     public int ShadowThreshold { get; set; } = 4;
 
+    /// <inheritdoc cref="IFormatterModeInfo.Name"/>
     public static string Name => "compact";
+
+    /// <inheritdoc cref="IFormatterModeInfo.Description"/>
     public static string Description => "Aggressive space optimization with tight statistical parameters";
 
+    /// <inheritdoc/>
     public TableFormatterOptions Options => new()
     {
         Percentile = Percentile,
@@ -20,6 +35,7 @@ public class CompactMode : IFormatterMode, IFormatterModeInfo
         ShadowThreshold = ShadowThreshold
     };
 
+    /// <inheritdoc/>
     public IReadOnlyList<IParameterDescriptor> GetParameters() =>
     [
         new ParameterDescriptor<double>("percentile",

--- a/src/MarkdownTable.Formatting/FieldDocument.cs
+++ b/src/MarkdownTable.Formatting/FieldDocument.cs
@@ -165,6 +165,9 @@ public sealed class FieldDocument : IDisposable
     /// <summary>Gets the keys of all fields in the document.</summary>
     public IEnumerable<string> Keys => _fields.Keys;
 
+    /// <summary>
+    /// No-op. The document's backing buffer is caller-owned, so there is nothing to release.
+    /// </summary>
     public void Dispose() { /* buffer is caller-owned */ }
 
     // --- Static targeted lookup (early exit, zero dictionary) ---

--- a/src/MarkdownTable.Formatting/FieldValue.cs
+++ b/src/MarkdownTable.Formatting/FieldValue.cs
@@ -40,6 +40,7 @@ public readonly struct FieldValue
     /// <summary>The number of items (1 for scalars).</summary>
     public int Count => _items?.Length ?? (_text is not null ? 1 : 0);
 
+    /// <summary>Returns <see cref="Text"/>, the scalar or joined rendering of the value.</summary>
     public override string ToString() => Text;
 
     /// <summary>Implicit conversion to string (returns Text).</summary>

--- a/src/MarkdownTable.Formatting/FullWidthMode.cs
+++ b/src/MarkdownTable.Formatting/FullWidthMode.cs
@@ -5,9 +5,15 @@ namespace MarkdownTable.Formatting;
 /// </summary>
 public class FullWidthMode : IFormatterMode, IFormatterModeInfo
 {
+    /// <inheritdoc cref="IFormatterModeInfo.Name"/>
     public static string Name => "full";
+
+    /// <inheritdoc cref="IFormatterModeInfo.Description"/>
     public static string Description => "Maximum width per column (no statistical optimization)";
 
+    /// <inheritdoc/>
     public TableFormatterOptions Options => new() { Mode = CalculationMode.FullWidth };
+
+    /// <inheritdoc/>
     public IReadOnlyList<IParameterDescriptor> GetParameters() => [];
 }

--- a/src/MarkdownTable.Formatting/LineReader.cs
+++ b/src/MarkdownTable.Formatting/LineReader.cs
@@ -98,6 +98,13 @@ public class LineReader
         }
     }
 
+    /// <summary>
+    /// Creates a line reader over <paramref name="stream"/>.
+    /// </summary>
+    /// <param name="stream">The stream to read UTF-8 bytes from.</param>
+    /// <param name="bufferSize">Size in bytes of the read buffer. Must be positive.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="bufferSize"/> is not positive.</exception>
     public LineReader(Stream stream, int bufferSize)
     {
         ArgumentNullException.ThrowIfNull(stream);

--- a/src/MarkdownTable.Formatting/MarkdownDocument.cs
+++ b/src/MarkdownTable.Formatting/MarkdownDocument.cs
@@ -63,6 +63,9 @@ public class DocumentSection
 /// </summary>
 public class DocumentTable
 {
+    /// <summary>The table's header cells, left to right.</summary>
     public string[] Headers { get; set; } = [];
+
+    /// <summary>The table's data rows, each holding one cell per header.</summary>
     public List<string[]> Rows { get; set; } = [];
 }

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>MarkdownTable.Formatting</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Statistical column-width optimization for markdown pipe tables</Description>
     <Version>0.3.3</Version>
   </PropertyGroup>

--- a/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
+++ b/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>MarkdownTable.Formatting</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Statistical column-width optimization for markdown pipe tables</Description>
-    <Version>0.3.3</Version>
+    <Version>0.3.4</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/MarkdownTable.Formatting/ParameterDescriptor.cs
+++ b/src/MarkdownTable.Formatting/ParameterDescriptor.cs
@@ -16,11 +16,19 @@ public class ParameterDescriptor<TValue>(
     Action<TValue> setter,
     TryParseDelegate<TValue> parser) : IParameterDescriptor
 {
+    /// <inheritdoc/>
     public string Name { get; } = name;
+
+    /// <inheritdoc/>
     public string Description { get; } = description;
+
+    /// <inheritdoc/>
     public string Type { get; } = type;
+
+    /// <inheritdoc/>
     public string DefaultValue { get; } = defaultValue?.ToString() ?? "";
 
+    /// <inheritdoc/>
     public bool TrySetValue(string value)
     {
         if (parser(value, out var parsedValue))

--- a/src/MarkdownTable.Formatting/PrettyMode.cs
+++ b/src/MarkdownTable.Formatting/PrettyMode.cs
@@ -5,9 +5,13 @@ namespace MarkdownTable.Formatting;
 /// </summary>
 public class PrettyMode : IFormatterMode, IFormatterModeInfo
 {
+    /// <inheritdoc cref="IFormatterModeInfo.Name"/>
     public static string Name => "pretty";
+
+    /// <inheritdoc cref="IFormatterModeInfo.Description"/>
     public static string Description => "Prioritizes visual alignment with relaxed statistical parameters";
 
+    /// <inheritdoc/>
     public TableFormatterOptions Options => new()
     {
         Percentile = 0.8,
@@ -15,5 +19,6 @@ public class PrettyMode : IFormatterMode, IFormatterModeInfo
         ShadowThreshold = 12
     };
 
+    /// <inheritdoc/>
     public IReadOnlyList<IParameterDescriptor> GetParameters() => [];
 }

--- a/src/MarkdownTable.Formatting/SmoothMode.cs
+++ b/src/MarkdownTable.Formatting/SmoothMode.cs
@@ -5,9 +5,15 @@ namespace MarkdownTable.Formatting;
 /// </summary>
 public class SmoothMode : IFormatterMode, IFormatterModeInfo
 {
+    /// <inheritdoc cref="IFormatterModeInfo.Name"/>
     public static string Name => "smooth";
+
+    /// <inheritdoc cref="IFormatterModeInfo.Description"/>
     public static string Description => "Auto-tuned statistical formatting for perfect trailing-edge alignment";
 
+    /// <inheritdoc/>
     public TableFormatterOptions Options => new() { AutoTune = true };
+
+    /// <inheritdoc/>
     public IReadOnlyList<IParameterDescriptor> GetParameters() => [];
 }

--- a/src/MarkdownTable.Query/MarkdownTable.Query.csproj
+++ b/src/MarkdownTable.Query/MarkdownTable.Query.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>MarkdownTable.Query</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Query engine for markdown pipe tables — select, filter, sort, slice</Description>
     <Version>0.2.1</Version>
   </PropertyGroup>

--- a/src/MarkdownTable.Query/Operations/ITableOperation.cs
+++ b/src/MarkdownTable.Query/Operations/ITableOperation.cs
@@ -5,5 +5,11 @@ namespace MarkdownTable.Query.Operations;
 /// </summary>
 public interface ITableOperation
 {
+    /// <summary>
+    /// Applies the operation to the given table.
+    /// </summary>
+    /// <param name="headers">The input table's header cells.</param>
+    /// <param name="rows">The input table's data rows.</param>
+    /// <returns>The operation's result, which may be a table or a scalar.</returns>
     QueryResult Execute(string[] headers, List<string[]> rows);
 }

--- a/src/MarkdownTable.Query/Operations/OrderByOperation.cs
+++ b/src/MarkdownTable.Query/Operations/OrderByOperation.cs
@@ -8,12 +8,16 @@ public class OrderByOperation : ITableOperation
     private readonly string _column;
     private readonly bool _descending;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="column">Name of the column to sort by. Matched case-insensitively.</param>
+    /// <param name="descending">Whether to sort in descending order.</param>
     public OrderByOperation(string column, bool descending)
     {
         _column = column;
         _descending = descending;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var colIdx = Array.FindIndex(headers, h => string.Equals(h, _column, StringComparison.OrdinalIgnoreCase));

--- a/src/MarkdownTable.Query/Operations/SelectOperation.cs
+++ b/src/MarkdownTable.Query/Operations/SelectOperation.cs
@@ -7,11 +7,14 @@ public class SelectOperation : ITableOperation
 {
     private readonly string[] _columns;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="columns">Names of the columns to project, in output order. Matched case-insensitively.</param>
     public SelectOperation(string[] columns)
     {
         _columns = columns;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var indices = ResolveColumnIndices(headers, _columns);

--- a/src/MarkdownTable.Query/Operations/TableOperations.cs
+++ b/src/MarkdownTable.Query/Operations/TableOperations.cs
@@ -7,11 +7,14 @@ public class TakeOperation : ITableOperation
 {
     private readonly int _count;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="count">Number of leading rows to keep.</param>
     public TakeOperation(int count)
     {
         _count = count;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var taken = rows.Take(_count).ToList();
@@ -26,11 +29,14 @@ public class SkipOperation : ITableOperation
 {
     private readonly int _count;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="count">Number of leading rows to discard.</param>
     public SkipOperation(int count)
     {
         _count = count;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var skipped = rows.Skip(_count).ToList();
@@ -43,6 +49,7 @@ public class SkipOperation : ITableOperation
 /// </summary>
 public class FirstOperation : ITableOperation
 {
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         if (rows.Count == 0)
@@ -57,6 +64,7 @@ public class FirstOperation : ITableOperation
 /// </summary>
 public class LastOperation : ITableOperation
 {
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         if (rows.Count == 0)
@@ -71,6 +79,7 @@ public class LastOperation : ITableOperation
 /// </summary>
 public class CountOperation : ITableOperation
 {
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         return QueryResult.Scalar(rows.Count.ToString());
@@ -82,6 +91,7 @@ public class CountOperation : ITableOperation
 /// </summary>
 public class DistinctOperation : ITableOperation
 {
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var seen = new HashSet<string>();
@@ -105,11 +115,14 @@ public class IndexOperation : ITableOperation
 {
     private readonly int _index;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="index">Row index to select. Negative values count back from the last row.</param>
     public IndexOperation(int index)
     {
         _index = index;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var idx = _index < 0 ? rows.Count + _index : _index;
@@ -128,12 +141,16 @@ public class SliceOperation : ITableOperation
     private readonly int? _start;
     private readonly int? _end;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="start">Inclusive start row index, or <see langword="null"/> for the first row. Negative values count back from the last row.</param>
+    /// <param name="end">Exclusive end row index, or <see langword="null"/> for past the last row. Negative values count back from the last row.</param>
     public SliceOperation(int? start, int? end)
     {
         _start = start;
         _end = end;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var start = _start ?? 0;
@@ -156,11 +173,14 @@ public class ColumnExtractOperation : ITableOperation
 {
     private readonly string _column;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="column">Name of the column to extract. Matched case-insensitively.</param>
     public ColumnExtractOperation(string column)
     {
         _column = column;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var colIdx = Array.FindIndex(headers, h => string.Equals(h, _column, StringComparison.OrdinalIgnoreCase));
@@ -185,12 +205,16 @@ public class CellExtractOperation : ITableOperation
     private readonly int _rowIndex;
     private readonly string _column;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="rowIndex">Row index to read. Negative values count back from the last row.</param>
+    /// <param name="column">Name of the column to read. Matched case-insensitively.</param>
     public CellExtractOperation(int rowIndex, string column)
     {
         _rowIndex = rowIndex;
         _column = column;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var rowIdx = _rowIndex < 0 ? rows.Count + _rowIndex : _rowIndex;

--- a/src/MarkdownTable.Query/Operations/WhereOperation.cs
+++ b/src/MarkdownTable.Query/Operations/WhereOperation.cs
@@ -9,6 +9,10 @@ public class WhereOperation : ITableOperation
     private readonly TokenKind _op;
     private readonly string _value;
 
+    /// <summary>Creates the operation.</summary>
+    /// <param name="column">Name of the column to test. Matched case-insensitively.</param>
+    /// <param name="op">The comparison operator, such as <see cref="TokenKind.Equal"/>.</param>
+    /// <param name="value">The value to compare each cell against.</param>
     public WhereOperation(string column, TokenKind op, string value)
     {
         _column = column;
@@ -16,6 +20,7 @@ public class WhereOperation : ITableOperation
         _value = value;
     }
 
+    /// <inheritdoc/>
     public QueryResult Execute(string[] headers, List<string[]> rows)
     {
         var colIdx = FindColumn(headers, _column);

--- a/src/MarkdownTable.Query/QueryExecutionException.cs
+++ b/src/MarkdownTable.Query/QueryExecutionException.cs
@@ -5,5 +5,7 @@ namespace MarkdownTable.Query;
 /// </summary>
 public class QueryExecutionException : Exception
 {
+    /// <summary>Creates the exception.</summary>
+    /// <param name="message">Description of the execution failure.</param>
     public QueryExecutionException(string message) : base(message) { }
 }

--- a/src/MarkdownTable.Query/QueryResult.cs
+++ b/src/MarkdownTable.Query/QueryResult.cs
@@ -7,7 +7,15 @@ namespace MarkdownTable.Query;
 /// </summary>
 public abstract class QueryResult
 {
+    /// <summary>Creates a <see cref="TableResult"/>.</summary>
+    /// <param name="headers">The result's header cells.</param>
+    /// <param name="rows">The result's data rows.</param>
+    /// <returns>A table result.</returns>
     public static QueryResult Table(string[] headers, List<string[]> rows) => new TableResult(headers, rows);
+
+    /// <summary>Creates a <see cref="ScalarResult"/>.</summary>
+    /// <param name="value">The scalar value.</param>
+    /// <returns>A scalar result.</returns>
     public static QueryResult Scalar(string value) => new ScalarResult(value);
 }
 
@@ -16,9 +24,15 @@ public abstract class QueryResult
 /// </summary>
 public sealed class TableResult : QueryResult
 {
+    /// <summary>The result's header cells, left to right.</summary>
     public string[] Headers { get; }
+
+    /// <summary>The result's data rows, each holding one cell per header.</summary>
     public List<string[]> Rows { get; }
 
+    /// <summary>Creates a table result.</summary>
+    /// <param name="headers">The result's header cells.</param>
+    /// <param name="rows">The result's data rows.</param>
     public TableResult(string[] headers, List<string[]> rows)
     {
         Headers = headers;
@@ -31,8 +45,11 @@ public sealed class TableResult : QueryResult
 /// </summary>
 public sealed class ScalarResult : QueryResult
 {
+    /// <summary>The scalar value.</summary>
     public string Value { get; }
 
+    /// <summary>Creates a scalar result.</summary>
+    /// <param name="value">The scalar value.</param>
     public ScalarResult(string value)
     {
         Value = value;
@@ -44,8 +61,11 @@ public sealed class ScalarResult : QueryResult
 /// </summary>
 public sealed class FieldsResult : QueryResult
 {
+    /// <summary>The fields, keyed by field name.</summary>
     public Dictionary<string, FieldValue> Fields { get; }
 
+    /// <summary>Creates a fields result.</summary>
+    /// <param name="fields">The fields, keyed by field name.</param>
     public FieldsResult(Dictionary<string, FieldValue> fields)
     {
         Fields = fields;

--- a/src/MarkdownTable.Query/Tokenizer.cs
+++ b/src/MarkdownTable.Query/Tokenizer.cs
@@ -6,42 +6,100 @@ namespace MarkdownTable.Query;
 public enum TokenKind
 {
     // Literals and identifiers
-    Dot,             // .
-    Identifier,      // bare word (Name, CPU, etc.)
-    QuotedString,    // "..."
-    Number,          // 42, 3.14
+
+    /// <summary>The <c>.</c> path separator.</summary>
+    Dot,
+
+    /// <summary>A bare word, such as a section or column name.</summary>
+    Identifier,
+
+    /// <summary>A double-quoted string literal.</summary>
+    QuotedString,
+
+    /// <summary>A numeric literal, integer or decimal.</summary>
+    Number,
 
     // Brackets and delimiters
-    OpenBracket,     // [
-    CloseBracket,    // ]
-    Comma,           // ,
-    Colon,           // :
-    Pipe,            // |
+
+    /// <summary>The <c>[</c> opening bracket.</summary>
+    OpenBracket,
+
+    /// <summary>The <c>]</c> closing bracket.</summary>
+    CloseBracket,
+
+    /// <summary>The <c>,</c> separator.</summary>
+    Comma,
+
+    /// <summary>The <c>:</c> slice separator.</summary>
+    Colon,
+
+    /// <summary>The <c>|</c> pipeline separator.</summary>
+    Pipe,
 
     // Comparison operators
-    Equal,           // ==
-    NotEqual,        // !=
-    GreaterThan,     // >
-    LessThan,        // <
-    GreaterOrEqual,  // >=
-    LessOrEqual,     // <=
+
+    /// <summary>The <c>==</c> equality operator.</summary>
+    Equal,
+
+    /// <summary>The <c>!=</c> inequality operator.</summary>
+    NotEqual,
+
+    /// <summary>The <c>&gt;</c> operator.</summary>
+    GreaterThan,
+
+    /// <summary>The <c>&lt;</c> operator.</summary>
+    LessThan,
+
+    /// <summary>The <c>&gt;=</c> operator.</summary>
+    GreaterOrEqual,
+
+    /// <summary>The <c>&lt;=</c> operator.</summary>
+    LessOrEqual,
 
     // Keywords
+
+    /// <summary>The <c>select</c> keyword.</summary>
     Select,
+
+    /// <summary>The <c>where</c> keyword.</summary>
     Where,
+
+    /// <summary>The <c>orderby</c> keyword.</summary>
     OrderBy,
+
+    /// <summary>The <c>take</c> keyword.</summary>
     Take,
+
+    /// <summary>The <c>skip</c> keyword.</summary>
     Skip,
+
+    /// <summary>The <c>first</c> keyword.</summary>
     First,
+
+    /// <summary>The <c>last</c> keyword.</summary>
     Last,
+
+    /// <summary>The <c>count</c> keyword.</summary>
     Count,
+
+    /// <summary>The <c>distinct</c> keyword.</summary>
     Distinct,
+
+    /// <summary>The <c>asc</c> keyword, for ascending sort order.</summary>
     Asc,
+
+    /// <summary>The <c>desc</c> keyword, for descending sort order.</summary>
     Desc,
+
+    /// <summary>The <c>and</c> keyword.</summary>
     And,
+
+    /// <summary>The <c>or</c> keyword.</summary>
     Or,
 
     // End
+
+    /// <summary>End of input.</summary>
     End
 }
 
@@ -72,6 +130,12 @@ public static class Tokenizer
         ["or"] = TokenKind.Or,
     };
 
+    /// <summary>
+    /// Splits <paramref name="query"/> into tokens, ending with <see cref="TokenKind.End"/>.
+    /// </summary>
+    /// <param name="query">The query string to tokenize.</param>
+    /// <returns>The tokens in source order.</returns>
+    /// <exception cref="QueryParseException">The query contains an unrecognized character or an unterminated string.</exception>
     public static List<Token> Tokenize(string query)
     {
         var tokens = new List<Token>();
@@ -253,8 +317,14 @@ public static class Tokenizer
 /// </summary>
 public class QueryParseException : Exception
 {
+    /// <summary>Zero-based character offset in the query where parsing failed.</summary>
     public int Position { get; }
 
+    /// <summary>
+    /// Creates the exception.
+    /// </summary>
+    /// <param name="message">Description of the parse failure.</param>
+    /// <param name="position">Zero-based character offset in the query where parsing failed.</param>
     public QueryParseException(string message, int position) : base(message)
     {
         Position = position;

--- a/src/Markout.Ansi.Spectre/Markout.Ansi.Spectre.csproj
+++ b/src/Markout.Ansi.Spectre/Markout.Ansi.Spectre.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Markout.Ansi.Spectre</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Spectre.Console renderer for Markout</Description>
   </PropertyGroup>
 

--- a/src/Markout.SourceGeneration/MarkoutSourceGenerator.cs
+++ b/src/Markout.SourceGeneration/MarkoutSourceGenerator.cs
@@ -13,6 +13,7 @@ namespace Markout.SourceGeneration;
 [Generator]
 public sealed class MarkoutSourceGenerator : IIncrementalGenerator
 {
+    /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Find all partial classes with [MarkoutContext] attributes

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Markout.Templates</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>0.3.0</Version>

--- a/src/Markout.Templates/Markout.Templates.csproj
+++ b/src/Markout.Templates/Markout.Templates.csproj
@@ -9,7 +9,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Template engine for Markout — compose human-authored documents with data-driven content</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\..\README.md"

--- a/src/Markout/Attributes/MarkoutSectionAttribute.cs
+++ b/src/Markout/Attributes/MarkoutSectionAttribute.cs
@@ -70,6 +70,7 @@ public sealed class MarkoutSectionAttribute : Attribute
     /// </summary>
     public bool IncludeSectionInStructuredRows { get; set; }
 
+    /// <summary>
     /// Gets or sets fallback text rendered as a paragraph when the section's collection is
     /// non-null but empty. The section heading is still emitted, followed by this text in place
     /// of the table or list. When the collection is null the section is omitted entirely, so the

--- a/src/Markout/Attributes/MarkoutValueFormatterAttribute.cs
+++ b/src/Markout/Attributes/MarkoutValueFormatterAttribute.cs
@@ -7,6 +7,17 @@ namespace Markout;
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 public sealed class MarkoutValueFormatterAttribute : Attribute
 {
+    /// <summary>
+    /// The formatter type, which must implement <see cref="IMarkoutValueFormatter{T}"/>
+    /// for the annotated property's type.
+    /// </summary>
     public Type FormatterType { get; }
+
+    /// <summary>
+    /// Initializes the attribute with the formatter applied to the annotated property.
+    /// </summary>
+    /// <param name="formatterType">
+    /// A type implementing <see cref="IMarkoutValueFormatter{T}"/> for the property's type.
+    /// </param>
     public MarkoutValueFormatterAttribute(Type formatterType) => FormatterType = formatterType;
 }

--- a/src/Markout/DocumentSchema.cs
+++ b/src/Markout/DocumentSchema.cs
@@ -30,11 +30,23 @@ public readonly record struct SchemaItem(string Name, string Kind)
 /// </summary>
 public sealed class SectionSchema
 {
+    /// <summary>
+    /// Creates a section schema from item names that all share the same kind.
+    /// </summary>
+    /// <param name="name">Display name of the section.</param>
+    /// <param name="itemKind">Kind applied to every item, such as <c>field</c> or <c>column</c>.</param>
+    /// <param name="itemNames">Display names of the items in the section.</param>
     public SectionSchema(string name, string itemKind, string[] itemNames)
         : this(name, itemKind, itemNames.Select(n => new SchemaItem(n, itemKind)).ToArray())
     {
     }
 
+    /// <summary>
+    /// Creates a section schema from items, overriding each item's kind with <paramref name="itemKind"/>.
+    /// </summary>
+    /// <param name="name">Display name of the section.</param>
+    /// <param name="itemKind">Kind applied to every item, such as <c>field</c> or <c>column</c>.</param>
+    /// <param name="items">The items in the section.</param>
     public SectionSchema(string name, string itemKind, SchemaItem[] items)
     {
         Name = name;
@@ -42,9 +54,16 @@ public sealed class SectionSchema
         Items = items.Select(i => i with { Kind = itemKind }).ToArray();
     }
 
+    /// <summary>Display name of the section.</summary>
     public string Name { get; }
+
+    /// <summary>Canonical machine-facing key for the section, derived from <see cref="Name"/>.</summary>
     public string Key => Formatting.FormatHelper.ToSnakeCase(Name);
+
+    /// <summary>Kind shared by every item in the section, such as <c>field</c> or <c>column</c>.</summary>
     public string ItemKind { get; }
+
+    /// <summary>The items the section exposes for discovery and projection.</summary>
     public SchemaItem[] Items { get; }
 }
 
@@ -53,7 +72,7 @@ public sealed class SectionSchema
 /// Used for discovery (-D), projection validation (--fields/--columns), and diagnostics.
 /// </summary>
 /// <remarks>
-/// <para>Built manually today via <see cref="Add"/>. Will be source-generated from
+/// <para>Built manually today via <see cref="Add(string, string, string[])"/>. Will be source-generated from
 /// Markout attributes in a future release.</para>
 /// <para>All name lookups are case-insensitive.</para>
 /// </remarks>
@@ -201,8 +220,15 @@ public sealed class DocumentSchema
 /// </summary>
 public sealed class ProjectionValidation
 {
+    /// <summary>A validation result with no resolved names, no unresolved names, and no suggestions.</summary>
     public static readonly ProjectionValidation Empty = new([], [], new Dictionary<string, string[]>());
 
+    /// <summary>
+    /// Creates a validation result.
+    /// </summary>
+    /// <param name="resolved">Names that matched the schema.</param>
+    /// <param name="unresolved">Names that did not match any schema item.</param>
+    /// <param name="suggestions">Prefix-based suggestions keyed by unresolved name.</param>
     public ProjectionValidation(string[] resolved, string[] unresolved,
         IReadOnlyDictionary<string, string[]> suggestions)
     {
@@ -220,5 +246,6 @@ public sealed class ProjectionValidation
     /// <summary>Prefix-based suggestions for unresolved names, keyed by the unresolved name.</summary>
     public IReadOnlyDictionary<string, string[]> Suggestions { get; }
 
+    /// <summary>Whether every requested name matched a schema item.</summary>
     public bool IsValid => Unresolved.Length == 0;
 }

--- a/src/Markout/IMarkoutPropertyFormatter.cs
+++ b/src/Markout/IMarkoutPropertyFormatter.cs
@@ -8,5 +8,8 @@ namespace Markout;
 /// <typeparam name="T">The type of the property value to format.</typeparam>
 public interface IMarkoutPropertyFormatter<in T> where T : class
 {
+    /// <summary>Formats <paramref name="value"/> as the rendered table cell.</summary>
+    /// <param name="value">The property value to format.</param>
+    /// <returns>The string to render.</returns>
     string Format(T value);
 }

--- a/src/Markout/IMarkoutValueFormatter.cs
+++ b/src/Markout/IMarkoutValueFormatter.cs
@@ -5,7 +5,11 @@ namespace Markout;
 /// Implement this interface and reference it from [MarkoutValueFormatter] to
 /// customize how a property is displayed.
 /// </summary>
+/// <typeparam name="T">The type of the property value to format.</typeparam>
 public interface IMarkoutValueFormatter<in T>
 {
+    /// <summary>Formats <paramref name="value"/> as the rendered field value.</summary>
+    /// <param name="value">The property value to format.</param>
+    /// <returns>The string to render.</returns>
     string Format(T value);
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -9,8 +9,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.30.0</Version>
-    <PackageReleaseNotes>The Markout consumer skill shelf now ships inside the package. Five skills — the base `markout` pattern plus `conditional-composition`, `output-formats`, `built-in-shapes`, and `composite-cells-cards` — are packed at `skills/&lt;name&gt;/SKILL.md` and restore to `~/.nuget/packages/markout/&lt;version&gt;/skills/`, where a package-skill installer can copy them into a consuming repo's `.github/skills/`. This pins the grounding to the package version that produced it, so an agent using Markout gets the current idioms without decompiling the assembly or searching the web. No API or behavior changes.</PackageReleaseNotes>
+    <Version>0.31.0</Version>
+    <PackageReleaseNotes>The package now ships XML documentation. `dotnet pack` places `lib/net10.0/Markout.xml` beside the assembly, so IntelliSense shows real summaries and an agent inspecting the restored package can read the API without decompiling it. Enabling this required documenting 110 previously undocumented public members across Markout, MarkdownTable.Formatting and MarkdownTable.Query, because the repo builds with warnings as errors. It also made the compiler start parsing doc comments it had been ignoring, which exposed five latent bugs that were shipping as broken documentation: two comments missing their opening summary tag, a cref to a member that does not exist, two crefs pointing across an inverted project dependency, an ambiguous overload cref, and a paramref naming a tuple element. A stale claim that unsupported shapes emit a runtime diagnostic silenced by MarkoutWriterOptions.SuppressedShapes was corrected: unsupported shapes write nothing and return false, and SuppressedShapes is reserved. No API or behavior changes.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Markout</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>0.30.0</Version>

--- a/src/Markout/MarkoutFieldOrderer.cs
+++ b/src/Markout/MarkoutFieldOrderer.cs
@@ -5,6 +5,15 @@ namespace Markout;
 /// </summary>
 public static class MarkoutFieldOrderer
 {
+    /// <summary>
+    /// Returns the fields reordered according to <paramref name="order"/>.
+    /// </summary>
+    /// <param name="fields">The fields in input order.</param>
+    /// <param name="order">The ordering policy to apply.</param>
+    /// <returns>
+    /// A new array holding the fields in the requested order. Input order is
+    /// preserved when <paramref name="order"/> is <see cref="MarkoutFieldOrder.Input"/>.
+    /// </returns>
     public static MarkoutField[] Apply(ReadOnlySpan<MarkoutField> fields, MarkoutFieldOrder order)
     {
         var ordered = fields.ToArray();

--- a/src/Markout/MarkoutSerializerContext.cs
+++ b/src/Markout/MarkoutSerializerContext.cs
@@ -72,7 +72,7 @@ public abstract class MarkoutSerializerContext
 
     /// <summary>
     /// Gets all type infos registered in this context.
-    /// Used by <see cref="Templates.MarkoutTemplate.BindContext"/> for automatic registration.
+    /// Used by <c>Markout.Templates.MarkoutTemplate.BindContext</c> for automatic registration.
     /// </summary>
     /// <returns>An enumerable of all registered type infos.</returns>
     public abstract IEnumerable<IMarkoutTypeInfo> GetRegisteredTypes();

--- a/src/Markout/MarkoutShape.cs
+++ b/src/Markout/MarkoutShape.cs
@@ -1,9 +1,10 @@
 namespace Markout;
 
 /// <summary>
-/// Flags indicating which rendering shapes a writer supports.
-/// Unsupported shapes produce a runtime diagnostic and are skipped; set
-/// <see cref="MarkoutWriterOptions.SuppressedShapes"/> to silence that diagnostic.
+/// Flags identifying the rendering shapes a writer may support.
+/// When the formatter behind a <see cref="MarkoutWriter"/> does not implement the
+/// capability interface for a shape, the corresponding <c>Write</c> method writes
+/// nothing and returns <c>false</c>; no diagnostic is emitted.
 /// </summary>
 [Flags]
 public enum MarkoutShape

--- a/src/Markout/MarkoutShape.cs
+++ b/src/Markout/MarkoutShape.cs
@@ -2,8 +2,8 @@ namespace Markout;
 
 /// <summary>
 /// Flags indicating which rendering shapes a writer supports.
-/// Writers declare their capabilities via <see cref="MarkoutWriter.SupportedShapes"/>.
-/// Unsupported shapes produce a runtime diagnostic and are skipped.
+/// Unsupported shapes produce a runtime diagnostic and are skipped; set
+/// <see cref="MarkoutWriterOptions.SuppressedShapes"/> to silence that diagnostic.
 /// </summary>
 [Flags]
 public enum MarkoutShape

--- a/src/Markout/MarkoutTypeInfo.cs
+++ b/src/Markout/MarkoutTypeInfo.cs
@@ -12,7 +12,7 @@ public interface IMarkoutTypeInfo
 
     /// <summary>
     /// Gets the template binding name for this type (snake_case).
-    /// Used by <see cref="Templates.MarkoutTemplate.BindContext"/> for automatic registration.
+    /// Used by <c>Markout.Templates.MarkoutTemplate.BindContext</c> for automatic registration.
     /// </summary>
     string BindingName { get; }
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -881,6 +881,8 @@ public class MarkoutWriter
         return WriteTable(headers, headerNames, outRows);
     }
 
+    /// <summary>
+    /// Writes a gated-metric table from <see cref="MetricChange{T}"/> rows: document formatters
     /// render fixed <c>Metric | Change | Target | Status</c> columns; decomposing formatters
     /// (TSV/JSONL) emit flat typed fields (<c>before</c>, <c>after</c>, optional <c>target</c>/
     /// <c>target_label</c>, <c>status</c>). Absent targets render <c>-</c> and are omitted from
@@ -1058,7 +1060,7 @@ public class MarkoutWriter
     }
 
     /// <summary>
-    /// Resolves the row's polarity for dense glyph rendering: the display <paramref name="Word"/>
+    /// Resolves the row's polarity for dense glyph rendering: the display <c>Word</c>
     /// (caller <see cref="MetricChange{T}.StatusLabel"/>, else the polarity slug), the underlying
     /// <see cref="GateStatus"/> enum when the polarity is derived or caller-set (so a glyph can be
     /// chosen), and whether the word is a caller-supplied custom label (which stays a word, not a glyph).

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -223,10 +223,13 @@ public class MarkoutWriterOptions
     }
 
     /// <summary>
-    /// Shapes to suppress warnings for when unsupported by the writer.
-    /// Use when the caller knows the writer doesn't support certain shapes
-    /// and wants to silence the diagnostic warnings globally.
+    /// Records shapes the caller knows the writer does not support.
     /// </summary>
+    /// <remarks>
+    /// Reserved: the value is stored and copied but is not read by any current code path,
+    /// because unsupported shapes are already silent — the corresponding <c>Write</c> method
+    /// writes nothing and returns <c>false</c> without emitting a diagnostic.
+    /// </remarks>
     public MarkoutShape SuppressedShapes
     {
         get => _suppressedShapes;

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -37,6 +37,10 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
     };
     private readonly bool _showHeader;
 
+    /// <summary>
+    /// Creates a table formatter.
+    /// </summary>
+    /// <param name="showHeader">Whether to emit the header row above the data rows.</param>
     public TableFormatter(bool showHeader = true)
     {
         _showHeader = showHeader;


### PR DESCRIPTION
## What

`dotnet pack` now ships `lib/<tfm>/<Assembly>.xml` alongside the DLL for all five shipping libraries. Enabling `GenerateDocumentationFile` is all the SDK needs — no pack-specific configuration.

| Package | XML shipped |
|---|---|
| `Markout` | 263 KB |
| `MarkdownTable.Formatting` | 43 KB |
| `MarkdownTable.Query` | 21 KB |
| `Markout.Templates` | 17 KB |
| `Markout.Ansi.Spectre` | 3 KB |

Tests, samples, tools and `Markout.Demo` are not packed and stay off — they carry ~4,000 undocumented members between them.

## Why it wasn't just a one-line change

`TreatWarningsAsErrors` is set repo-wide in `Directory.Build.props`, so switching the property on turns every undocumented public member into a build **error**. 110 needed filling:

| Project | Gaps |
|---|---|
| `MarkdownTable.Query` | 65 |
| `MarkdownTable.Formatting` | 29 |
| `Markout` | 15 |
| `Markout.SourceGeneration` | 1 |

The bulk is `TokenKind`, where trailing `// ==` style comments became real doc comments. Interface implementations use `<inheritdoc/>` rather than restating what the interface already says.

## The interesting part

Generating the doc file makes the compiler start *parsing* doc comments it had previously ignored. That surfaced five latent bugs that were silently shipping as broken documentation:

| Bug | Where |
|---|---|
| Comment missing its opening `<summary>` tag | `MarkoutSectionAttribute.EmptyText`, `MarkoutWriter.WriteMetricChangeTable` |
| `cref` to a member that does not exist | `MarkoutShape` referenced `MarkoutWriter.SupportedShapes`; the real member is `MarkoutWriterOptions.SuppressedShapes` |
| `cref` across an inverted dependency | `Markout` referenced `Markout.Templates.MarkoutTemplate.BindContext` twice, but Templates depends on Markout, not the reverse |
| Ambiguous `cref` to an overload | `DocumentSchema` remarks pointed at `Add` |
| `paramref` naming a tuple element | `MarkoutWriter.ResolveStatus` |

These are exactly the errors that stay invisible while the doc file is off, which is the argument for keeping it on: the setting is a latch, not a formality.

## Verification

- Solution builds clean under warnings-as-errors.
- 1,195 tests pass (837 Markout, 236 MarkdownTable, 122 Templates).
- `unzip -l` confirms the `.xml` is present in `lib/net10.0/` in all five nupkgs.

`AGENTS.md` gains an **XML documentation** section so the constraint — new public API needs a doc comment, and crefs must resolve from the referencing project — is discoverable rather than something a contributor rediscovers via a confusing build failure.