### PR TITLE
Name every shipped skill for the package (0.33.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,15 @@ installation stays an explicit, visible act.
 
 Consequences for maintainers:
 
+- **Every skill is named for the package.** The base skill is `markout`; every workflow skill is
+  `markout-<domain>`. The directory name and the frontmatter `name` are the same string, and that
+  string is the name used everywhere the skill is referred to. Skill names are a **flat, global
+  namespace** in a consuming repo — this shelf installs next to every other package's, with no
+  coordinating authority — so a bare `output-formats` is a name any other maintainer could also
+  ship. Deriving from the package id inherits uniqueness from the NuGet id namespace instead of
+  negotiating it. `dotnet pack` **fails** on a skill directory that is neither `markout` nor
+  `markout-*`, or whose frontmatter `name` disagrees with its directory. See
+  [authoring-principles.md](https://github.com/richlander/dotnet-package-skills/blob/main/docs/authoring-principles.md#naming-derive-every-skill-name-from-the-package-id).
 - The `version:` stamp in every `skills/*/SKILL.md` and in `skills/plugin.json` tracks the
   **Markout package version**. `dotnet pack` **fails** if they disagree with `<Version>` in
   `Markout.csproj`, because the shipped shelf must not misstate which release it describes.

--- a/grounding/markout/eval.md
+++ b/grounding/markout/eval.md
@@ -198,7 +198,7 @@ and field layout. Drive output through the serializer. Build and run to confirm.
 
 ## CT07: conditional section via ShowWhenProperty
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT07/Report.csproj](fixtures/ct/CT07/Report.csproj), [CT07/Program.cs](fixtures/ct/CT07/Program.cs)
 
@@ -229,7 +229,7 @@ imperative string-building. Build and run to confirm.
 
 ## CT08: render a section subset with IncludeSections
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT08/Report.csproj](fixtures/ct/CT08/Report.csproj), [CT08/Program.cs](fixtures/ct/CT08/Program.cs)
 
@@ -260,7 +260,7 @@ Build and run to confirm.
 
 ## CT09: machine-readable TSV output
 
-- Target skill: output-formats
+- Target skill: markout-output-formats
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT09/Report.csproj](fixtures/ct/CT09/Report.csproj), [CT09/Program.cs](fixtures/ct/CT09/Program.cs)
 
@@ -289,7 +289,7 @@ Do not hand-build the TSV strings. Build and run to confirm.
 
 ## CT10: metric bars and a breakdown
 
-- Target skill: built-in-shapes
+- Target skill: markout-built-in-shapes
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT10/Report.csproj](fixtures/ct/CT10/Report.csproj), [CT10/Program.cs](fixtures/ct/CT10/Program.cs)
 
@@ -319,7 +319,7 @@ and the breakdown rather than hand-built rows. Build and run to confirm.
 
 ## CT11: before -&gt; after change cells
 
-- Target skill: composite-cells-cards
+- Target skill: markout-composite-cells-cards
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT11/Report.csproj](fixtures/ct/CT11/Report.csproj), [CT11/Program.cs](fixtures/ct/CT11/Program.cs)
 
@@ -349,7 +349,7 @@ change cells so the absolute delta is appended. Do not hand-format the arrows/de
 
 ## CT12: conditional table column via IgnoreColumnWhen
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT12/Report.csproj](fixtures/ct/CT12/Report.csproj), [CT12/Program.cs](fixtures/ct/CT12/Program.cs)
 
@@ -381,7 +381,7 @@ or imperatively build the table. Build and run to confirm.
 
 ## CT13: verbosity-gated detail sections (quiet vs verbose)
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT13/Report.csproj](fixtures/ct/CT13/Report.csproj), [CT13/Program.cs](fixtures/ct/CT13/Program.cs)
 
@@ -412,7 +412,7 @@ hand-write the omitted sections). Drive output through the serializer. Build and
 
 ## CT14: JSONL with typed numeric values
 
-- Target skill: output-formats
+- Target skill: markout-output-formats
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT14/Report.csproj](fixtures/ct/CT14/Report.csproj), [CT14/Program.cs](fixtures/ct/CT14/Program.cs)
 
@@ -442,7 +442,7 @@ Build and run to confirm.
 
 ## CT15: dependency tree with badges
 
-- Target skill: built-in-shapes
+- Target skill: markout-built-in-shapes
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT15/Report.csproj](fixtures/ct/CT15/Report.csproj), [CT15/Program.cs](fixtures/ct/CT15/Program.cs)
 
@@ -472,7 +472,7 @@ hand-built indentation. Build and run to confirm.
 
 ## CT16: gated metric-change card with goals
 
-- Target skill: composite-cells-cards
+- Target skill: markout-composite-cells-cards
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT16/Report.csproj](fixtures/ct/CT16/Report.csproj), [CT16/Program.cs](fixtures/ct/CT16/Program.cs)
 
@@ -504,7 +504,7 @@ than computing status by hand. Build and run to confirm.
 
 ## CT17: same-name polymorphic sections (one heading, two shapes)
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT17/Report.csproj](fixtures/ct/CT17/Report.csproj), [CT17/Program.cs](fixtures/ct/CT17/Program.cs)
 
@@ -535,7 +535,7 @@ serializer; do not hand-write the heading or branch with imperative string-build
 
 ## CT18: one model rendered at three verbosity levels
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT18/Report.csproj](fixtures/ct/CT18/Report.csproj), [CT18/Program.cs](fixtures/ct/CT18/Program.cs)
 
@@ -566,7 +566,7 @@ output through the serializer. Build and run to confirm.
 
 ## CT19: central multi-format dispatch with row cap
 
-- Target skill: output-formats
+- Target skill: markout-output-formats
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT19/Report.csproj](fixtures/ct/CT19/Report.csproj), [CT19/Program.cs](fixtures/ct/CT19/Program.cs)
 
@@ -598,7 +598,7 @@ run to confirm.
 
 ## CT20: advisory with a callout, code block, and definitions
 
-- Target skill: built-in-shapes
+- Target skill: markout-built-in-shapes
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT20/Report.csproj](fixtures/ct/CT20/Report.csproj), [CT20/Program.cs](fixtures/ct/CT20/Program.cs)
 
@@ -629,7 +629,7 @@ confirm.
 
 ## CT21: multi-source comparison matrix with verdicts
 
-- Target skill: composite-cells-cards
+- Target skill: markout-composite-cells-cards
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT21/Report.csproj](fixtures/ct/CT21/Report.csproj), [CT21/Program.cs](fixtures/ct/CT21/Program.cs)
 
@@ -660,7 +660,7 @@ hand-built table. Build and run to confirm.
 
 ## CT22: full composed inspection report
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT22/Report.csproj](fixtures/ct/CT22/Report.csproj), [CT22/Program.cs](fixtures/ct/CT22/Program.cs)
 
@@ -697,7 +697,7 @@ hand-write headings or tables. Build and run to confirm.
 
 ## CT23: dense composite cell that decomposes into columns
 
-- Target skill: output-formats
+- Target skill: markout-output-formats
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT23/Report.csproj](fixtures/ct/CT23/Report.csproj), [CT23/Program.cs](fixtures/ct/CT23/Program.cs)
 
@@ -728,7 +728,7 @@ percent. Do not hand-build any format. Build and run to confirm.
 
 ## CT24: section-targeted verbosity views from one model (-D / -S)
 
-- Target skill: conditional-composition
+- Target skill: markout-conditional-composition
 - Tool restriction: No web search / fetch allowed.
 - Fixtures: [CT24/Report.csproj](fixtures/ct/CT24/Report.csproj), [CT24/Program.cs](fixtures/ct/CT24/Program.cs)
 

--- a/grounding/markout/eval.yaml
+++ b/grounding/markout/eval.yaml
@@ -213,7 +213,7 @@ scenarios:
     timeout: 900
 
   - name: "CT07: conditional section via ShowWhenProperty"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds two plain PackageInfo
       objects — one WITH deprecations, one WITHOUT. Using the serializer, print a Markdown report for each with
@@ -244,7 +244,7 @@ scenarios:
     timeout: 900
 
   - name: "CT08: render a section subset with IncludeSections"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain ServiceStatus
       with scalar fields and two list sections (Incidents, Metrics). Using the serializer, print the SAME model
@@ -275,7 +275,7 @@ scenarios:
     timeout: 900
 
   - name: "CT09: machine-readable TSV output"
-    expected_skill: output-formats   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-output-formats   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain Roster with a
       list of members. Using the serializer, print the members as tab-separated values (TSV) — one header row of
@@ -304,7 +304,7 @@ scenarios:
     timeout: 900
 
   - name: "CT10: metric bars and a breakdown"
-    expected_skill: built-in-shapes   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-built-in-shapes   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain PerfReport
       with a list of timing measurements (label + seconds) and a coverage breakdown (covered vs
@@ -334,7 +334,7 @@ scenarios:
     timeout: 900
 
   - name: "CT11: before -> after change cells"
-    expected_skill: composite-cells-cards   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-composite-cells-cards   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain
       RegressionReport with two before -> after change values (Change cells) for Errors and
@@ -364,7 +364,7 @@ scenarios:
     timeout: 900
 
   - name: "CT12: conditional table column via IgnoreColumnWhen"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds two plain PackageDeps
       objects — one whose dependencies are ALL required, and one with a MIX of required and optional.
@@ -396,7 +396,7 @@ scenarios:
     timeout: 900
 
   - name: "CT13: verbosity-gated detail sections (quiet vs verbose)"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain PackageReport
       (scalars plus Dependencies and Tags collections). Using the serializer, print BOTH a quiet and a verbose
@@ -427,7 +427,7 @@ scenarios:
     timeout: 900
 
   - name: "CT14: JSONL with typed numeric values"
-    expected_skill: output-formats   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-output-formats   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain BenchReport
       with a list of benchmark rows (a name plus numeric OpsPerSec and AllocatedKb). Using the serializer, print
@@ -457,7 +457,7 @@ scenarios:
     timeout: 900
 
   - name: "CT15: dependency tree with badges"
-    expected_skill: built-in-shapes   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-built-in-shapes   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain DependencyTree
       whose Root is a TreeNode with nested children (some carrying a badge marker). Using the serializer,
@@ -487,7 +487,7 @@ scenarios:
     timeout: 900
 
   - name: "CT16: gated metric-change card with goals"
-    expected_skill: composite-cells-cards   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-composite-cells-cards   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain QualityGate
       with a list of MetricChange rows (Failures 7 -> 0, Coverage 78 -> 85). Using the serializer, render a
@@ -519,7 +519,7 @@ scenarios:
     timeout: 900
 
   - name: "CT17: same-name polymorphic sections (one heading, two shapes)"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds two plain PackageInfo
       objects — one that exposes APIs, one that is types-only. Using the serializer, print a Markdown report for
@@ -550,7 +550,7 @@ scenarios:
     timeout: 900
 
   - name: "CT18: one model rendered at three verbosity levels"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain PackageReport
       with scalar fields and two list sections (Dependencies, Diagnostics). Using the serializer, print the SAME
@@ -581,7 +581,7 @@ scenarios:
     timeout: 900
 
   - name: "CT19: central multi-format dispatch with row cap"
-    expected_skill: output-formats   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-output-formats   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain SearchReport
       with a Query and a list of hits. Using the serializer, write ONE dispatch that renders the SAME model in a
@@ -613,7 +613,7 @@ scenarios:
     timeout: 1200
 
   - name: "CT20: advisory with a callout, code block, and definitions"
-    expected_skill: built-in-shapes   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-built-in-shapes   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain Advisory with
       a warning Callout, a Repro CodeSection (a C# snippet), and a list of Description terms. Using
@@ -644,7 +644,7 @@ scenarios:
     timeout: 900
 
   - name: "CT21: multi-source comparison matrix with verdicts"
-    expected_skill: composite-cells-cards   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-composite-cells-cards   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain ModelComparison
       whose rows compare a "baseline" and a "grounded" source across several metrics, using composite cells (Fraction, Share, Percent, Segments) and a Verdict. Using the serializer, render a "##
@@ -675,7 +675,7 @@ scenarios:
     timeout: 900
 
   - name: "CT22: full composed inspection report"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain PackageInfo.
       Using the serializer, print ONE Markdown report composed of these sections in order:
@@ -712,7 +712,7 @@ scenarios:
     timeout: 1200
 
   - name: "CT23: dense composite cell that decomposes into columns"
-    expected_skill: output-formats   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-output-formats   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain BenchReport
       whose rows each carry a before -> after change value (a Change cell). Using the serializer, print
@@ -743,7 +743,7 @@ scenarios:
     timeout: 1200
 
   - name: "CT24: section-targeted verbosity views from one model (-D / -S)"
-    expected_skill: conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
+    expected_skill: markout-conditional-composition   # methodology prior: the ONE target skill (grounding/eval)
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj). Program.cs holds one plain PackageReport
       with scalar fields and two detail sections (Dependencies, Diagnostics), where Diagnostics is the

--- a/grounding/markout/meta.yaml
+++ b/grounding/markout/meta.yaml
@@ -6,5 +6,5 @@ name: markout
 package: Markout
 description: >-
   Markout workflow grounding: a compact base skill (title + scalar fields + simple
-  sections + formatter choice) plus four domain workflow skills (conditional-composition,
-  output-formats, built-in-shapes, composite-cells-cards).
+  sections + formatter choice) plus four domain workflow skills (markout-conditional-composition,
+  markout-output-formats, markout-built-in-shapes, markout-composite-cells-cards).

--- a/skills/markout-built-in-shapes/SKILL.md
+++ b/skills/markout-built-in-shapes/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: built-in-shapes
-version: 0.32.0
+name: markout-built-in-shapes
+version: 0.33.0
 description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn

--- a/skills/markout-composite-cells-cards/SKILL.md
+++ b/skills/markout-composite-cells-cards/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: composite-cells-cards
-version: 0.32.0
+name: markout-composite-cells-cards
+version: 0.33.0
 description: >-
   Use when a single value must render dense in Markdown but decompose into typed columns in
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas

--- a/skills/markout-conditional-composition/SKILL.md
+++ b/skills/markout-conditional-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: conditional-composition
-version: 0.32.0
+name: markout-conditional-composition
+version: 0.33.0
 description: >-
   Use when a Markout report must adapt to its data — show or hide whole sections, drop table
   columns that are empty/uniform, filter output to a chosen set of sections, or render one

--- a/skills/markout-output-formats/SKILL.md
+++ b/skills/markout-output-formats/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: output-formats
-version: 0.32.0
+name: markout-output-formats
+version: 0.33.0
 description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout
-version: 0.32.0
+version: 0.33.0
 description: >-
   Use when generating Markdown or other structured output (plain text, ANSI, pretty tables,
   TSV/JSONL) from C# objects instead of hand-built strings — CLIs, tools, reports, agent

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
-  "version": "0.32.0",
-  "description": "Markout library skills: one base skill, markout; four workflow-specific skills, conditional-composition, output-formats, built-in-shapes, composite-cells-cards. Each workflow-specific skill carries the required serializer-context setup so it works on its own; the base skill is the fuller treatment of the library.",
+  "version": "0.33.0",
+  "description": "Markout library skills: one base skill, markout; four workflow-specific skills, markout-conditional-composition, markout-output-formats, markout-built-in-shapes, markout-composite-cells-cards. Each workflow-specific skill carries the required serializer-context setup so it works on its own; the base skill is the fuller treatment of the library.",
   "skills": ["."]
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -9,8 +9,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.32.0</Version>
-    <PackageReleaseNotes>The shipped skill shelf is now five standalone skills. Each workflow skill (conditional-composition, output-formats, built-in-shapes, composite-cells-cards) carries the required MarkoutSerializerContext setup for its own examples, so it produces code that compiles when read on its own; previously that pattern appeared only in the base markout skill and Markout has no reflection fallback. The base skill drops its routing table and instead states its scope, naming the topics the other skills cover without naming the skills, so nothing dangles when an installer writes a subset. Measured on a 26-scenario benchmark at 130 runs per variant: this shelf passes 87.7% against 84.6% for the previous routing shelf (not a significant difference) while 27.7% of runs complete using a workflow skill with no base skill at all, which the routing shelf never did once. An intermediate version that removed the routing table but let the base skill claim to be complete regressed to 78.5%, because agents on a domain task read that claim and stopped looking. Also fixes a built-in-shapes example that never compiled: CodeSection is a readonly record struct, so a CodeSection? property makes the generator emit member access on Nullable&lt;T&gt;. No API or behavior changes.</PackageReleaseNotes>
+    <Version>0.33.0</Version>
+    <PackageReleaseNotes>The four workflow skills on the shipped shelf are now named for the package that ships them: markout-conditional-composition, markout-output-formats, markout-built-in-shapes, and markout-composite-cells-cards. The base skill stays markout. Skill names occupy a flat, global namespace once installed — a consumer's .github/skills/ holds every package's shelf side by side, with no coordinating authority — so a bare name like output-formats is one any other maintainer could also ship. Deriving each name from the package id inherits uniqueness from the NuGet id namespace instead of negotiating it. Pack now fails on a skill directory that is neither markout nor markout-&lt;domain&gt;, or whose frontmatter name disagrees with its directory. Consumers who installed the previous shelf should delete the four old directories from .github/skills/ before installing this one; the skills carry no cross-references, so nothing else moves. No API or behavior changes.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,15 +53,28 @@
     consumer restored. They drifted before (0.22.0 while the package shipped 0.29.0, across
     seven releases) because keeping them in sync was a rule someone had to remember. Fail
     the pack instead.
+
+    Skill names are enforced here for the same reason. Once installed they sit in a consumer's
+    .github/skills/ next to every other package's shelf — one flat namespace, no coordinating
+    authority — so each name is derived from the package id: `markout` for the base skill,
+    `markout-<domain>` for the rest. The directory name and the frontmatter `name` are the same
+    string, because that name is how the skill is addressed everywhere.
   -->
   <Target Name="ValidateShelfVersionStamps" BeforeTargets="GenerateNuspec">
     <ItemGroup>
       <_ShelfSkill Include="$(MSBuildThisFileDirectory)..\..\skills\**\SKILL.md" />
+      <_ShelfSkill>
+        <SkillName>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(FullPath)'))))</SkillName>
+      </_ShelfSkill>
     </ItemGroup>
     <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Contains('%0Aversion: $(Version)%0A'))"
-           Text="skills/%(_ShelfSkill.RecursiveDir)SKILL.md does not carry 'version: $(Version)'. The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
+           Text="skills/%(_ShelfSkill.SkillName)/SKILL.md does not carry 'version: $(Version)'. The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
     <Error Condition="!$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\skills\plugin.json').Contains('&quot;version&quot;: &quot;$(Version)&quot;'))"
            Text="skills/plugin.json does not carry version $(Version). The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
+    <Error Condition="'%(_ShelfSkill.SkillName)' != 'markout' AND !$([System.String]::new('%(_ShelfSkill.SkillName)').StartsWith('markout-'))"
+           Text="skills/%(_ShelfSkill.SkillName)/ is not named for the package. Skill names share one flat namespace in a consuming repo, so the base skill must be 'markout' and every workflow skill 'markout-&lt;domain&gt;'." />
+    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Contains('%0Aname: %(_ShelfSkill.SkillName)%0A'))"
+           Text="skills/%(_ShelfSkill.SkillName)/SKILL.md declares a frontmatter 'name' that is not its directory name. A skill is addressed by that name, so the two must be the same string." />
   </Target>
 
 </Project>


### PR DESCRIPTION
The four workflow skills on the shipped shelf are renamed for the package that ships them. The base skill is unchanged.

| Before | After |
| --- | --- |
| `markout` | `markout` |
| `conditional-composition` | `markout-conditional-composition` |
| `output-formats` | `markout-output-formats` |
| `built-in-shapes` | `markout-built-in-shapes` |
| `composite-cells-cards` | `markout-composite-cells-cards` |

## Why

Skill names are a flat, global namespace, and the shelf is not the boundary that matters. These directories land in a consumer's `.github/skills/` next to every other package's shelf, and nothing coordinates between two maintainers who have never met. `output-formats` is a name any of them could plausibly also ship — and generic enough that it is a matter of time.

Deriving each name from the NuGet id inherits uniqueness from a namespace that already has a real owner, rather than negotiating it after the fact. It is the same trade the ecosystem already makes in package ids themselves. The cost is a longer directory name; the longest here is `markout-composite-cells-cards`, 29 characters against the 64-character cap.

This adopts the ratified rule in [dotnet-package-skills authoring-principles](https://github.com/richlander/dotnet-package-skills/blob/main/docs/authoring-principles.md#naming-derive-every-skill-name-from-the-package-id), and is Markout's half of the approach proposed on [dotnet-package-skills#26](https://github.com/richlander/dotnet-package-skills/issues/26): authors opt into the prefix, the installer never renames, and a residual collision is a refuse-and-report error.

## One name, used everywhere

The name is a single string: the directory and the frontmatter `name` carry it, and it is what the skill is addressed by anywhere it is referred to. `dotnet pack` now fails on:

- a skill directory that is neither `markout` nor `markout-<domain>`
- a frontmatter `name` that disagrees with its directory name

Both were verified to fire. This sits alongside the existing version-stamp guards, for the same reason those exist: the shipped shelf should not depend on a maintainer remembering a rule.

## Migration

The shelf carries no cross-references between skills — those were dropped in #171, which gave each workflow skill its own serializer-context setup — so the rename leaves nothing dangling. A consumer who installed the previous shelf deletes the four old directories from `.github/skills/` before installing this one. No API or behavior changes.

## Eval

`grounding/markout/eval.yaml` and its rendered `eval.md` get the renamed `expected_skill` labels, so the harness keeps matching the shipped shelf on future runs. `results.md` is deliberately untouched: it records what past runs actually measured, under the names they ran against.

## Verification

- `dotnet pack` succeeds; the nupkg carries `skills/markout/`, `skills/markout-built-in-shapes/`, `skills/markout-composite-cells-cards/`, `skills/markout-conditional-composition/`, `skills/markout-output-formats/`, and `skills/plugin.json`
- both new guards confirmed to fail the pack when violated
- `markdownlint` clean on all changed markdown
