### PR TITLE
Finish the skill rename in the eval file's comments

### DIFF
--- a/grounding/markout/eval.yaml
+++ b/grounding/markout/eval.yaml
@@ -2,8 +2,8 @@
 #
 # 24 workflow/user-problem scenarios that exercise the base "markout" skill plus four domain
 # workflow skills. First 6 are the basics (floor); the remaining 18 rise in difficulty across
-# the four domains (conditional-composition, output-formats, built-in-shapes,
-# composite-cells-cards), four difficulty rounds A<B<C<D.
+# the four domains (markout-conditional-composition, markout-output-formats,
+# markout-built-in-shapes, markout-composite-cells-cards), four difficulty rounds A<B<C<D.
 #
 # DESIGN: each fixture ships a BARE domain model (plain POCOs) + populated data + a TODO. The
 # agent authors ONLY the rendering (Markout attributes + serializer call). This isolates the
@@ -776,14 +776,16 @@ scenarios:
       - "Section selection uses IncludeSections; omitted sections are never hand-written"
     timeout: 1200
 
-  # ── CT25/CT26: HELD OUT of the shipped 24-scenario benchmark. They target multi-view-verbosity,
-  #    which is currently NOT on the shelf (skills/multi-view-verbosity was deleted — on the 24-ladder
-  #    it self-selected ×1, below the keep threshold). These two collect-less "backpressure"
-  #    discriminators (marginal +0.42 in the n=5 haiku ablation) are what justify MVV; re-add
-  #    skills/multi-view-verbosity and fold CT25/CT26 into the benchmark when it grows past 24. ──
+  # ── CT25/CT26: HELD OUT of the shipped 24-scenario benchmark. They target
+  #    markout-multi-view-verbosity, which is currently NOT on the shelf (the skill was deleted — on
+  #    the 24-ladder it self-selected ×1, below the keep threshold). These two collect-less
+  #    "backpressure" discriminators (marginal +0.42 in the n=5 haiku ablation) are what justify MVV;
+  #    re-add skills/markout-multi-view-verbosity and fold CT25/CT26 into the benchmark when it grows
+  #    past 24. Note the name carries the package prefix: `dotnet pack` rejects a bare
+  #    skills/multi-view-verbosity. ──
   - name: "CT25: flag-driven collect-less (quiet skips the expensive scan)"
     held_out: true                         # authored but NOT in the shipped 24-scenario benchmark
-    expected_skill: multi-view-verbosity   # methodology prior: backpressure = gate what you COLLECT
+    expected_skill: markout-multi-view-verbosity   # methodology prior: backpressure = gate what you COLLECT
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj).
       Program.cs holds one plain PackageReport with scalar fields and a Diagnostics detail section.
@@ -828,7 +830,7 @@ scenarios:
 
   - name: "CT26: section-targeted promotion collects only the requested scan"
     held_out: true                         # authored but NOT in the shipped 24-scenario benchmark
-    expected_skill: multi-view-verbosity   # methodology prior: promote collection per requested section
+    expected_skill: markout-multi-view-verbosity   # methodology prior: promote collection per requested section
     prompt: |
       This console project references a source-generated .NET Markdown serializer (see the .csproj).
       Program.cs holds one plain PackageReport with scalar fields and two detail sections


### PR DESCRIPTION
#176 renamed every `expected_skill` label to the package-prefixed form, but left two comments in `eval.yaml` still describing the old names.

## The one that matters

The **CT25/CT26 held-out note** tells a future maintainer to re-add `skills/multi-view-verbosity` when the ladder grows past 24 — a directory name that **the guard added in that same PR now rejects at pack time.** Anyone following the instruction hits a pack failure and has to work out why the repo is arguing with itself.

The note now names `skills/markout-multi-view-verbosity`, states outright that the prefix is required, and the two held-out `expected_skill` labels move with it — so the scenario pair is internally consistent whenever someone folds it in.

## The cosmetic one

The header comment listing the four domains by bare name, six lines above labels that spell those same domains the new way.

## Deliberately not changed

`# Markout — CT-24 workflow ladder (Markout 0.23.0)` looks stale against a 0.33.0 release, but **0.23.0 is the version the 26 fixtures pin**, not the release — so it is accurate as written. (Worth a separate look at some point: the shelf ships at 0.33.0 while the eval restores 0.23.0. It works today, but nothing enforces that the shelf only teaches APIs the fixtures can resolve.)

## Verification

All 24 shipped `expected_skill` labels resolve to a real directory on the shelf; the only unresolved label is the held-out `markout-multi-view-verbosity`, which is intentional and documented.