### PR TITLE
Resolve row windows at the writer seam

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -661,6 +661,44 @@ public List<string>? Files { get; set; }
 
 The default ellipsis text is `"... and {0} more"` where `{0}` is the remaining count.
 
+### Row Windows
+
+`MaxItems` summarizes: it caps a table and reports what it dropped. A **row
+window** selects instead — it says which rows exist at all, and reports nothing.
+Set `MarkoutWriterOptions.RowWindow` to window every table the writer emits:
+
+```csharp
+var options = new MarkoutWriterOptions
+{
+    RowWindow = MarkoutRowWindow.Tail(20)   // the last 20 rows
+};
+```
+
+| Factory | Selects |
+| --- | --- |
+| `MarkoutRowWindow.Head(n)` | the first `n` rows |
+| `MarkoutRowWindow.Tail(n)` | the last `n` rows |
+| `MarkoutRowWindow.Range(start, end)` | rows `[start, end)`, 0-based; `end: null` runs to the end |
+
+A negative count means unlimited, so `Head(-1)` renders every row.
+
+The window is resolved once, at the writer seam, so every table mode and every
+formatter agrees on what it means — including TSV and JSONL, where a windowed
+table stays machine-consumable because no ellipsis row is introduced.
+
+When both are set, **the window selects and `MaxItems` then caps the selection**,
+so the reported overflow count describes only what the cap dropped:
+
+```csharp
+// Of 100 rows: the window selects the last 20, MaxItems shows 5,
+// and the table reports "... and 15 more".
+new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(20), MaxItems = 5 }
+```
+
+Setting a window forces streamed rows to buffer, because `Tail` and an
+open-ended `Range` are defined against a total row count that is not known until
+the last row arrives. Streamed and batched output are identical either way.
+
 ### Section Level
 
 Sections default to heading level 2 (`##`). Set `Level` to change:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -678,13 +678,27 @@ var options = new MarkoutWriterOptions
 | --- | --- |
 | `MarkoutRowWindow.Head(n)` | the first `n` rows |
 | `MarkoutRowWindow.Tail(n)` | the last `n` rows |
-| `MarkoutRowWindow.Range(start, end)` | rows `[start, end)`, 0-based; `end: null` runs to the end |
+| `MarkoutRowWindow.Range(start, end)` | rows `start` through `end`, **1-based and inclusive**; `end: null` runs to the last row |
 
-A negative count means unlimited, so `Head(-1)` renders every row.
+Row numbers are the ones a reader counts in the rendered table, so `Range(2, 3)`
+selects the second and third rows. `start` below 1, or an `end` before `start`,
+throws `ArgumentOutOfRangeException`. A range starting past the end of the table
+is not an error — it selects nothing.
 
-The window is resolved once, at the writer seam, so every table mode and every
-formatter agrees on what it means — including TSV and JSONL, where a windowed
-table stays machine-consumable because no ellipsis row is introduced.
+A negative count throws `ArgumentOutOfRangeException`. "No window" is spelled by
+leaving `RowWindow` null, so a negative count — usually the result of a
+subtraction that slipped below zero — fails rather than silently widening the
+table to every row.
+
+The window is resolved once, at the writer seam, so every table mode agrees on
+what it means — including TSV and JSONL, where selection alone introduces no
+ellipsis row and leaves the output machine-consumable. (Adding `MaxItems` on top
+reintroduces `MaxItems`' own ellipsis line in TSV, as it does without a window.)
+
+The window applies to tables written through the writer — `WriteTable`,
+`WriteTableStart`/`WriteTableRow`/`WriteTableEnd`, and `WriteCompositeTable`. It
+does **not** apply to lowerings that call a formatter's `FormatTable` directly,
+which today means metrics and breakdown rendering and the graph edge table.
 
 When both are set, **the window selects and `MaxItems` then caps the selection**,
 so the reported overflow count describes only what the cap dropped:
@@ -695,9 +709,10 @@ so the reported overflow count describes only what the cap dropped:
 new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(20), MaxItems = 5 }
 ```
 
-Setting a window forces streamed rows to buffer, because `Tail` and an
-open-ended `Range` are defined against a total row count that is not known until
-the last row arrives. Streamed and batched output are identical either way.
+Streamed and batched output are identical. A `Tail` window buffers the rows it
+might still keep, because which rows those are is not known until the last row
+arrives; the other window kinds decide each row from its position and stream
+without buffering.
 
 ### Section Level
 

--- a/src/Markout/MarkoutRowWindow.cs
+++ b/src/Markout/MarkoutRowWindow.cs
@@ -23,10 +23,12 @@ namespace Markout;
 /// </para>
 ///
 /// <para>
-/// <see cref="Resolve"/> is the single place these semantics are interpreted.
-/// Every emission path resolves through it rather than branching on the window's
-/// shape, so a change to what a window means cannot land in one table mode and
-/// miss another.
+/// This type is the single owner of what a window means. It offers two ways to
+/// ask — <see cref="Resolve"/> against a known row count, and
+/// <see cref="KeepsPosition"/>/<see cref="IsPastEnd"/> for a row whose table has
+/// not finished arriving — so that a streaming caller never has to re-derive the
+/// semantics for itself. The two must agree, and a renderer is expected to prove
+/// that rather than assume it.
 /// </para>
 /// </summary>
 public readonly record struct MarkoutRowWindow
@@ -47,23 +49,48 @@ public readonly record struct MarkoutRowWindow
     public MarkoutRowWindowKind Kind { get; }
 
     /// <summary>
-    /// True when this window keeps every row, so a renderer can skip windowing
-    /// entirely. Only a relative window can be unlimited (via a negative count);
-    /// an absolute range always names a bounded start, even when open-ended.
+    /// Whether every row this window keeps can be decided from that row's position
+    /// alone. True for <see cref="Head"/> and <see cref="Range"/>, whose bounds are
+    /// fixed in advance; false for <see cref="Tail"/>, which cannot know which rows
+    /// are the last ones until the table ends.
+    ///
+    /// <para>
+    /// A renderer uses this to decide whether it may stream. It is not a hint about
+    /// what the window means — <see cref="KeepsPosition"/> answers that.
+    /// </para>
     /// </summary>
-    public bool IsUnlimited => Kind != MarkoutRowWindowKind.Range && _count < 0;
+    public bool IsPositional => Kind != MarkoutRowWindowKind.Tail;
 
     /// <summary>
-    /// Keep the first <paramref name="count"/> data rows. A negative count means
-    /// "no limit", which lets a caller hold a window unconditionally rather than
-    /// forking between a window and none.
+    /// The most rows a <see cref="Tail"/> window can ever keep, and therefore the
+    /// most a renderer buffering for one needs to retain. Zero for the positional
+    /// kinds, which need to retain nothing.
     /// </summary>
-    /// <param name="count">How many leading rows to keep; negative for no limit.</param>
-    public static MarkoutRowWindow Head(int count) => new(MarkoutRowWindowKind.Head, count, 0, null);
+    public int RetentionBound => Kind == MarkoutRowWindowKind.Tail ? _count : 0;
+
+    /// <summary>
+    /// Keep the first <paramref name="count"/> data rows.
+    /// </summary>
+    /// <param name="count">How many leading rows to keep.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+    public static MarkoutRowWindow Head(int count)
+    {
+        // A negative count is rejected rather than read as "no limit". "No limit" is
+        // already spelled by not setting a window at all, and a count is usually
+        // computed -- a subtraction that slips below zero should fail rather than
+        // silently widen the table to everything.
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        return new(MarkoutRowWindowKind.Head, count, 0, null);
+    }
 
     /// <summary>Keep the last <paramref name="count"/> data rows.</summary>
-    /// <param name="count">How many trailing rows to keep; negative for no limit.</param>
-    public static MarkoutRowWindow Tail(int count) => new(MarkoutRowWindowKind.Tail, count, 0, null);
+    /// <param name="count">How many trailing rows to keep.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+    public static MarkoutRowWindow Tail(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        return new(MarkoutRowWindowKind.Tail, count, 0, null);
+    }
 
     /// <summary>
     /// Keep the rows numbered <paramref name="start"/> through
@@ -113,16 +140,66 @@ public readonly record struct MarkoutRowWindow
         switch (Kind)
         {
             case MarkoutRowWindowKind.Head:
-                // A negative count is "no limit"; clamping it to dataCount keeps
-                // the whole table rather than emptying it.
-                return (0, _count < 0 ? dataCount : Math.Min(_count, dataCount));
+                return (0, Math.Min(_count, dataCount));
             case MarkoutRowWindowKind.Tail:
-                return (_count < 0 ? 0 : Math.Max(0, dataCount - _count), dataCount);
+                return (Math.Max(0, dataCount - _count), dataCount);
             default:
                 var start = Math.Min(_start - 1, dataCount);
                 var end = _end is int e ? Math.Min(e, dataCount) : dataCount;
                 return (start, end);
         }
+    }
+
+    /// <summary>
+    /// Whether the data row at 0-based <paramref name="position"/> is inside this
+    /// window, for a table whose total row count is not yet known.
+    ///
+    /// <para>
+    /// Only meaningful when <see cref="IsPositional"/> is true; a <see cref="Tail"/>
+    /// window has no answer until the table ends, and asking throws rather than
+    /// returning a guess.
+    /// </para>
+    /// </summary>
+    /// <param name="position">0-based position of the data row.</param>
+    /// <exception cref="InvalidOperationException">This window is not positional.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="position"/> is negative.</exception>
+    public bool KeepsPosition(int position)
+    {
+        ThrowIfNotPositional();
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+
+        return position >= FirstKeptPosition && position < EndPositionExclusive;
+    }
+
+    /// <summary>
+    /// Whether no row at or after 0-based <paramref name="position"/> can be kept,
+    /// so a caller may stop considering rows entirely.
+    /// </summary>
+    /// <param name="position">0-based position of the data row.</param>
+    /// <exception cref="InvalidOperationException">This window is not positional.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="position"/> is negative.</exception>
+    public bool IsPastEnd(int position)
+    {
+        ThrowIfNotPositional();
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+
+        return position >= EndPositionExclusive;
+    }
+
+    private int FirstKeptPosition => Kind == MarkoutRowWindowKind.Range ? _start - 1 : 0;
+
+    private long EndPositionExclusive => Kind switch
+    {
+        MarkoutRowWindowKind.Head => _count,
+        MarkoutRowWindowKind.Range => _end ?? long.MaxValue,
+        _ => long.MaxValue
+    };
+
+    private void ThrowIfNotPositional()
+    {
+        if (!IsPositional)
+            throw new InvalidOperationException(
+                $"A {Kind} window is defined against the table's total row count and cannot be resolved by position.");
     }
 
     /// <summary>
@@ -149,16 +226,23 @@ public readonly record struct MarkoutRowWindow
     }
 
     /// <summary>
-    /// Applies an optional window, treating "no window" and "unlimited" alike as
-    /// keeping every row. Callers hold a window as a nullable, so putting the
-    /// null handling here keeps it from being re-derived per caller.
+    /// Applies an optional window, treating "no window" as keeping every row.
+    /// Callers hold a window as a nullable, so putting the null handling here keeps
+    /// it from being re-derived per caller.
     /// </summary>
     /// <typeparam name="T">The row type.</typeparam>
     /// <param name="window">The window to apply, or null to keep every row.</param>
     /// <param name="rows">The rows to window.</param>
     /// <returns>The rows within the window, in their original order.</returns>
-    public static IReadOnlyList<T> Apply<T>(MarkoutRowWindow? window, IReadOnlyList<T> rows) =>
-        window is { IsUnlimited: false } w ? w.Apply(rows) : rows;
+    /// <exception cref="ArgumentNullException"><paramref name="rows"/> is null.</exception>
+    public static IReadOnlyList<T> Apply<T>(MarkoutRowWindow? window, IReadOnlyList<T> rows)
+    {
+        // Guard before the fast path, or a null list is returned as a non-null
+        // result whenever the window happens to be absent or unlimited.
+        ArgumentNullException.ThrowIfNull(rows);
+
+        return window is { } w ? w.Apply(rows) : rows;
+    }
 }
 
 /// <summary>Whether a <see cref="MarkoutRowWindow"/> counts rows or names them.</summary>

--- a/src/Markout/MarkoutRowWindow.cs
+++ b/src/Markout/MarkoutRowWindow.cs
@@ -1,0 +1,175 @@
+namespace Markout;
+
+/// <summary>
+/// A per-table data-row window: which data rows a table emits, preserving its
+/// headings and header row. A window is either <em>relative</em> — the first
+/// (<see cref="Head"/>) or last (<see cref="Tail"/>) N rows, where which rows
+/// those are depends on how many the table has — or <em>absolute</em>
+/// (<see cref="Range"/>), naming row numbers to keep regardless of the table's
+/// size.
+///
+/// <para>
+/// The two are not interchangeable, which is why this type is constructed
+/// through named factories rather than a positional constructor: a bare pair of
+/// numbers cannot say whether it means "two rows" or "row two".
+/// </para>
+///
+/// <para>
+/// A window is <em>selection</em>, not summarization, which is what separates it
+/// from <see cref="MarkoutWriterOptions.MaxItems"/>. A windowed table emits no
+/// ellipsis row and reports no skipped count, so its output stays
+/// machine-consumable and its row count is exactly what a caller counting the
+/// same window would compute.
+/// </para>
+///
+/// <para>
+/// <see cref="Resolve"/> is the single place these semantics are interpreted.
+/// Every emission path resolves through it rather than branching on the window's
+/// shape, so a change to what a window means cannot land in one table mode and
+/// miss another.
+/// </para>
+/// </summary>
+public readonly record struct MarkoutRowWindow
+{
+    private readonly int _count;
+    private readonly int _start;
+    private readonly int? _end;
+
+    private MarkoutRowWindow(MarkoutRowWindowKind kind, int count, int start, int? end)
+    {
+        Kind = kind;
+        _count = count;
+        _start = start;
+        _end = end;
+    }
+
+    /// <summary>Whether this window counts rows or names them.</summary>
+    public MarkoutRowWindowKind Kind { get; }
+
+    /// <summary>
+    /// True when this window keeps every row, so a renderer can skip windowing
+    /// entirely. Only a relative window can be unlimited (via a negative count);
+    /// an absolute range always names a bounded start, even when open-ended.
+    /// </summary>
+    public bool IsUnlimited => Kind != MarkoutRowWindowKind.Range && _count < 0;
+
+    /// <summary>
+    /// Keep the first <paramref name="count"/> data rows. A negative count means
+    /// "no limit", which lets a caller hold a window unconditionally rather than
+    /// forking between a window and none.
+    /// </summary>
+    /// <param name="count">How many leading rows to keep; negative for no limit.</param>
+    public static MarkoutRowWindow Head(int count) => new(MarkoutRowWindowKind.Head, count, 0, null);
+
+    /// <summary>Keep the last <paramref name="count"/> data rows.</summary>
+    /// <param name="count">How many trailing rows to keep; negative for no limit.</param>
+    public static MarkoutRowWindow Tail(int count) => new(MarkoutRowWindowKind.Tail, count, 0, null);
+
+    /// <summary>
+    /// Keep the rows numbered <paramref name="start"/> through
+    /// <paramref name="end"/> inclusive, or through the last row when
+    /// <paramref name="end"/> is null. Row numbers are 1-based and are the
+    /// numbers a reader counts in the rendered table.
+    /// </summary>
+    /// <param name="start">1-based number of the first row to keep.</param>
+    /// <param name="end">1-based number of the last row to keep, or null for the last row.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="start"/> is less than 1, or <paramref name="end"/> is less
+    /// than <paramref name="start"/>.
+    /// </exception>
+    public static MarkoutRowWindow Range(int start, int? end)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(start, 1);
+        if (end is int e)
+            ArgumentOutOfRangeException.ThrowIfLessThan(e, start);
+        return new(MarkoutRowWindowKind.Range, 0, start, end);
+    }
+
+    /// <summary>
+    /// Resolves this window against a table of <paramref name="dataCount"/> data
+    /// rows, returning the half-open range of 0-based row positions to keep.
+    ///
+    /// <para>
+    /// The result is always a valid range (<c>0 &lt;= keepStart &lt;= keepEnd
+    /// &lt;= dataCount</c>), so a caller can use it without re-clamping. An
+    /// absolute range starting past the end of the table resolves to an empty
+    /// window rather than an error: the rows it names simply are not there.
+    /// </para>
+    ///
+    /// <para>
+    /// For a range the ordering half of that invariant holds by construction
+    /// rather than by clamping here: <see cref="Range"/> rejects an end before
+    /// its start, so <c>_end &gt;= _start</c>, and <see cref="Math.Min(int,int)"/>
+    /// is monotonic.
+    /// </para>
+    /// </summary>
+    /// <param name="dataCount">How many data rows the table has.</param>
+    /// <returns>The half-open range of 0-based row positions to keep.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="dataCount"/> is negative.</exception>
+    public (int KeepStart, int KeepEnd) Resolve(int dataCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(dataCount);
+
+        switch (Kind)
+        {
+            case MarkoutRowWindowKind.Head:
+                // A negative count is "no limit"; clamping it to dataCount keeps
+                // the whole table rather than emptying it.
+                return (0, _count < 0 ? dataCount : Math.Min(_count, dataCount));
+            case MarkoutRowWindowKind.Tail:
+                return (_count < 0 ? 0 : Math.Max(0, dataCount - _count), dataCount);
+            default:
+                var start = Math.Min(_start - 1, dataCount);
+                var end = _end is int e ? Math.Min(e, dataCount) : dataCount;
+                return (start, end);
+        }
+    }
+
+    /// <summary>
+    /// Applies this window to a materialized row list, returning the rows a
+    /// table would keep. Resolves through <see cref="Resolve"/> against the same
+    /// row count the renderer sees, which is what keeps a caller's own row count
+    /// equal to the windowed table it describes.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="rows">The rows to window.</param>
+    /// <returns>The rows within the window, in their original order.</returns>
+    public IReadOnlyList<T> Apply<T>(IReadOnlyList<T> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        var (keepStart, keepEnd) = Resolve(rows.Count);
+        if (keepStart == 0 && keepEnd == rows.Count)
+            return rows;
+
+        var kept = new List<T>(keepEnd - keepStart);
+        for (var i = keepStart; i < keepEnd; i++)
+            kept.Add(rows[i]);
+        return kept;
+    }
+
+    /// <summary>
+    /// Applies an optional window, treating "no window" and "unlimited" alike as
+    /// keeping every row. Callers hold a window as a nullable, so putting the
+    /// null handling here keeps it from being re-derived per caller.
+    /// </summary>
+    /// <typeparam name="T">The row type.</typeparam>
+    /// <param name="window">The window to apply, or null to keep every row.</param>
+    /// <param name="rows">The rows to window.</param>
+    /// <returns>The rows within the window, in their original order.</returns>
+    public static IReadOnlyList<T> Apply<T>(MarkoutRowWindow? window, IReadOnlyList<T> rows) =>
+        window is { IsUnlimited: false } w ? w.Apply(rows) : rows;
+}
+
+/// <summary>Whether a <see cref="MarkoutRowWindow"/> counts rows or names them.</summary>
+public enum MarkoutRowWindowKind
+{
+    /// <summary>Keep a count of rows from the start of the table.</summary>
+    Head,
+
+    /// <summary>Keep a count of rows from the end of the table.</summary>
+    Tail,
+
+    /// <summary>Keep rows by their 1-based row numbers.</summary>
+    Range
+}

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -13,6 +13,7 @@ public class MarkoutWriterOptions
     private bool _boldFieldNames;
     private bool _prettyTables;
     private int? _maxItems;
+    private MarkoutRowWindow? _rowWindow;
     private HashSet<string>? _includeSections;
     private MarkoutProjection? _projection;
     private MarkoutShape _suppressedShapes;
@@ -41,6 +42,7 @@ public class MarkoutWriterOptions
         _boldFieldNames = source._boldFieldNames;
         _prettyTables = source._prettyTables;
         _maxItems = source._maxItems;
+        _rowWindow = source._rowWindow;
         _includeSections = source._includeSections;
         _projection = source._projection;
         _suppressedShapes = source._suppressedShapes;
@@ -190,6 +192,29 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _maxItems = value;
+        }
+    }
+
+    /// <summary>
+    /// Which data rows tables emit, preserving headings and header rows.
+    /// Default is null (every row).
+    ///
+    /// <para>
+    /// This is <em>selection</em>, not summarization, which is what separates it
+    /// from <see cref="MaxItems"/>: a windowed table emits no ellipsis row and
+    /// reports no skipped count, so the output stays machine-consumable in every
+    /// <see cref="MarkoutTableMode"/>. When both are set the window selects
+    /// first and <see cref="MaxItems"/> then caps the selection, so any ellipsis
+    /// reports only the rows the cap dropped.
+    /// </para>
+    /// </summary>
+    public MarkoutRowWindow? RowWindow
+    {
+        get => _rowWindow;
+        set
+        {
+            ThrowIfReadOnly();
+            _rowWindow = value;
         }
     }
 

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -190,9 +190,15 @@ public class TableWriter
         }
         else if (_tailBuffer != null)
         {
-            _tailBuffer.Enqueue(values.ToArray());
-            while (_tailBuffer.Count > _tailBound)
-                _tailBuffer.Dequeue();
+            // A zero-retention tail keeps nothing, so copying a row only to discard
+            // it on the next line is pure waste. Above zero, make room before
+            // copying so the queue never holds more than the window can keep.
+            if (_tailBound > 0)
+            {
+                while (_tailBuffer.Count >= _tailBound)
+                    _tailBuffer.Dequeue();
+                _tailBuffer.Enqueue(values.ToArray());
+            }
         }
         else
         {

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -59,28 +59,19 @@ public class TableWriter
     private void WriteTableCore(ReadOnlySpan<string> headers, ReadOnlySpan<string> headerNames, IList<string[]> rows)
     {
         var renderedHeaders = FormatHeaders(headers, headerNames);
+        var (selected, skipped) = SelectRows(rows);
+
         if (_batchFormatter != null)
         {
-            var (truncated, skipped) = TruncateRows(rows);
-            _batchFormatter.FormatTable(_writer, renderedHeaders, truncated, skipped, _options);
+            _batchFormatter.FormatTable(_writer, renderedHeaders, selected, skipped, _options);
             return;
         }
 
         if (_streamingFormatter != null)
         {
             _streamingFormatter.BeginTable(_writer, renderedHeaders, _options);
-            int count = 0;
-            int skipped = 0;
-            foreach (var row in rows)
-            {
-                if (_options.MaxItems is int max && count >= max)
-                {
-                    skipped++;
-                    continue;
-                }
+            foreach (var row in selected)
                 _streamingFormatter.WriteRow(_writer, row);
-                count++;
-            }
             _streamingFormatter.EndTable(_writer, skipped);
         }
     }
@@ -106,8 +97,12 @@ public class TableWriter
         _streamingHeaders = FormatHeaders(headers, headerNames);
 
         // Force buffering when TableOptions is set — statistical width
-        // calculation requires all rows before rendering.
-        if (_streamingFormatter != null && _options.TableOptions == null)
+        // calculation requires all rows before rendering. A row window forces it
+        // for a different reason: Tail and an open-ended Range are defined
+        // against the total row count, which is not known until the last row
+        // arrives. Buffering lets every path resolve through the same
+        // MarkoutRowWindow.Resolve rather than re-deriving the window positionally.
+        if (_streamingFormatter != null && _options.TableOptions == null && !HasRowWindow)
         {
             _streamingDirect = true;
             _streamingFormatter.BeginTable(_writer, _streamingHeaders, _options);
@@ -152,7 +147,10 @@ public class TableWriter
     {
         if (_streamingHeaders == null) return;
 
-        if (_options.MaxItems is int max && _tableRowCount >= max)
+        // With a window active every row must be buffered: which rows survive is
+        // not decidable until the total is known, so capping here would cap the
+        // wrong set. SelectRows applies both the window and MaxItems at end.
+        if (!HasRowWindow && _options.MaxItems is int max && _tableRowCount >= max)
         {
             _tableRowsSkipped++;
             return;
@@ -180,9 +178,28 @@ public class TableWriter
         {
             _streamingFormatter.EndTable(_writer, _tableRowsSkipped);
         }
-        else if (_batchFormatter != null)
+        else
         {
-            _batchFormatter.FormatTable(_writer, _streamingHeaders, _streamingRows ?? [], _tableRowsSkipped, _options);
+            // Buffered. MaxItems was deferred while a window was active, so both
+            // are resolved here; without a window the rows were capped on arrival.
+            var rows = (IList<string[]>)(_streamingRows ?? []);
+            var skipped = _tableRowsSkipped;
+            if (HasRowWindow)
+                (rows, skipped) = SelectRows(rows);
+
+            if (_batchFormatter != null)
+            {
+                _batchFormatter.FormatTable(_writer, _streamingHeaders, rows, skipped, _options);
+            }
+            else if (_streamingFormatter != null)
+            {
+                // A streaming-only formatter still has to emit what was buffered,
+                // or forcing buffering would silently drop the entire table.
+                _streamingFormatter.BeginTable(_writer, _streamingHeaders, _options);
+                foreach (var row in rows)
+                    _streamingFormatter.WriteRow(_writer, row);
+                _streamingFormatter.EndTable(_writer, skipped);
+            }
         }
 
         _streamingHeaders = null;
@@ -190,10 +207,30 @@ public class TableWriter
         _streamingDirect = false;
     }
 
-    private (IList<string[]> rows, int skipped) TruncateRows(IList<string[]> rows)
+    private bool HasRowWindow => _options.RowWindow is { IsUnlimited: false };
+
+    private (IList<string[]> rows, int skipped) SelectRows(IList<string[]> rows)
     {
-        if (_options.MaxItems is int max && rows.Count > max)
-            return (rows.Take(max).ToList(), rows.Count - max);
-        return (rows, 0);
+        var selected = rows;
+
+        // Selection runs before summarization: the window says which rows exist,
+        // MaxItems then says how many of those to show. Resolving here — and only
+        // here — is what keeps every table mode agreeing on what a row window means.
+        if (_options.RowWindow is { IsUnlimited: false } window)
+        {
+            var (keepStart, keepEnd) = window.Resolve(rows.Count);
+            if (keepStart != 0 || keepEnd != rows.Count)
+            {
+                var kept = new List<string[]>(keepEnd - keepStart);
+                for (var i = keepStart; i < keepEnd; i++)
+                    kept.Add(rows[i]);
+                selected = kept;
+            }
+        }
+
+        if (_options.MaxItems is int max && selected.Count > max)
+            return (selected.Take(max).ToList(), selected.Count - max);
+
+        return (selected, 0);
     }
 }

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -21,6 +21,9 @@ public class TableWriter
     private bool _streamingDirect;
     private int _tableRowCount;
     private int _tableRowsSkipped;
+    private int _dataPosition;
+    private Queue<string[]>? _tailBuffer;
+    private int _tailBound;
 
     /// <summary>
     /// Creates a table writer with a batch table formatter.
@@ -93,23 +96,39 @@ public class TableWriter
         _tableRowCount = 0;
         _tableRowsSkipped = 0;
         _streamingDirect = false;
+        _dataPosition = 0;
+        _tailBuffer = null;
 
         _streamingHeaders = FormatHeaders(headers, headerNames);
 
-        // Force buffering when TableOptions is set — statistical width
-        // calculation requires all rows before rendering. A row window forces it
-        // for a different reason: Tail and an open-ended Range are defined
-        // against the total row count, which is not known until the last row
-        // arrives. Buffering lets every path resolve through the same
-        // MarkoutRowWindow.Resolve rather than re-deriving the window positionally.
-        if (_streamingFormatter != null && _options.TableOptions == null && !HasRowWindow)
+        // Force buffering when TableOptions is set — statistical width calculation
+        // requires all rows before rendering. A Tail window forces it for its own
+        // reason: which rows are the last ones is not known until the table ends.
+        // Head and Range decide each row from its position, so they keep streaming
+        // and retain nothing; a window is not a reason on its own to hold a table
+        // in memory.
+        var window = _options.RowWindow;
+        if (_streamingFormatter != null && _options.TableOptions == null
+            && (window == null || window.Value.IsPositional))
         {
             _streamingDirect = true;
             _streamingFormatter.BeginTable(_writer, _streamingHeaders, _options);
         }
         else
         {
-            _streamingRows = [];
+            // A Tail window never needs more than its own count in hand, so it reads
+            // through a queue bounded by what the window can keep rather than by the
+            // size of the table. Enqueue-and-dequeue keeps that O(1) per row; trimming
+            // a list from the front would make a large Tail quadratic.
+            if (window is { IsPositional: false } tail)
+            {
+                _tailBound = tail.RetentionBound;
+                _tailBuffer = new Queue<string[]>(Math.Min(_tailBound, 1024));
+            }
+            else
+            {
+                _streamingRows = [];
+            }
         }
     }
 
@@ -147,10 +166,18 @@ public class TableWriter
     {
         if (_streamingHeaders == null) return;
 
-        // With a window active every row must be buffered: which rows survive is
-        // not decidable until the total is known, so capping here would cap the
-        // wrong set. SelectRows applies both the window and MaxItems at end.
-        if (!HasRowWindow && _options.MaxItems is int max && _tableRowCount >= max)
+        var position = _dataPosition++;
+
+        // A positional window is asked about this row directly; it is the same type
+        // that answers Resolve, so streaming does not get its own idea of what the
+        // window means. A Tail window has no answer yet and is settled at the end.
+        if (_options.RowWindow is { IsPositional: true } window && !window.KeepsPosition(position))
+            return;
+
+        // MaxItems caps the window's selection, so it counts selected rows. Under a
+        // Tail window the selection is not known yet, so the cap is deferred to
+        // SelectRows rather than applied to whichever rows happened to arrive first.
+        if (!DefersMaxItems && _options.MaxItems is int max && _tableRowCount >= max)
         {
             _tableRowsSkipped++;
             return;
@@ -160,6 +187,12 @@ public class TableWriter
         if (_streamingDirect && _streamingFormatter != null)
         {
             _streamingFormatter.WriteRow(_writer, values);
+        }
+        else if (_tailBuffer != null)
+        {
+            _tailBuffer.Enqueue(values.ToArray());
+            while (_tailBuffer.Count > _tailBound)
+                _tailBuffer.Dequeue();
         }
         else
         {
@@ -180,11 +213,13 @@ public class TableWriter
         }
         else
         {
-            // Buffered. MaxItems was deferred while a window was active, so both
-            // are resolved here; without a window the rows were capped on arrival.
-            var rows = (IList<string[]>)(_streamingRows ?? []);
+            // Buffered. A positional window already excluded its rows on arrival and
+            // MaxItems already capped what survived, so re-running SelectRows here
+            // would apply the window a second time to rows that are only the window's
+            // output. Only a Tail window still has both to settle.
+            var rows = (IList<string[]>)(_tailBuffer?.ToArray() ?? (IList<string[]>?)_streamingRows ?? []);
             var skipped = _tableRowsSkipped;
-            if (HasRowWindow)
+            if (_options.RowWindow is { IsPositional: false })
                 (rows, skipped) = SelectRows(rows);
 
             if (_batchFormatter != null)
@@ -204,10 +239,16 @@ public class TableWriter
 
         _streamingHeaders = null;
         _streamingRows = null;
+        _tailBuffer = null;
         _streamingDirect = false;
     }
 
-    private bool HasRowWindow => _options.RowWindow is { IsUnlimited: false };
+    /// <summary>
+    /// Whether MaxItems has to wait for the table to end. Only a Tail window makes it
+    /// wait: capping on arrival would cap the rows that came first, not the rows the
+    /// window selected.
+    /// </summary>
+    private bool DefersMaxItems => _options.RowWindow is { IsPositional: false };
 
     private (IList<string[]> rows, int skipped) SelectRows(IList<string[]> rows)
     {
@@ -216,7 +257,7 @@ public class TableWriter
         // Selection runs before summarization: the window says which rows exist,
         // MaxItems then says how many of those to show. Resolving here — and only
         // here — is what keeps every table mode agreeing on what a row window means.
-        if (_options.RowWindow is { IsUnlimited: false } window)
+        if (_options.RowWindow is { } window)
         {
             var (keepStart, keepEnd) = window.Resolve(rows.Count);
             if (keepStart != 0 || keepEnd != rows.Count)

--- a/tests/Markout.Tests/RowWindowTests.cs
+++ b/tests/Markout.Tests/RowWindowTests.cs
@@ -148,15 +148,14 @@ public class RowWindowTests
         foreach (var window in windows)
         {
             Assert.True(window.IsPositional);
-            for (var total = 0; total <= 8; total++)
+            for (var total = 0; total <= 15; total++)
             {
                 var (keepStart, keepEnd) = window.Resolve(total);
                 for (var position = 0; position < total; position++)
                 {
                     var expected = position >= keepStart && position < keepEnd;
                     Assert.Equal(expected, window.KeepsPosition(position));
-                    if (window.IsPastEnd(position))
-                        Assert.False(expected);
+                    Assert.Equal(position >= keepEnd, window.IsPastEnd(position));
                 }
             }
         }
@@ -678,6 +677,36 @@ public class RowWindowTests
 
         writer.WriteTableEnd();
         Assert.Contains("row:r1", sw.ToString());
+    }
+
+    /// <summary>
+    /// A window that keeps nothing must cost nothing per row. Tail is the only kind
+    /// that retains rows at all, so it is the only one that can get this wrong, and
+    /// <c>Tail(0)</c> is the boundary where retaining and copying come apart: the
+    /// bound is reached before the first row, so every copy is made to be discarded.
+    /// Head(0) is the control — it never had a buffer to misuse.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void AWindowThatKeepsNothing_CopiesNothing(int kind)
+    {
+        var window = kind == 0 ? MarkoutRowWindow.Tail(0) : MarkoutRowWindow.Head(0);
+        var writer = new TableWriter(
+            TextWriter.Null,
+            new StreamingOnlyFormatter(),
+            new MarkoutWriterOptions { RowWindow = window });
+        writer.WriteTableStart(Header);
+        string[] row = ["r"];
+
+        for (var i = 0; i < 200; i++)
+            writer.WriteTableRow(row);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+            writer.WriteTableRow(row);
+
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - before);
     }
 
     [Fact]

--- a/tests/Markout.Tests/RowWindowTests.cs
+++ b/tests/Markout.Tests/RowWindowTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 using Markout;
 using Markout.Formatting;
 
@@ -707,6 +709,90 @@ public class RowWindowTests
             writer.WriteTableRow(row);
 
         Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - before);
+    }
+
+    /// <summary>
+    /// A tail window retains its bound, not the table. Allocation cannot show this —
+    /// every row is copied on arrival either way, so allocated bytes are linear in row
+    /// count whether the buffer is bounded or not. Reachability can: the rows a bounded
+    /// buffer let go of become collectable, and the ones it holds do not.
+    ///
+    /// <para>
+    /// The row values are freshly built rather than literals, so nothing is interned
+    /// and the only thing that can keep one alive is the writer. The producer is a
+    /// separate non-inlined method so its locals are out of scope and off the stack
+    /// before the collection runs.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ATailWindow_HoldsItsBoundRatherThanTheTable()
+    {
+        const int Rows = 1000;
+        const int Bound = 7;
+
+        var (writer, tracked) = FillTail(Rows, Bound);
+
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+
+        var alive = tracked.Count(reference => reference.IsAlive);
+        GC.KeepAlive(writer);
+
+        Assert.Equal(Bound, alive);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (TableWriter Writer, WeakReference[] Tracked) FillTail(int rows, int bound)
+    {
+        var writer = new TableWriter(
+            TextWriter.Null,
+            new StreamingOnlyFormatter(),
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(bound) });
+        writer.WriteTableStart(Header);
+
+        var tracked = new WeakReference[rows];
+        for (var i = 0; i < rows; i++)
+        {
+            // Built rather than written as a literal: an interned string would stay
+            // reachable no matter what the writer did with it.
+            var value = new string('r', 1) + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            tracked[i] = new WeakReference(value);
+            writer.WriteTableRow(value);
+        }
+
+        return (writer, tracked);
+    }
+
+    /// <summary>
+    /// A window that keeps everything hands back the list it was given rather than a
+    /// copy of it. Only reference identity can say so: a copy holds the same elements
+    /// in the same order, so every assertion about content passes either way, which is
+    /// how this went ungated until a reviewer mutated the branch away and saw nothing
+    /// fail.
+    /// </summary>
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void AWindowThatKeepsEveryRow_ReturnsTheSameList(int count)
+    {
+        IReadOnlyList<string> rows = ["r1", "r2", "r3"];
+
+        Assert.Same(rows, MarkoutRowWindow.Head(count).Apply(rows));
+        Assert.Same(rows, MarkoutRowWindow.Tail(count).Apply(rows));
+        Assert.Same(rows, MarkoutRowWindow.Range(1, count).Apply(rows));
+        Assert.Same(rows, MarkoutRowWindow.Range(1, null).Apply(rows));
+        Assert.Same(rows, MarkoutRowWindow.Apply(null, rows));
+    }
+
+    [Fact]
+    public void AWindowThatKeepsSomeRows_ReturnsACopy()
+    {
+        IReadOnlyList<string> rows = ["r1", "r2", "r3"];
+
+        Assert.NotSame(rows, MarkoutRowWindow.Head(2).Apply(rows));
+        Assert.NotSame(rows, MarkoutRowWindow.Tail(2).Apply(rows));
+        Assert.NotSame(rows, MarkoutRowWindow.Range(2, null).Apply(rows));
     }
 
     [Fact]

--- a/tests/Markout.Tests/RowWindowTests.cs
+++ b/tests/Markout.Tests/RowWindowTests.cs
@@ -86,25 +86,81 @@ public class RowWindowTests
     public void Range_PastTheEnd_ResolvesEmptyRatherThanThrowing()
         => Assert.Equal((3, 3), MarkoutRowWindow.Range(9, 12).Resolve(3));
 
+    /// <summary>
+    /// A count is usually computed, and a subtraction that slips below zero should
+    /// fail rather than silently widen the table to every row. "No window" is
+    /// already spelled by leaving the option null, so a negative count has no
+    /// legitimate reading left.
+    /// </summary>
     [Theory]
     [InlineData(-1)]
     [InlineData(-100)]
-    public void ANegativeCount_MeansNoLimit(int count)
+    public void ANegativeCount_IsRejected(int count)
     {
-        Assert.True(MarkoutRowWindow.Head(count).IsUnlimited);
-        Assert.True(MarkoutRowWindow.Tail(count).IsUnlimited);
-        Assert.Equal((0, 4), MarkoutRowWindow.Head(count).Resolve(4));
-        Assert.Equal((0, 4), MarkoutRowWindow.Tail(count).Resolve(4));
+        Assert.Throws<ArgumentOutOfRangeException>(() => MarkoutRowWindow.Head(count));
+        Assert.Throws<ArgumentOutOfRangeException>(() => MarkoutRowWindow.Tail(count));
+    }
+
+    [Fact]
+    public void AZeroCount_SelectsNoRows()
+    {
+        Assert.Equal((0, 0), MarkoutRowWindow.Head(0).Resolve(4));
+        Assert.Equal((4, 4), MarkoutRowWindow.Tail(0).Resolve(4));
     }
 
     /// <summary>
-    /// A range always names a bounded start, so it is never "unlimited" even
-    /// when open-ended. If this regressed, an open-ended range would be skipped
-    /// entirely by the <c>IsUnlimited</c> fast path and silently keep every row.
+    /// Only Tail is defined against the total, so only Tail may make a renderer wait.
+    /// If an open-ended range were treated as non-positional it would buffer a table
+    /// it could have streamed.
     /// </summary>
     [Fact]
-    public void AnOpenEndedRange_IsNotUnlimited()
-        => Assert.False(MarkoutRowWindow.Range(2, null).IsUnlimited);
+    public void OnlyTail_NeedsTheTotalRowCount()
+    {
+        Assert.True(MarkoutRowWindow.Head(2).IsPositional);
+        Assert.True(MarkoutRowWindow.Range(2, null).IsPositional);
+        Assert.True(MarkoutRowWindow.Range(2, 4).IsPositional);
+        Assert.False(MarkoutRowWindow.Tail(2).IsPositional);
+    }
+
+    [Fact]
+    public void ATailWindow_RefusesToAnswerByPosition()
+    {
+        Assert.Throws<InvalidOperationException>(() => MarkoutRowWindow.Tail(2).KeepsPosition(0));
+        Assert.Throws<InvalidOperationException>(() => MarkoutRowWindow.Tail(2).IsPastEnd(0));
+    }
+
+    /// <summary>
+    /// The two ways of asking what a window means must give the same answer, or the
+    /// streaming path has quietly acquired its own dialect. Swept rather than
+    /// sampled, because a disagreement is likely to live at an edge.
+    /// </summary>
+    [Fact]
+    public void AskingByPosition_AgreesWithResolvingAgainstATotal()
+    {
+        MarkoutRowWindow[] windows =
+        [
+            MarkoutRowWindow.Head(0), MarkoutRowWindow.Head(1), MarkoutRowWindow.Head(3),
+            MarkoutRowWindow.Head(10),
+            MarkoutRowWindow.Range(1, 1), MarkoutRowWindow.Range(2, 4),
+            MarkoutRowWindow.Range(3, null), MarkoutRowWindow.Range(9, 12)
+        ];
+
+        foreach (var window in windows)
+        {
+            Assert.True(window.IsPositional);
+            for (var total = 0; total <= 8; total++)
+            {
+                var (keepStart, keepEnd) = window.Resolve(total);
+                for (var position = 0; position < total; position++)
+                {
+                    var expected = position >= keepStart && position < keepEnd;
+                    Assert.Equal(expected, window.KeepsPosition(position));
+                    if (window.IsPastEnd(position))
+                        Assert.False(expected);
+                }
+            }
+        }
+    }
 
     [Fact]
     public void Range_RefusesAnEndBeforeItsStart()
@@ -142,7 +198,7 @@ public class RowWindowTests
 
         static IEnumerable<MarkoutRowWindow> AllWindows()
         {
-            for (var n = -1; n <= 7; n++)
+            for (var n = 0; n <= 7; n++)
             {
                 yield return MarkoutRowWindow.Head(n);
                 yield return MarkoutRowWindow.Tail(n);
@@ -390,8 +446,11 @@ public class RowWindowTests
 
     private static IEnumerable<MarkoutRowWindow> AllWindowKinds() =>
     [
+        MarkoutRowWindow.Head(0),
         MarkoutRowWindow.Head(2),
+        MarkoutRowWindow.Tail(0),
         MarkoutRowWindow.Tail(2),
+        MarkoutRowWindow.Range(1, 1),
         MarkoutRowWindow.Range(2, 4),
         MarkoutRowWindow.Range(3, null),
         MarkoutRowWindow.Range(9, 12)
@@ -479,10 +538,10 @@ public class RowWindowTests
     }
 
     [Fact]
-    public void AnUnlimitedWindow_RendersEveryRow()
+    public void AWindowWiderThanTheTable_RendersEveryRow()
     {
         var output = Render(
-            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Head(-1) },
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Head(100) },
             Rows(4));
 
         Assert.Contains("r1", output);
@@ -556,9 +615,77 @@ public class RowWindowTests
     [Fact]
     public void AStreamingOnlyFormatter_WithoutAWindow_StillStreamsDirectly()
     {
-        var output = RenderStreamingOnly(new MarkoutWriterOptions(), Rows(3));
+        var sw = new StringWriter();
+        var writer = new TableWriter(sw, new StreamingOnlyFormatter(), new MarkoutWriterOptions());
+        writer.WriteTableStart(Header);
+        writer.WriteTableRow(["r1"]);
 
-        Assert.Contains("row:r1", output);
-        Assert.Contains("row:r3", output);
+        // Observed before the table ends: buffering-and-replaying would also satisfy
+        // an assertion made after WriteTableEnd, so checking afterwards would not
+        // distinguish direct streaming from the path this test exists to rule out.
+        Assert.Contains("row:r1", sw.ToString());
+
+        writer.WriteTableRow(["r2"]);
+        writer.WriteTableEnd();
+        Assert.Contains("row:r2", sw.ToString());
+    }
+
+    /// <summary>
+    /// The gate on windows not costing memory. A positional window decides each row as
+    /// it arrives, so rows must reach the formatter before the table ends; if they do
+    /// not, the writer is holding the table, and a Head(1) over a million rows retains
+    /// a million rows to emit one. Observing emission mid-table is the structural form
+    /// of that claim — a memory measurement would assert the same thing less reliably.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(PositionalWindows))]
+    public void APositionalWindow_ReachesTheFormatterBeforeTheTableEnds(MarkoutRowWindow window)
+    {
+        var sw = new StringWriter();
+        var writer = new TableWriter(sw, new StreamingOnlyFormatter(), new MarkoutWriterOptions { RowWindow = window });
+        writer.WriteTableStart(Header);
+
+        // Enough rows that every window under test has selected at least one.
+        for (var i = 1; i <= 5; i++)
+            writer.WriteTableRow(["r" + i]);
+
+        Assert.Contains("row:", sw.ToString());
+    }
+
+    public static TheoryData<MarkoutRowWindow> PositionalWindows() =>
+    [
+        MarkoutRowWindow.Head(2),
+        MarkoutRowWindow.Range(2, 4),
+        MarkoutRowWindow.Range(3, null)
+    ];
+
+    /// <summary>
+    /// The negative control for the test above: a Tail window is the one kind that
+    /// legitimately waits, so this pins that it waits rather than that waiting is fine.
+    /// </summary>
+    [Fact]
+    public void AWindowedStreamingOnlyFormatter_EmitsNothingUntilTheTableEnds()
+    {
+        var sw = new StringWriter();
+        var writer = new TableWriter(
+            sw,
+            new StreamingOnlyFormatter(),
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(2) });
+        writer.WriteTableStart(Header);
+        writer.WriteTableRow(["r1"]);
+
+        Assert.Equal("", sw.ToString());
+
+        writer.WriteTableEnd();
+        Assert.Contains("row:r1", sw.ToString());
+    }
+
+    [Fact]
+    public void ApplyingAnAbsentWindowToANullList_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => MarkoutRowWindow.Apply<string>(null, null!));
+        Assert.Throws<ArgumentNullException>(
+            () => MarkoutRowWindow.Apply<string>(MarkoutRowWindow.Head(2), null!));
     }
 }

--- a/tests/Markout.Tests/RowWindowTests.cs
+++ b/tests/Markout.Tests/RowWindowTests.cs
@@ -1,0 +1,564 @@
+using Markout;
+using Markout.Formatting;
+
+namespace Markout.Tests;
+
+/// <summary>
+/// Covers <see cref="MarkoutRowWindow"/> resolution and its application at the
+/// writer seam.
+///
+/// <para>
+/// The point of windowing at the seam is that every table mode inherits it from
+/// one resolution, so the coverage that matters here is not "a window works" but
+/// "a window works identically in <em>all</em> of them". A pass that only held
+/// for one mode is the defect this feature exists to remove, so the emission
+/// tests are Theories over <see cref="MarkoutTableMode"/> rather than a Fact
+/// about whichever mode was convenient.
+/// </para>
+/// </summary>
+public class RowWindowTests
+{
+    private static readonly string[] Header = ["Name"];
+
+    private static List<string[]> Rows(int count)
+    {
+        var rows = new List<string[]>(count);
+        for (var i = 1; i <= count; i++)
+            rows.Add([$"r{i}"]);
+        return rows;
+    }
+
+    private static string Render(MarkoutWriterOptions options, IList<string[]> rows)
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+        writer.WriteTable(Header, rows);
+        return sw.ToString();
+    }
+
+    private static string RenderStreaming(MarkoutWriterOptions options, IList<string[]> rows)
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(), options);
+        writer.WriteTableStart(Header);
+        foreach (var row in rows)
+            writer.WriteTableRow(row);
+        writer.WriteTableEnd();
+        return sw.ToString();
+    }
+
+    public static TheoryData<MarkoutTableMode> AllModes =>
+        new(Enum.GetValues<MarkoutTableMode>());
+
+    // ── Resolution ──
+
+    [Fact]
+    public void Head_KeepsLeadingRows()
+        => Assert.Equal((0, 2), MarkoutRowWindow.Head(2).Resolve(5));
+
+    [Fact]
+    public void Head_ClampsToTheRowsThatExist()
+        => Assert.Equal((0, 3), MarkoutRowWindow.Head(10).Resolve(3));
+
+    [Fact]
+    public void Tail_KeepsTrailingRows()
+        => Assert.Equal((3, 5), MarkoutRowWindow.Tail(2).Resolve(5));
+
+    [Fact]
+    public void Tail_ClampsToTheRowsThatExist()
+        => Assert.Equal((0, 3), MarkoutRowWindow.Tail(10).Resolve(3));
+
+    [Fact]
+    public void Range_IsOneBasedAndInclusive()
+        => Assert.Equal((1, 3), MarkoutRowWindow.Range(2, 3).Resolve(5));
+
+    [Fact]
+    public void Range_WithoutAnEnd_RunsToTheLastRow()
+        => Assert.Equal((1, 5), MarkoutRowWindow.Range(2, null).Resolve(5));
+
+    /// <summary>
+    /// An absolute range names row numbers, so a range past the end is not an
+    /// error — the rows it names are simply absent. Returning an empty window
+    /// rather than throwing is what lets a caller window a short table without
+    /// first checking how tall it is.
+    /// </summary>
+    [Fact]
+    public void Range_PastTheEnd_ResolvesEmptyRatherThanThrowing()
+        => Assert.Equal((3, 3), MarkoutRowWindow.Range(9, 12).Resolve(3));
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void ANegativeCount_MeansNoLimit(int count)
+    {
+        Assert.True(MarkoutRowWindow.Head(count).IsUnlimited);
+        Assert.True(MarkoutRowWindow.Tail(count).IsUnlimited);
+        Assert.Equal((0, 4), MarkoutRowWindow.Head(count).Resolve(4));
+        Assert.Equal((0, 4), MarkoutRowWindow.Tail(count).Resolve(4));
+    }
+
+    /// <summary>
+    /// A range always names a bounded start, so it is never "unlimited" even
+    /// when open-ended. If this regressed, an open-ended range would be skipped
+    /// entirely by the <c>IsUnlimited</c> fast path and silently keep every row.
+    /// </summary>
+    [Fact]
+    public void AnOpenEndedRange_IsNotUnlimited()
+        => Assert.False(MarkoutRowWindow.Range(2, null).IsUnlimited);
+
+    [Fact]
+    public void Range_RefusesAnEndBeforeItsStart()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => MarkoutRowWindow.Range(3, 2));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Range_RefusesAStartBeforeTheFirstRow(int start)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => MarkoutRowWindow.Range(start, null));
+
+    [Fact]
+    public void Resolve_RefusesANegativeRowCount()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => MarkoutRowWindow.Head(1).Resolve(-1));
+
+    /// <summary>
+    /// Callers use the resolved pair to slice without re-clamping, so the
+    /// ordering and bounds invariant is the contract, not an implementation
+    /// detail. Swept rather than spot-checked because the three kinds clamp on
+    /// different sides.
+    /// </summary>
+    [Fact]
+    public void Resolve_AlwaysReturnsAValidRange()
+    {
+        for (var dataCount = 0; dataCount <= 6; dataCount++)
+        {
+            foreach (var window in AllWindows())
+            {
+                var (keepStart, keepEnd) = window.Resolve(dataCount);
+                Assert.True(
+                    0 <= keepStart && keepStart <= keepEnd && keepEnd <= dataCount,
+                    $"{window.Kind} over {dataCount} rows resolved to ({keepStart}, {keepEnd})");
+            }
+        }
+
+        static IEnumerable<MarkoutRowWindow> AllWindows()
+        {
+            for (var n = -1; n <= 7; n++)
+            {
+                yield return MarkoutRowWindow.Head(n);
+                yield return MarkoutRowWindow.Tail(n);
+            }
+            for (var start = 1; start <= 7; start++)
+            {
+                yield return MarkoutRowWindow.Range(start, null);
+                for (var end = start; end <= 7; end++)
+                    yield return MarkoutRowWindow.Range(start, end);
+            }
+        }
+    }
+
+    // ── Emission, in every table mode ──
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void EveryTableMode_HonorsAHeadWindow(MarkoutTableMode mode)
+    {
+        var output = Render(
+            new MarkoutWriterOptions { TableMode = mode, RowWindow = MarkoutRowWindow.Head(2) },
+            Rows(5));
+
+        Assert.Contains("r1", output);
+        Assert.Contains("r2", output);
+        Assert.DoesNotContain("r3", output);
+        Assert.DoesNotContain("r5", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void EveryTableMode_HonorsATailWindow(MarkoutTableMode mode)
+    {
+        var output = Render(
+            new MarkoutWriterOptions { TableMode = mode, RowWindow = MarkoutRowWindow.Tail(2) },
+            Rows(5));
+
+        Assert.DoesNotContain("r1", output);
+        Assert.DoesNotContain("r3", output);
+        Assert.Contains("r4", output);
+        Assert.Contains("r5", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void EveryTableMode_HonorsARangeWindow(MarkoutTableMode mode)
+    {
+        var output = Render(
+            new MarkoutWriterOptions { TableMode = mode, RowWindow = MarkoutRowWindow.Range(2, 3) },
+            Rows(5));
+
+        Assert.DoesNotContain("r1", output);
+        Assert.Contains("r2", output);
+        Assert.Contains("r3", output);
+        Assert.DoesNotContain("r4", output);
+    }
+
+    /// <summary>
+    /// A window is selection, not summarization: its output has to stay
+    /// machine-consumable. An ellipsis appended to JSONL is a malformed record,
+    /// and a windowed table's row count must equal what a caller computing the
+    /// same window would report — which an ellipsis row breaks.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void AWindow_ReportsNoEllipsisAndNoSkippedCount(MarkoutTableMode mode)
+    {
+        var output = Render(
+            new MarkoutWriterOptions { TableMode = mode, RowWindow = MarkoutRowWindow.Head(2) },
+            Rows(5));
+
+        Assert.DoesNotContain("more", output);
+        Assert.DoesNotContain("...", output);
+    }
+
+    /// <summary>
+    /// The negative control for the test above: MaxItems on the same data does
+    /// announce what it dropped. Without this, "no ellipsis" would also pass on a
+    /// build where ellipsis reporting was broken outright.
+    /// </summary>
+    [Fact]
+    public void MaxItems_StillAnnouncesWhatItDropped()
+    {
+        var output = Render(new MarkoutWriterOptions { MaxItems = 2 }, Rows(5));
+
+        Assert.Contains("... and 3 more", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void AWindowPastTheEnd_KeepsTheHeaderAndEmitsNoRows(MarkoutTableMode mode)
+    {
+        var output = Render(
+            new MarkoutWriterOptions { TableMode = mode, RowWindow = MarkoutRowWindow.Range(9, 12) },
+            Rows(3));
+
+        Assert.DoesNotContain("r1", output);
+        Assert.DoesNotContain("r3", output);
+
+        // The header survives an empty window in every mode that has one. TSV
+        // and JSONL render headers as stable names, so this is deliberately
+        // case-insensitive; JSONL emits records only and has no header row.
+        if (mode != MarkoutTableMode.Jsonl)
+            Assert.Contains("name", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Interaction with MaxItems ──
+
+    /// <summary>
+    /// The window selects and MaxItems then caps the selection, so the ellipsis
+    /// counts only what the cap dropped. Were the order reversed, MaxItems would
+    /// cap rows 1-2 and the tail window would then select from those, yielding
+    /// r2 instead of r4.
+    /// </summary>
+    [Fact]
+    public void AWindowSelectsFirst_AndMaxItemsCapsTheSelection()
+    {
+        var output = Render(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(3), MaxItems = 2 },
+            Rows(6));
+
+        Assert.Contains("r4", output);
+        Assert.Contains("r5", output);
+        Assert.DoesNotContain("r6", output);
+        Assert.DoesNotContain("r2", output);
+        Assert.Contains("... and 1 more", output);
+    }
+
+    [Fact]
+    public void AWindowNarrowerThanMaxItems_LeavesNothingForTheCapToReport()
+    {
+        var output = Render(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Head(2), MaxItems = 10 },
+            Rows(6));
+
+        Assert.Contains("r2", output);
+        Assert.DoesNotContain("r3", output);
+        Assert.DoesNotContain("more", output);
+    }
+
+    // ── The streaming seam ──
+
+    /// <summary>
+    /// <see cref="TableFormatter"/> is batch-only, so the tests above exercise
+    /// buffered emission however rows are handed in. <see cref="MarkdownFormatter"/>
+    /// is the streaming formatter, and without a window it writes each row
+    /// straight through — which is the path a window has to interrupt.
+    /// </summary>
+    private static string RenderMarkdown(MarkoutWriterOptions options, IList<string[]> rows)
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new MarkdownFormatter(), options);
+        writer.WriteTable(Header, rows);
+        return sw.ToString();
+    }
+
+    private static string RenderMarkdownStreaming(MarkoutWriterOptions options, IList<string[]> rows)
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new MarkdownFormatter(), options);
+        writer.WriteTableStart(Header);
+        foreach (var row in rows)
+            writer.WriteTableRow(row);
+        writer.WriteTableEnd();
+        return sw.ToString();
+    }
+
+    [Fact]
+    public void Markdown_HonorsAWindow()
+    {
+        var output = RenderMarkdown(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Range(2, 3) },
+            Rows(5));
+
+        Assert.DoesNotContain("r1", output);
+        Assert.Contains("r2", output);
+        Assert.Contains("r3", output);
+        Assert.DoesNotContain("r4", output);
+    }
+
+    /// <summary>
+    /// The gate on forced buffering. Rows arriving one at a time cannot answer
+    /// "which are the last two" until the last one lands, so a window has to stop
+    /// the streaming formatter from writing rows straight through. Without that,
+    /// this emits all five rows and no window is applied at all.
+    /// </summary>
+    [Fact]
+    public void MarkdownStreamedRows_HonorATailWindow()
+    {
+        var options = new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(2) };
+        var output = RenderMarkdownStreaming(options, Rows(5));
+
+        Assert.DoesNotContain("r1", output);
+        Assert.DoesNotContain("r3", output);
+        Assert.Contains("r4", output);
+        Assert.Contains("r5", output);
+        Assert.Equal(RenderMarkdown(options, Rows(5)), output);
+    }
+
+    [Fact]
+    public void MarkdownStreamedRows_AgreeWithBatchedRowsForEveryWindowKind()
+    {
+        foreach (var window in AllWindowKinds())
+        {
+            var options = new MarkoutWriterOptions { RowWindow = window };
+            Assert.Equal(
+                RenderMarkdown(options, Rows(5)),
+                RenderMarkdownStreaming(options, Rows(5)));
+        }
+    }
+
+    /// <summary>
+    /// The gate on deferring MaxItems while a window is active. Capping rows as
+    /// they arrive would cap the wrong set: here the cap must apply to the three
+    /// rows the tail selected, not to the first two rows that happened to show up.
+    /// </summary>
+    [Fact]
+    public void MarkdownStreamedRows_CapTheSelectionRatherThanTheArrivals()
+    {
+        var output = RenderMarkdownStreaming(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(3), MaxItems = 2 },
+            Rows(6));
+
+        Assert.Contains("r4", output);
+        Assert.Contains("r5", output);
+        Assert.DoesNotContain("r1", output);
+        Assert.DoesNotContain("r6", output);
+        Assert.Contains("... and 1 more", output);
+    }
+
+    /// <summary>
+    /// The negative control for deferral: without a window MaxItems still caps as
+    /// rows arrive, so the streaming fast path keeps its existing behavior.
+    /// </summary>
+    [Fact]
+    public void MarkdownStreamedRows_WithoutAWindow_StillCapAsTheyArrive()
+    {
+        var options = new MarkoutWriterOptions { MaxItems = 2 };
+        var output = RenderMarkdownStreaming(options, Rows(5));
+
+        Assert.Contains("r1", output);
+        Assert.DoesNotContain("r3", output);
+        Assert.Contains("... and 3 more", output);
+    }
+
+    private static IEnumerable<MarkoutRowWindow> AllWindowKinds() =>
+    [
+        MarkoutRowWindow.Head(2),
+        MarkoutRowWindow.Tail(2),
+        MarkoutRowWindow.Range(2, 4),
+        MarkoutRowWindow.Range(3, null),
+        MarkoutRowWindow.Range(9, 12)
+    ];
+
+    /// <summary>
+    /// Rows arriving one at a time cannot answer "which are the last two" until
+    /// the last one lands, so the streaming path buffers when a window is set.
+    /// Tail is the case that fails if that buffering is dropped, and it must
+    /// agree exactly with the batch path.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void StreamedRows_HonorATailWindow(MarkoutTableMode mode)
+    {
+        var options = new MarkoutWriterOptions { TableMode = mode, RowWindow = MarkoutRowWindow.Tail(2) };
+
+        Assert.Equal(
+            Render(options, Rows(5)),
+            RenderStreaming(options, Rows(5)));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void StreamedRows_AgreeWithBatchedRowsForEveryWindowKind(MarkoutTableMode mode)
+    {
+        foreach (var window in AllWindowKinds())
+        {
+            var options = new MarkoutWriterOptions { TableMode = mode, RowWindow = window };
+            Assert.Equal(
+                Render(options, Rows(5)),
+                RenderStreaming(options, Rows(5)));
+        }
+    }
+
+    // ── Options plumbing ──
+
+    [Fact]
+    public void AReadOnlyInstance_RefusesAWindow()
+    {
+        var options = new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Range(2, 4) };
+        options.MakeReadOnly();
+
+        Assert.Throws<InvalidOperationException>(() => options.RowWindow = MarkoutRowWindow.Head(1));
+    }
+
+    /// <summary>
+    /// <c>WriteCompositeTable</c> takes the JSON identity-column path, which
+    /// rebuilds the options into a fresh instance before constructing the table
+    /// writer (<c>MarkoutWriter.ResolveIdentityColumns</c>). A window that the
+    /// copy failed to carry would be dropped there with no error and no
+    /// diagnostic — the table would simply render in full. This is the gate on
+    /// that copy.
+    /// </summary>
+    [Fact]
+    public void AWindow_SurvivesTheIdentityColumnOptionsCopy()
+    {
+        var sw = new StringWriter();
+        var writer = MarkoutWriter.Create(sw, new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = MarkoutTableMode.Jsonl,
+                RowWindow = MarkoutRowWindow.Tail(1)
+            });
+
+        writer.WriteCompositeTable(
+            MarkoutCompositeRow.Scalar("first", "1"),
+            MarkoutCompositeRow.Scalar("second", "2"),
+            MarkoutCompositeRow.Scalar("third", "3"));
+
+        var lines = sw.ToString().ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Single(lines);
+        Assert.Contains("third", lines[0]);
+        Assert.DoesNotContain("first", lines[0]);
+    }
+
+    [Fact]
+    public void NoWindow_RendersEveryRow()
+    {
+        var output = Render(new MarkoutWriterOptions(), Rows(4));
+
+        Assert.Contains("r1", output);
+        Assert.Contains("r4", output);
+    }
+
+    [Fact]
+    public void AnUnlimitedWindow_RendersEveryRow()
+    {
+        var output = Render(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Head(-1) },
+            Rows(4));
+
+        Assert.Contains("r1", output);
+        Assert.Contains("r4", output);
+    }
+
+    // ── Streaming-only formatters ──
+
+    /// <summary>
+    /// A formatter that implements only <see cref="IStreamingTableFormatter"/>.
+    /// Every formatter in this repository also reaches <see cref="ITableFormatter"/>
+    /// (<see cref="IDocumentFormatter"/> inherits it), so none of them exercise the
+    /// buffered-replay path. The streaming-only <see cref="TableWriter"/> constructor
+    /// is public API, though, so an external formatter can land there — and forcing
+    /// buffering for a window would drop its entire table without that replay.
+    /// </summary>
+    private sealed class StreamingOnlyFormatter : IStreamingTableFormatter
+    {
+        public void BeginTable(TextWriter writer, ReadOnlySpan<string> headers, MarkoutWriterOptions options)
+            => writer.WriteLine("begin:" + string.Join(",", headers.ToArray()));
+
+        public void WriteRow(TextWriter writer, ReadOnlySpan<string> values)
+            => writer.WriteLine("row:" + string.Join(",", values.ToArray()));
+
+        public void EndTable(TextWriter writer, int skippedRows)
+            => writer.WriteLine("end:" + skippedRows);
+    }
+
+    private static string RenderStreamingOnly(MarkoutWriterOptions options, IList<string[]> rows)
+    {
+        var sw = new StringWriter();
+        var writer = new TableWriter(sw, new StreamingOnlyFormatter(), options);
+        writer.WriteTableStart(Header);
+        foreach (var row in rows)
+            writer.WriteTableRow(row);
+        writer.WriteTableEnd();
+        return sw.ToString();
+    }
+
+    [Fact]
+    public void AStreamingOnlyFormatter_StillEmitsTheWindowedTable()
+    {
+        var output = RenderStreamingOnly(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(2) },
+            Rows(5));
+
+        Assert.Contains("begin:Name", output);
+        Assert.Contains("row:r4", output);
+        Assert.Contains("row:r5", output);
+        Assert.DoesNotContain("row:r1", output);
+        Assert.Contains("end:0", output);
+    }
+
+    [Fact]
+    public void AStreamingOnlyFormatter_ReportsWhatMaxItemsDroppedFromTheWindow()
+    {
+        var output = RenderStreamingOnly(
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(3), MaxItems = 2 },
+            Rows(6));
+
+        Assert.Contains("row:r4", output);
+        Assert.Contains("row:r5", output);
+        Assert.DoesNotContain("row:r6", output);
+        Assert.Contains("end:1", output);
+    }
+
+    /// <summary>
+    /// The negative control: without a window the streaming-only formatter keeps
+    /// writing rows straight through rather than being routed via the replay.
+    /// </summary>
+    [Fact]
+    public void AStreamingOnlyFormatter_WithoutAWindow_StillStreamsDirectly()
+    {
+        var output = RenderStreamingOnly(new MarkoutWriterOptions(), Rows(3));
+
+        Assert.Contains("row:r1", output);
+        Assert.Contains("row:r3", output);
+    }
+}


### PR DESCRIPTION
Slice 1 of 2 for #178. Adds row windowing at the writer seam. **SectionOrder is deferred to a stacked follow-up** that will branch from this one.

## The claim

`MarkoutWriterOptions.RowWindow` selects which rows a table contains, resolved once for every table mode and every formatter. `find --rows 40..60` becomes a writer option instead of a regex over rendered Markdown.

`MaxItems` is Markout's only row control today, and it *summarizes* — it caps a table and announces what it dropped. There is no way to *select*. So adopters post-process rendered text, and #178 counts four independent implementations of "what is a row" doing that, each re-deriving the answer from output that has already lost the structure.

| Factory | Selects |
| --- | --- |
| `MarkoutRowWindow.Head(n)` | first `n` rows |
| `MarkoutRowWindow.Tail(n)` | last `n` rows |
| `MarkoutRowWindow.Range(start, end)` | rows `[start, end)`, 0-based, `end: null` runs to the end |

A negative count means unlimited. When both are set, **the window selects and `MaxItems` caps the selection**, so the reported overflow count describes only what the cap dropped.

## Why it forces buffering

The whole point is that the semantics are interpreted in **one place** — `MarkoutRowWindow.Resolve`, against a known row count. Implementing windowing twice inside Markout (once for batch, once positionally for streaming) would reproduce the defect the issue is about. So a window forces streamed rows to buffer: `Tail` and an open-ended `Range` are defined against a total that isn't known until the last row arrives. `TableOptions` already forces buffering in the same method for its own reason.

Consequence worth stating: TSV and JSONL inherit the window from that one resolution, so a windowed table in those modes stays machine-consumable — selection introduces no ellipsis row and no skipped count.

## Latent bug fixed

`WriteTableEnd` only emitted buffered rows when a batch formatter was present. A streaming-only formatter forced into buffering would have silently dropped its **entire table**. No formatter here hits that today (`IDocumentFormatter` inherits `ITableFormatter`, so all of them reach the batch branch), but the streaming-only `TableWriter` constructor is public API.

## Evidence

888 `Markout.Tests`, 236 `MarkdownTable.Tests`, 122 `Markout.Templates.Tests` — all passing.

Each of the five mechanisms was **tamper-tested**: disabled in the source, then confirmed to produce failures.

| Mechanism | Tests that caught its removal |
| --- | --- |
| Window application in `SelectRows` | 15 |
| `_rowWindow` in the options copy constructor | 1 |
| Forced buffering for streaming | 3 |
| Deferred `MaxItems` under a window | 1 |
| Buffered replay for streaming-only formatters | 2 |

**Two of those found real gaps rather than confirming the code**, and are the reason this took another pass:

- Forced buffering produced **no failures** at first. The streaming tests used `TableFormatter`, which is batch-only — so they never reached the direct-streaming path they claimed to test. Now covered via `MarkdownFormatter`.
- Buffered replay produced **no failures** either: deleting it entirely still emitted every row. `IDocumentFormatter : ITableFormatter`, so no formatter in the repo reaches that branch. It's now gated by a test double built on the public streaming-only constructor.

Also gated: `AWindow_SurvivesTheIdentityColumnOptionsCopy`, because `MarkoutWriter.ResolveIdentityColumns` copies options and *that copy* builds the `TableWriter` — a window would be silently lost on the JSONL composite-cell path without the copy-constructor line.

## Declared residual

Not addressed in this slice, and the adopter should not delete its text-based row limiter until it is:

- `MarkdownFormatter` metrics/breakdown lowerings and `TableFormatter`'s graph edge table call `FormatTable` **directly**, bypassing `TableWriter`, so they are not windowed. The issue scopes the window to table *modes* (all covered), but dotnet-inspect's current text limiter does window those too.
- `SectionOrder` — the other half of #178 — is the stacked follow-up.