### PR TITLE
Add Markdown graph rendering modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Markout ships five formatters. The serializer writes through `MarkoutWriter` (th
 
 | Formatter | Output | Use case |
 |---|---|---|
-| **MarkdownFormatter** | GitHub-Flavored Markdown | Documentation, LLM tool output, rendered reports |
+| **MarkdownFormatter** | GitHub-Flavored Markdown; graphs as edge tables or fenced Mermaid | Documentation, LLM tool output, rendered reports |
 | **PlainTextFormatter** | Plain text without markup | Minimal output, no syntax characters |
 | **UnicodeFormatter** | Box-drawing characters | Rich tables with borders, no color |
 | **TableFormatter** | Tables, lists, fields | Compact summaries, pretty tables, TSV/JSONL rows |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,6 +15,9 @@ Markout is a source-generated .NET serializer for projecting object graphs into 
 ## Output contract
 
 - Markdown is the primary readable document format.
+- Markdown renders `Graph` as an edge table by default. Pass
+  `MarkdownGraphMode.Mermaid` to `MarkdownFormatter` to embed the same graph as
+  a fenced Mermaid diagram.
 - `TableFormatter` renders compact table projections. `MarkoutTableMode.Pretty` uses display headers and space-padded columns. `MarkoutTableMode.Tsv` emits normalized TSV with stable snake_case headers.
 - Markdown table cell pipes are normalized to `&#124;`, not escaped as `\|`.
 - TSV cells never contain embedded tabs or newlines.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -883,7 +883,18 @@ Each formatter renders the graph as whatever its format can express:
 |---|---|
 | `MermaidFormatter` | `graph TD` flowchart; focus declared first, groups as subgraphs |
 | `TableFormatter` | edge table, one row per edge |
-| `MarkdownFormatter`, `PlainTextFormatter`, `DiagramFormatter`, `UnicodeFormatter` | tree rooted at the focus node |
+| `MarkdownFormatter` | Markdown edge table by default; fenced Mermaid with `MarkdownGraphMode.Mermaid` |
+| `PlainTextFormatter`, `DiagramFormatter`, `UnicodeFormatter` | tree rooted at the focus node |
+
+Use one graph model for either Markdown presentation:
+
+```csharp
+var table = new MarkdownFormatter();
+var diagram = new MarkdownFormatter(MarkdownGraphMode.Mermaid);
+```
+
+The Mermaid mode writes a fenced `mermaid` code block, so the graph can compose
+with headings, fields, and other sections in the same Markdown document.
 
 `GraphLowering` exposes those projections directly, so a custom formatter can reuse them:
 

--- a/skills/markout-built-in-shapes/SKILL.md
+++ b/skills/markout-built-in-shapes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-built-in-shapes
-version: 0.35.0
+version: 0.35.1
 description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn

--- a/skills/markout-composite-cells-cards/SKILL.md
+++ b/skills/markout-composite-cells-cards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-composite-cells-cards
-version: 0.35.0
+version: 0.35.1
 description: >-
   Use when a single value must render dense in Markdown but decompose into typed columns in
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas

--- a/skills/markout-conditional-composition/SKILL.md
+++ b/skills/markout-conditional-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-conditional-composition
-version: 0.35.0
+version: 0.35.1
 description: >-
   Use when a Markout report must adapt to its data — show or hide whole sections, drop table
   columns that are empty/uniform, filter output to a chosen set of sections, or render one

--- a/skills/markout-output-formats/SKILL.md
+++ b/skills/markout-output-formats/SKILL.md
@@ -56,6 +56,17 @@ MarkoutSerializer.Serialize(r, Console.Out, new SpectreFormatter(AnsiConsole.Con
 
 `Markout.Ansi.Spectre` is a separate NuGet package; Markdown/plain/table/TSV/JSONL need only `Markout`.
 
+`Graph` sections become Markdown edge tables by default. To embed the same
+graph as Mermaid without rebuilding it, select the Markdown graph mode:
+
+```csharp
+MarkoutSerializer.Serialize(
+    report,
+    Console.Out,
+    new MarkdownFormatter(MarkdownGraphMode.Mermaid),
+    ctx);
+```
+
 ## TableFormatter modes + writer options
 
 `TableFormatter` + `MarkoutWriterOptions.TableMode` selects the tabular shape:

--- a/skills/markout-output-formats/SKILL.md
+++ b/skills/markout-output-formats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-output-formats
-version: 0.35.0
+version: 0.35.1
 description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout
-version: 0.35.0
+version: 0.35.1
 description: >-
   Use when generating Markdown or other structured output (plain text, ANSI, pretty tables,
   TSV/JSONL) from C# objects instead of hand-built strings — CLIs, tools, reports, agent

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Markout library skills: one base skill, markout; four workflow-specific skills, markout-conditional-composition, markout-output-formats, markout-built-in-shapes, markout-composite-cells-cards. Each workflow-specific skill carries the required serializer-context setup so it works on its own; the base skill is the fuller treatment of the library.",
   "skills": ["."]
 }

--- a/src/Markout/Formatting/IGraphTableLowering.cs
+++ b/src/Markout/Formatting/IGraphTableLowering.cs
@@ -1,0 +1,9 @@
+namespace Markout.Formatting;
+
+/// <summary>
+/// Lets the writer route a graph's table lowering through the normal table pipeline.
+/// </summary>
+internal interface IGraphTableLowering
+{
+    bool TryLowerGraphToTable(Graph graph, out GraphLowering.GraphEdgeTable table);
+}

--- a/src/Markout/Formatting/IGraphTableLowering.cs
+++ b/src/Markout/Formatting/IGraphTableLowering.cs
@@ -1,9 +1,0 @@
-namespace Markout.Formatting;
-
-/// <summary>
-/// Lets the writer route a graph's table lowering through the normal table pipeline.
-/// </summary>
-internal interface IGraphTableLowering
-{
-    bool TryLowerGraphToTable(Graph graph, out GraphLowering.GraphEdgeTable table);
-}

--- a/src/Markout/GraphLowering.cs
+++ b/src/Markout/GraphLowering.cs
@@ -21,6 +21,10 @@ public static class GraphLowering
     /// </param>
     public readonly record struct GraphEdgeTable(ImmutableArray<string> Headers, List<string[]> Rows);
 
+    internal readonly record struct DeferredGraphEdgeTable(
+        ImmutableArray<string> Headers,
+        IEnumerable<string[]> Rows);
+
     /// <summary>
     /// Projects the graph as one row per edge, plus one row per isolated node.
     /// </summary>
@@ -42,6 +46,14 @@ public static class GraphLowering
     /// Defaults to <see cref="GraphNode.Label"/>.
     /// </param>
     public static GraphEdgeTable ToEdgeTable(Graph graph, Func<GraphNode, string>? label = null)
+    {
+        var deferred = ToDeferredEdgeTable(graph, label);
+        return new GraphEdgeTable(deferred.Headers, deferred.Rows.ToList());
+    }
+
+    internal static DeferredGraphEdgeTable ToDeferredEdgeTable(
+        Graph graph,
+        Func<GraphNode, string>? label = null)
     {
         ArgumentNullException.ThrowIfNull(graph);
         // A caller-supplied selector is not trusted to be total; a null cell would fault the
@@ -77,8 +89,19 @@ public static class GraphLowering
         if (hasGroups) headers.Add("To Group");
         if (hasEdgeLabels) headers.Add("Label");
 
+        return new DeferredGraphEdgeTable(
+            headers.ToImmutable(),
+            Rows(graph, select, headers.Count, hasGroups, hasEdgeLabels));
+    }
+
+    private static IEnumerable<string[]> Rows(
+        Graph graph,
+        Func<GraphNode, string> select,
+        int columnCount,
+        bool hasGroups,
+        bool hasEdgeLabels)
+    {
         var connected = new HashSet<string>(StringComparer.Ordinal);
-        var rows = new List<string[]>(graph.Edges.Length);
         foreach (var edge in graph.Edges)
         {
             var from = graph[edge.From];
@@ -86,14 +109,14 @@ public static class GraphLowering
             connected.Add(edge.From);
             connected.Add(edge.To);
 
-            var row = new string[headers.Count];
+            var row = new string[columnCount];
             var i = 0;
             row[i++] = select(from);
             if (hasGroups) row[i++] = from.Group ?? "";
             row[i++] = select(to);
             if (hasGroups) row[i++] = to.Group ?? "";
             if (hasEdgeLabels) row[i] = edge.Label ?? "";
-            rows.Add(row);
+            yield return row;
         }
 
         foreach (var node in graph.Nodes)
@@ -101,17 +124,15 @@ public static class GraphLowering
             if (connected.Contains(node.Key))
                 continue;
 
-            var row = new string[headers.Count];
+            var row = new string[columnCount];
             var i = 0;
             row[i++] = select(node);
             if (hasGroups) row[i++] = node.Group ?? "";
             row[i++] = "";
             if (hasGroups) row[i++] = "";
             if (hasEdgeLabels) row[i] = "";
-            rows.Add(row);
+            yield return row;
         }
-
-        return new GraphEdgeTable(headers.ToImmutable(), rows);
     }
 
     /// <summary>

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -11,7 +11,7 @@ namespace Markout;
 /// </summary>
 public class MarkdownFormatter : IMarkoutFormatter,
     IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter, IGlyphFormatter, IEmphasisFormatter,
-    IGraphFormatter, IGraphTableLowering
+    IGraphFormatter
 {
     private const int CellPadding = 2; // leading space + trailing space
     private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
@@ -542,13 +542,17 @@ public class MarkdownFormatter : IMarkoutFormatter,
             return;
         }
 
-        ((IGraphTableLowering)this).TryLowerGraphToTable(graph, out var table);
-        new TableWriter(w, (ITableFormatter)this, options).WriteTable(table.Headers.AsSpan(), table.Rows);
+        var table = GraphLowering.ToEdgeTable(
+            graph,
+            node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
+        new TableWriter(w, (IStreamingTableFormatter)this, options).WriteTable(
+            table.Headers.AsSpan(),
+            table.Rows);
     }
 
-    bool IGraphTableLowering.TryLowerGraphToTable(
+    internal bool TryLowerGraphToTable(
         Graph graph,
-        out GraphLowering.GraphEdgeTable table)
+        out GraphLowering.DeferredGraphEdgeTable table)
     {
         if (_graphMode != MarkdownGraphMode.EdgeTable)
         {
@@ -556,7 +560,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
             return false;
         }
 
-        table = GraphLowering.ToEdgeTable(
+        table = GraphLowering.ToDeferredEdgeTable(
             graph,
             node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
         return true;

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -10,7 +10,8 @@ namespace Markout;
 /// ``` code fences, and trailing double-space hard line breaks.
 /// </summary>
 public class MarkdownFormatter : IMarkoutFormatter,
-    IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter, IGlyphFormatter, IEmphasisFormatter, IGraphFormatter
+    IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter, IGlyphFormatter, IEmphasisFormatter,
+    IGraphFormatter, IGraphTableLowering
 {
     private const int CellPadding = 2; // leading space + trailing space
     private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
@@ -541,10 +542,24 @@ public class MarkdownFormatter : IMarkoutFormatter,
             return;
         }
 
-        var table = GraphLowering.ToEdgeTable(
+        ((IGraphTableLowering)this).TryLowerGraphToTable(graph, out var table);
+        new TableWriter(w, (ITableFormatter)this, options).WriteTable(table.Headers.AsSpan(), table.Rows);
+    }
+
+    bool IGraphTableLowering.TryLowerGraphToTable(
+        Graph graph,
+        out GraphLowering.GraphEdgeTable table)
+    {
+        if (_graphMode != MarkdownGraphMode.EdgeTable)
+        {
+            table = default;
+            return false;
+        }
+
+        table = GraphLowering.ToEdgeTable(
             graph,
             node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
-        ((ITableFormatter)this).FormatTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, options);
+        return true;
     }
 
     // ── ITreeFormatter ──

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -14,6 +14,27 @@ public class MarkdownFormatter : IMarkoutFormatter,
 {
     private const int CellPadding = 2; // leading space + trailing space
     private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
+    private readonly MarkdownGraphMode _graphMode;
+
+    /// <summary>
+    /// Creates a Markdown formatter that renders graphs as edge tables.
+    /// </summary>
+    public MarkdownFormatter()
+        : this(MarkdownGraphMode.EdgeTable)
+    {
+    }
+
+    /// <summary>
+    /// Creates a Markdown formatter with the requested graph lowering.
+    /// </summary>
+    /// <param name="graphMode">How graphs are rendered inside the Markdown document.</param>
+    public MarkdownFormatter(MarkdownGraphMode graphMode)
+    {
+        if (!Enum.IsDefined(graphMode))
+            throw new ArgumentOutOfRangeException(nameof(graphMode));
+
+        _graphMode = graphMode;
+    }
 
     // ── IEmphasisFormatter ──
 
@@ -505,18 +526,26 @@ public class MarkdownFormatter : IMarkoutFormatter,
     // ── IGraphFormatter ──
 
     /// <summary>
-    /// Renders the graph as a nested list, the same lowering the other prose formatters use.
-    /// Markdown can express both a nested list and a table; the list names each node once and keeps
-    /// reachability readable, where an edge table repeats every label on both sides of every edge.
-    /// The tabular formatters own the edge-table view for callers that want one row per edge.
+    /// Renders the graph as either an edge table or a fenced Mermaid diagram.
     /// </summary>
     void IGraphFormatter.FormatGraph(TextWriter w, Graph graph, MarkoutWriterOptions options)
-        => ((ITreeFormatter)this).FormatTree(
-            w,
-            GraphLowering.ToTree(
-                graph,
-                node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label).AsSpan(),
-            options);
+    {
+        if (graph.IsEmpty)
+            return;
+
+        if (_graphMode == MarkdownGraphMode.Mermaid)
+        {
+            ((ICodeBlockFormatter)this).FormatCodeStart(w, "mermaid");
+            ((IGraphFormatter)new MermaidFormatter()).FormatGraph(w, graph, options);
+            ((ICodeBlockFormatter)this).FormatCodeEnd(w);
+            return;
+        }
+
+        var table = GraphLowering.ToEdgeTable(
+            graph,
+            node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
+        ((ITableFormatter)this).FormatTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, options);
+    }
 
     // ── ITreeFormatter ──
 

--- a/src/Markout/MarkdownGraphMode.cs
+++ b/src/Markout/MarkdownGraphMode.cs
@@ -1,0 +1,17 @@
+namespace Markout;
+
+/// <summary>
+/// Selects how a <see cref="Graph"/> is rendered inside a Markdown document.
+/// </summary>
+public enum MarkdownGraphMode
+{
+    /// <summary>
+    /// Render one Markdown table row per directed edge.
+    /// </summary>
+    EdgeTable,
+
+    /// <summary>
+    /// Render a Mermaid flowchart inside a fenced <c>mermaid</c> code block.
+    /// </summary>
+    Mermaid
+}

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -73,13 +73,15 @@
         <SkillName>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(FullPath)'))))</SkillName>
       </_ShelfSkill>
     </ItemGroup>
-    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D', '').Contains('%0Aversion: $(Version)%0A'))"
+    <Error Condition="$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D%0A', '').Contains('%0D'))"
+           Text="skills/%(_ShelfSkill.SkillName)/SKILL.md contains a standalone carriage return. Use LF or CRLF line endings so frontmatter validation cannot reinterpret malformed keys." />
+    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D%0A', '%0A').Contains('%0Aversion: $(Version)%0A'))"
            Text="skills/%(_ShelfSkill.SkillName)/SKILL.md does not carry 'version: $(Version)'. The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
     <Error Condition="!$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\skills\plugin.json').Contains('&quot;version&quot;: &quot;$(Version)&quot;'))"
            Text="skills/plugin.json does not carry version $(Version). The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
     <Error Condition="'%(_ShelfSkill.SkillName)' != 'markout' AND !$([System.String]::new('%(_ShelfSkill.SkillName)').StartsWith('markout-'))"
            Text="skills/%(_ShelfSkill.SkillName)/ is not named for the package. Skill names share one flat namespace in a consuming repo, so the base skill must be 'markout' and every workflow skill 'markout-&lt;domain&gt;'." />
-    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D', '').Contains('%0Aname: %(_ShelfSkill.SkillName)%0A'))"
+    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D%0A', '%0A').Contains('%0Aname: %(_ShelfSkill.SkillName)%0A'))"
            Text="skills/%(_ShelfSkill.SkillName)/SKILL.md declares a frontmatter 'name' that is not its directory name. A skill is addressed by that name, so the two must be the same string." />
   </Target>
 

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -9,8 +9,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.35.0</Version>
-    <PackageReleaseNotes>Adds the MarkoutTable built-in shape: a table whose columns are runtime data (headers and rows) rather than a fixed set of attributed properties. Attach a MarkoutTable-typed model property with [MarkoutSection] and the source generator routes it through the writer like any generated table, so it participates in section ordering, row windowing, column projection, inclusion filtering, and TSV/JSONL decomposition with no imperative writer calls. Combined with [MarkoutUnwrap] over a list of title-bearing elements, a caller can emit a runtime-determined set of named sections, each carrying a runtime-column table, entirely through the serializer model. A MarkoutTable validates its own invariants at construction: every row must carry exactly one cell per header, and no two columns may share a canonical structured key, because a mismatched row rendered differently in each format and colliding keys emitted JSONL a consumer could only read the last value from. Table headers are now escaped the same way cells are, which matters because a MarkoutTable header is runtime text that could otherwise change the column count or end the table. BEHAVIOR CHANGE: a column projection that matches none of an individual table's columns now renders that table as nothing instead of throwing. Throwing made a document with heterogeneous sections impossible to project at all -- any projection naming one section's columns aborted the whole render. Projection is an allow list, so a table with nothing the caller asked for contributes nothing, and the sections the projection does match render normally. Reach is still checked, but per document rather than per table: a projection that matches nothing anywhere in a document that had tables to offer it still throws when the document is finished, because that names columns the document does not have and is almost always a typo. A document with no tables at all leaves the projection vacuous and does not throw. A projection may also now be spelled with the canonical snake_case keys that TSV and JSONL actually emit, so a projection copied from structured output matches instead of silently selecting the wrong columns.</PackageReleaseNotes>
+    <Version>0.35.1</Version>
+    <PackageReleaseNotes>Markdown graphs now render as edge tables by default and can opt into fenced Mermaid with MarkdownGraphMode.Mermaid. Built-in graph tables flow through the normal table pipeline, so column projection, row windows, limits, ordering, and structured header formatting apply consistently without rebuilding the graph. Custom formatter subclasses retain their graph overrides, and projection rejects graph tables before edge rows are materialized.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -73,13 +73,13 @@
         <SkillName>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(FullPath)'))))</SkillName>
       </_ShelfSkill>
     </ItemGroup>
-    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Contains('%0Aversion: $(Version)%0A'))"
+    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D', '').Contains('%0Aversion: $(Version)%0A'))"
            Text="skills/%(_ShelfSkill.SkillName)/SKILL.md does not carry 'version: $(Version)'. The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
     <Error Condition="!$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)..\..\skills\plugin.json').Contains('&quot;version&quot;: &quot;$(Version)&quot;'))"
            Text="skills/plugin.json does not carry version $(Version). The packed shelf would misstate which release it describes. Bump the stamp with &lt;Version&gt;." />
     <Error Condition="'%(_ShelfSkill.SkillName)' != 'markout' AND !$([System.String]::new('%(_ShelfSkill.SkillName)').StartsWith('markout-'))"
            Text="skills/%(_ShelfSkill.SkillName)/ is not named for the package. Skill names share one flat namespace in a consuming repo, so the base skill must be 'markout' and every workflow skill 'markout-&lt;domain&gt;'." />
-    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Contains('%0Aname: %(_ShelfSkill.SkillName)%0A'))"
+    <Error Condition="!$([System.IO.File]::ReadAllText('%(_ShelfSkill.FullPath)').Replace('%0D', '').Contains('%0Aname: %(_ShelfSkill.SkillName)%0A'))"
            Text="skills/%(_ShelfSkill.SkillName)/SKILL.md declares a frontmatter 'name' that is not its directory name. A skill is addressed by that name, so the two must be the same string." />
   </Target>
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -1728,6 +1728,12 @@ public class MarkoutWriter
         if (graph.IsEmpty || _sectionExcluded)
             return true;
 
+        if (_formatter is IGraphTableLowering tableLowering
+            && tableLowering.TryLowerGraphToTable(graph, out var table))
+        {
+            return WriteTable(table.Headers, table.Rows);
+        }
+
         if (_formatter is not IGraphFormatter gf)
             return false;
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -1728,8 +1728,13 @@ public class MarkoutWriter
         if (graph.IsEmpty || _sectionExcluded)
             return true;
 
-        if (_formatter is IGraphTableLowering tableLowering
-            && tableLowering.TryLowerGraphToTable(graph, out var table))
+        GraphLowering.DeferredGraphEdgeTable table = default;
+        bool hasTable =
+            _formatter.GetType() == typeof(MarkdownFormatter)
+                ? ((MarkdownFormatter)_formatter).TryLowerGraphToTable(graph, out table)
+                : _formatter.GetType() == typeof(TableFormatter)
+                    && ((TableFormatter)_formatter).TryLowerGraphToTable(graph, out table);
+        if (hasTable)
         {
             return WriteTable(table.Headers, table.Rows);
         }

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -10,7 +10,8 @@ namespace Markout;
 /// Formatter for compact tabular output. It can render normalized TSV or a pretty
 /// space-padded table from the same row/column projection.
 /// </summary>
-public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter, ICompositeCellFormatter, IGraphFormatter
+public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter,
+    ICompositeCellFormatter, IGraphFormatter, IGraphTableLowering
 {
     // ── IGraphFormatter ──
 
@@ -23,9 +24,18 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         if (graph.IsEmpty)
             return;
 
-        var table = GraphLowering.ToEdgeTable(graph);
-        ((ITableFormatter)this).FormatTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, options);
+        ((IGraphTableLowering)this).TryLowerGraphToTable(graph, out var table);
+        new TableWriter(w, (ITableFormatter)this, options).WriteTable(table.Headers.AsSpan(), table.Rows);
     }
+
+    bool IGraphTableLowering.TryLowerGraphToTable(
+        Graph graph,
+        out GraphLowering.GraphEdgeTable table)
+    {
+        table = GraphLowering.ToEdgeTable(graph);
+        return true;
+    }
+
     private const int ColumnGap = 2;
 
     /// <summary>Structured output decomposes composite cells into typed columns.</summary>

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -11,7 +11,7 @@ namespace Markout;
 /// space-padded table from the same row/column projection.
 /// </summary>
 public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter,
-    ICompositeCellFormatter, IGraphFormatter, IGraphTableLowering
+    ICompositeCellFormatter, IGraphFormatter
 {
     // ── IGraphFormatter ──
 
@@ -24,15 +24,15 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         if (graph.IsEmpty)
             return;
 
-        ((IGraphTableLowering)this).TryLowerGraphToTable(graph, out var table);
+        var table = GraphLowering.ToEdgeTable(graph);
         new TableWriter(w, (ITableFormatter)this, options).WriteTable(table.Headers.AsSpan(), table.Rows);
     }
 
-    bool IGraphTableLowering.TryLowerGraphToTable(
+    internal bool TryLowerGraphToTable(
         Graph graph,
-        out GraphLowering.GraphEdgeTable table)
+        out GraphLowering.DeferredGraphEdgeTable table)
     {
-        table = GraphLowering.ToEdgeTable(graph);
+        table = GraphLowering.ToDeferredEdgeTable(graph);
         return true;
     }
 

--- a/tests/Markout.Tests/GeneratedGraphTests.cs
+++ b/tests/Markout.Tests/GeneratedGraphTests.cs
@@ -40,10 +40,28 @@ public class GeneratedGraphTests
         var mdf = MarkoutSerializer.Serialize(Sample(), GraphContext.Default);
 
         Assert.Contains("## Call Graph", mdf, StringComparison.Ordinal);
-        // Markdown lowers a graph to its tree projection.
-        Assert.Contains("└─ B", mdf, StringComparison.Ordinal);
-        Assert.Contains("A", mdf, StringComparison.Ordinal);
+        Assert.Contains("| From | To |", mdf, StringComparison.Ordinal);
+        Assert.Contains("| A | B |", mdf, StringComparison.Ordinal);
         Assert.DoesNotContain("No calls found.", mdf, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GraphProperty_ComposesAsEmbeddedMermaidInMarkdown()
+    {
+        var sink = new StringWriter();
+        MarkoutSerializer.Serialize(
+            Sample(),
+            sink,
+            new MarkdownFormatter(MarkdownGraphMode.Mermaid),
+            GraphContext.Default);
+        var output = sink.ToString();
+
+        Assert.Contains("| Member | Run |", output, StringComparison.Ordinal);
+        Assert.Contains("## Call Graph", output, StringComparison.Ordinal);
+        Assert.Contains("```mermaid", output, StringComparison.Ordinal);
+        Assert.Contains("graph TD", output, StringComparison.Ordinal);
+        Assert.Contains("n0 --> n1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("| From | To |", output, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -456,6 +456,57 @@ public class GraphTests
     }
 
     [Fact]
+    public void MarkdownEdgeTable_HonorsTableProjectionAndRowLimits()
+    {
+        var orch = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions
+            {
+                MaxItems = 1,
+                Projection = new MarkoutProjection { IncludeColumns = ["To"] },
+            });
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = orch.ToString();
+        Assert.Contains("| To |", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("| From |", output, StringComparison.Ordinal);
+        Assert.Contains("| B |", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("| C |", output, StringComparison.Ordinal);
+        Assert.Contains("1 more", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmbeddedMermaid_IgnoresTableProjectionAndRowLimits()
+    {
+        var orch = MarkoutWriter.Create(
+            new MarkdownFormatter(MarkdownGraphMode.Mermaid),
+            new MarkoutWriterOptions
+            {
+                MaxItems = 1,
+                Projection = new MarkoutProjection { IncludeColumns = ["To"] },
+            });
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = Normalize(orch.ToString());
+        Assert.Contains("n0 --> n1", output, StringComparison.Ordinal);
+        Assert.Contains("n1 --> n2", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TableGraph_HonorsRowWindows()
+    {
+        var orch = MarkoutWriter.Create(
+            new TableFormatter(),
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Head(1) });
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = orch.ToString();
+        Assert.Contains("A", output, StringComparison.Ordinal);
+        Assert.Contains("B", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("C", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Table_RendersAnEdgeTable()
     {
         var orch = MarkoutWriter.Create(new TableFormatter());

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -507,6 +507,54 @@ public class GraphTests
     }
 
     [Fact]
+    public void ProjectedOutGraphTable_DoesNotMaterializeEdgeRows()
+    {
+        var nodes = Enumerable.Range(0, 10_001)
+            .Select(i => new GraphNode($"n{i}", $"N{i}"))
+            .ToArray();
+        var edges = Enumerable.Range(0, 10_000)
+            .Select(i => new GraphEdge($"n{i}", $"n{i + 1}"))
+            .ToArray();
+        var graph = new Graph(nodes, edges);
+        var options = new MarkoutWriterOptions
+        {
+            Projection = new MarkoutProjection { IncludeColumns = ["Name"] },
+        };
+
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(), options);
+        Assert.True(orch.WriteTable(["Name"], [["kept"]]));
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.True(orch.WriteGraph(graph));
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Contains("kept", orch.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("N0", orch.ToString(), StringComparison.Ordinal);
+        Assert.True(allocated < 128 * 1024, $"projection miss allocated {allocated:N0} bytes");
+    }
+
+    [Fact]
+    public void MarkdownSubclass_CanOverrideGraphRendering()
+    {
+        var orch = MarkoutWriter.Create(new CustomMarkdownGraphFormatter());
+
+        Assert.True(orch.WriteGraph(SimpleChain()));
+        Assert.Equal("custom graph", Normalize(orch.ToString()));
+    }
+
+    [Fact]
+    public void DirectMarkdownGraphFormatting_RendersTheEdgeTable()
+    {
+        var sink = new StringWriter();
+
+        ((IGraphFormatter)new MarkdownFormatter()).FormatGraph(
+            sink,
+            SimpleChain(),
+            new MarkoutWriterOptions());
+
+        Assert.Contains("| From | To |", sink.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Table_RendersAnEdgeTable()
     {
         var orch = MarkoutWriter.Create(new TableFormatter());
@@ -846,6 +894,15 @@ public class GraphTests
     {
         void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
             => w.Write(text);
+    }
+
+    private sealed class CustomMarkdownGraphFormatter : MarkdownFormatter, IGraphFormatter
+    {
+        void IGraphFormatter.FormatGraph(
+            TextWriter writer,
+            Graph graph,
+            MarkoutWriterOptions options)
+            => writer.Write("custom graph");
     }
 
     private static string Normalize(string text) => text.Replace("\r\n", "\n");

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -430,17 +430,29 @@ public class GraphTests
     // ── Cross-formatter behavior ──
 
     [Fact]
-    public void Markdown_RendersATree()
+    public void Markdown_RendersAnEdgeTableByDefault()
     {
         var orch = MarkoutWriter.Create(new MarkdownFormatter());
         Assert.True(orch.WriteGraph(SimpleChain()));
 
         var output = orch.ToString();
-        Assert.Contains("A", output);
-        Assert.Contains("└─ B", output);
-        Assert.Contains("└─ C", output);
-        // The tree lowering names each node once; it is not the edge-table lowering.
-        Assert.DoesNotContain("| From | To |", output);
+        Assert.Contains("| From | To |", output);
+        Assert.Contains("| A | B |", output);
+        Assert.Contains("| B | C |", output);
+        Assert.DoesNotContain("└─", output);
+    }
+
+    [Fact]
+    public void Markdown_CanEmbedAMermaidGraph()
+    {
+        var orch = MarkoutWriter.Create(new MarkdownFormatter(MarkdownGraphMode.Mermaid));
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = Normalize(orch.ToString());
+        Assert.StartsWith("```mermaid\ngraph TD\n", output, StringComparison.Ordinal);
+        Assert.Contains("n0 --> n1", output, StringComparison.Ordinal);
+        Assert.EndsWith("```", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("| From | To |", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -468,6 +480,13 @@ public class GraphTests
         orch.WriteGraph(graph);
 
         Assert.Contains("**A**", orch.ToString());
+    }
+
+    [Fact]
+    public void Markdown_RejectsAnUnknownGraphMode()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new MarkdownFormatter((MarkdownGraphMode)int.MaxValue));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Markdown graph sections now default to edge tables, while callers can select fenced Mermaid diagrams through `new MarkdownFormatter(MarkdownGraphMode.Mermaid)`. Both modes lower the same `Graph`, so hosts can choose the final Markdown representation without rebuilding graph data.

The explicit parameterless `MarkdownFormatter()` constructor remains and now selects `EdgeTable`, preserving binary compatibility for existing compiled consumers. Plain-text tree, standalone Mermaid, and tabular graph formatters are unchanged.

## Validation

- `dotnet build Markout.sln -c Release`
- `dotnet run --project tests/Markout.Tests -c Release -- -class "Markout.Tests.GraphTests"` (59 passed)
- `dotnet run --project tests/Markout.Tests -c Release -- -class "Markout.Tests.GeneratedGraphTests"` (6 passed)
- `markdownlint` on all changed Markdown
- Source-referenced by dotnet-inspect with default Markdown table, standalone tree/Mermaid, embedded Mermaid, table/TSV/JSONL, count, and row-window coverage