### PR TITLE
Delete the unreferenced field-filter that skipped the allow-list snapshot

### DIFF
--- a/src/Markout/MarkoutProjection.cs
+++ b/src/Markout/MarkoutProjection.cs
@@ -114,33 +114,6 @@ public class MarkoutProjection
     }
 
     /// <summary>
-    /// Returns true if the given field key should be included in output.
-    /// </summary>
-    internal bool IsFieldIncluded(string key)
-    {
-        if (_includeFields != null)
-        {
-            foreach (var field in _includeFields)
-            {
-                if (MatchesName(field, key))
-                    return true;
-            }
-            return false;
-        }
-
-        if (_excludeFields != null)
-        {
-            foreach (var field in _excludeFields)
-            {
-                if (MatchesName(field, key))
-                    return false;
-            }
-        }
-
-        return true;
-    }
-
-    /// <summary>
     /// Resolves the column projection against display headers.
     /// </summary>
     public ColumnProjectionResolution ResolveColumns(ReadOnlySpan<string> headers)


### PR DESCRIPTION
`MarkoutProjection.IsFieldIncluded` had **no callers anywhere in the repository** — it was the only occurrence of its own name. Deleting it is a no-op the compiler proves: it is `internal`, `Markout.Tests` has `InternalsVisibleTo`, and both build clean.

## Why delete it rather than leave it

It enumerated `_includeFields` directly, once per field key. The live path — `ProjectFields` in `MarkoutWriter` — routes both `IncludeFields` and `ExcludeFields` through `SnapshotNames` first.

`IncludeFields` is `IReadOnlyList<string>`, an interface the caller implements, so an implementation yielding different names on different enumerations would have had each key judged against a *different allow list*. That is the exact inconsistency `SnapshotSelection`'s remarks spell out a few lines below, for `IncludeColumns`:

> Every consumer of a selection [...] has to be looking at the same names, or they can disagree about which request was even made.

So the hazard was not that the dead code was wrong today. It was a second implementation of field filtering sitting next to the paragraph explaining why it must not be written that way, ready for the next caller who needs field filtering and finds it first.

## Evidence

| Check | Result |
| --- | --- |
| `dotnet build Markout.sln -c Release` | Succeeded, **0 warnings** |
| `Markout.Tests` | **5263 passed, 0 failed** |

No version bump: this is a pure deletion of unreachable internal code with no behavioral effect, so it rides the next release.

**Review:** trivial — a deletion of code with zero references, where the compiler is the gate.

Found while closing out the `IncludeColumns` snapshot question from the 0.35.2 release work; the columns and live-fields paths both already snapshot correctly.