### PR TITLE
Complete row-window routing for Markdown metrics

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -698,9 +698,9 @@ reintroduces `MaxItems`' own ellipsis line in TSV, as it does without a window.)
 The window applies to tables written through the writer — `WriteTable`,
 `WriteTableStart`/`WriteTableRow`/`WriteTableEnd`, and `WriteCompositeTable`.
 Table-shaped formatter lowerings use the same pipeline: graph edge tables and
-Markdown metric and breakdown tables honor the window over their visible rows.
-Visual bar and diagram renderers are not tables, so row windows do not apply to
-them.
+Markdown metric and breakdown tables honor the window over their visible rows,
+and `MaxItems` caps those rows. Visual bar and diagram renderers are not tables,
+so row windows and table caps do not apply to them.
 
 When both are set, **the window selects and `MaxItems` then caps the selection**,
 so the reported overflow count describes only what the cap dropped:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -696,9 +696,11 @@ ellipsis row and leaves the output machine-consumable. (Adding `MaxItems` on top
 reintroduces `MaxItems`' own ellipsis line in TSV, as it does without a window.)
 
 The window applies to tables written through the writer — `WriteTable`,
-`WriteTableStart`/`WriteTableRow`/`WriteTableEnd`, and `WriteCompositeTable`. It
-does **not** apply to lowerings that call a formatter's `FormatTable` directly,
-which today means metrics and breakdown rendering and the graph edge table.
+`WriteTableStart`/`WriteTableRow`/`WriteTableEnd`, and `WriteCompositeTable`.
+Table-shaped formatter lowerings use the same pipeline: graph edge tables and
+Markdown metric and breakdown tables honor the window over their visible rows.
+Visual bar and diagram renderers are not tables, so row windows do not apply to
+them.
 
 When both are set, **the window selects and `MaxItems` then caps the selection**,
 so the reported overflow count describes only what the cap dropped:

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -614,16 +614,18 @@ public class MarkdownFormatter : IMarkoutFormatter,
             if (total == 0) total = 1;
 
             var headers = new[] { "Category", "Count", "%" };
+            var headerNames = new[] { "Category", "Count", "Percent" };
             var rows = item.Slices
                 .Where(s => s.Count > 0)
                 .Select(s => new[] { s.Category, s.Count.ToString(), $"{s.Count * 100.0 / total:F0}" })
                 .ToList();
 
-            new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, rows);
+            new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, headerNames, rows);
         }
         else
         {
             var headers = new[] { "Label", "Category", "Count", "%" };
+            var headerNames = new[] { "Label", "Category", "Count", "Percent" };
             var rows = new List<string[]>();
             foreach (var item in items)
             {
@@ -635,7 +637,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
                     rows.Add([item.Label, seg.Category, seg.Count.ToString(), $"{seg.Count * 100.0 / total:F0}"]);
             }
 
-            new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, rows);
+            new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, headerNames, rows);
         }
     }
 

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -619,7 +619,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
                 .Select(s => new[] { s.Category, s.Count.ToString(), $"{s.Count * 100.0 / total:F0}" })
                 .ToList();
 
-            ((ITableFormatter)this).FormatTable(w, headers, rows, 0, options);
+            new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, rows);
         }
         else
         {
@@ -635,7 +635,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
                     rows.Add([item.Label, seg.Category, seg.Count.ToString(), $"{seg.Count * 100.0 / total:F0}"]);
             }
 
-            ((ITableFormatter)this).FormatTable(w, headers, rows, 0, options);
+            new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, rows);
         }
     }
 
@@ -644,7 +644,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
         // Render as a pipe table: Label | Value
         var headers = new[] { "Label", "Value" };
         var rows = items.Select(m => new[] { m.Label, FormatHelper.FormatBarValue(m.Value) }).ToList();
-        ((ITableFormatter)this).FormatTable(w, headers, rows, 0, options);
+        new TableWriter(w, (ITableFormatter)this, options).WriteTable(headers, rows);
     }
 
     void IMetricsFormatter.FormatVerticalMetrics(TextWriter w, IReadOnlyList<Metric> items, int maxBarHeight, int? barWidth, MarkoutWriterOptions options)

--- a/tests/Markout.Tests/MarkoutWriterTests.cs
+++ b/tests/Markout.Tests/MarkoutWriterTests.cs
@@ -231,6 +231,19 @@ public class MarkoutWriterTests
     }
 
     [Fact]
+    public void MarkdownFormatter_WriteBreakdown_UsesPercentAsTheStableHeaderName()
+    {
+        var orch = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { TableHeaderStyle = MarkoutTableHeaderStyle.StableName });
+        var breakdown = new Breakdown("Test", [new Slice("Pass", 8), new Slice("Fail", 2)]);
+
+        Assert.True(orch.WriteBreakdown([breakdown]));
+
+        Assert.Contains("| category | count | percent |", orch.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MarkdownFormatter_WriteMetrics_Renders()
     {
         var orch = MarkoutWriter.Create(new MarkdownFormatter());

--- a/tests/Markout.Tests/RowWindowTests.cs
+++ b/tests/Markout.Tests/RowWindowTests.cs
@@ -49,8 +49,34 @@ public class RowWindowTests
         return sw.ToString();
     }
 
+    private static string RenderMetrics(
+        MarkoutRowWindow window,
+        Action<MarkoutWriter, IReadOnlyList<Metric>> write)
+    {
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { RowWindow = window });
+        write(
+            writer,
+            [
+                new Metric("m1", 1),
+                new Metric("m2", 2),
+                new Metric("m3", 3),
+                new Metric("m4", 4)
+            ]);
+        return writer.Complete();
+    }
+
     public static TheoryData<MarkoutTableMode> AllModes =>
         new(Enum.GetValues<MarkoutTableMode>());
+
+    public static TheoryData<MarkoutRowWindow, string[], string[]> MetricWindows =>
+        new()
+        {
+            { MarkoutRowWindow.Head(2), ["m1", "m2"], ["m3", "m4"] },
+            { MarkoutRowWindow.Tail(2), ["m3", "m4"], ["m1", "m2"] },
+            { MarkoutRowWindow.Range(2, 3), ["m2", "m3"], ["m1", "m4"] }
+        };
 
     // ── Resolution ──
 
@@ -108,6 +134,93 @@ public class RowWindowTests
     {
         Assert.Equal((0, 0), MarkoutRowWindow.Head(0).Resolve(4));
         Assert.Equal((4, 4), MarkoutRowWindow.Tail(0).Resolve(4));
+    }
+
+    [Theory]
+    [MemberData(nameof(MetricWindows))]
+    public void MarkdownMetrics_HonorRowWindows(
+        MarkoutRowWindow window,
+        string[] included,
+        string[] excluded)
+    {
+        var output = RenderMetrics(window, static (writer, items) => writer.WriteMetrics(items));
+
+        foreach (var label in included)
+            Assert.Contains(label, output, StringComparison.Ordinal);
+        foreach (var label in excluded)
+            Assert.DoesNotContain(label, output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(MetricWindows))]
+    public void MarkdownVerticalMetrics_HonorRowWindows(
+        MarkoutRowWindow window,
+        string[] included,
+        string[] excluded)
+    {
+        var output = RenderMetrics(window, static (writer, items) => writer.WriteVerticalMetrics(items));
+
+        foreach (var label in included)
+            Assert.Contains(label, output, StringComparison.Ordinal);
+        foreach (var label in excluded)
+            Assert.DoesNotContain(label, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MetricsWriter_WindowSelectsBeforeMaxItemsCaps()
+    {
+        var sw = new StringWriter();
+        var writer = new MetricsWriter(
+            sw,
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions
+            {
+                RowWindow = MarkoutRowWindow.Range(2, 4),
+                MaxItems = 2
+            });
+
+        writer.WriteMetrics(
+        [
+            new Metric("m1", 1),
+            new Metric("m2", 2),
+            new Metric("m3", 3),
+            new Metric("m4", 4)
+        ]);
+
+        var output = sw.ToString();
+        Assert.Contains("m2", output, StringComparison.Ordinal);
+        Assert.Contains("m3", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("m1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("m4", output, StringComparison.Ordinal);
+        Assert.Contains("... and 1 more", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownBreakdown_WindowSelectsFlattenedTableRows()
+    {
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Range(2, 3) });
+
+        writer.WriteBreakdown(
+        [
+            new Breakdown("first",
+            [
+                new Slice("a1", 1),
+                new Slice("a2", 2)
+            ]),
+            new Breakdown("second",
+            [
+                new Slice("b1", 3),
+                new Slice("b2", 4)
+            ])
+        ]);
+
+        var output = writer.Complete();
+        Assert.Contains("a2", output, StringComparison.Ordinal);
+        Assert.Contains("b1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("a1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("b2", output, StringComparison.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- route Markdown metric and breakdown tables through the shared `TableWriter` pipeline
- apply row windows to flattened breakdown rows and preserve selection-before-`MaxItems` semantics
- preserve `%` as the display label while supplying `percent` as its stable table key
- document that table-shaped lowerings honor row windows and table caps while visual renderers do not

## Demo

A range selects first, then `MaxItems` caps only that selection:

```csharp
var options = new MarkoutWriterOptions
{
    RowWindow = MarkoutRowWindow.Range(2, 4),
    MaxItems = 2
};

writer.WriteMetrics(
[
    new Metric("Parse", 10),
    new Metric("Analyze", 20),
    new Metric("Render", 30),
    new Metric("Publish", 40)
]);
```

| Label | Value |
| --- | ---: |
| Analyze | 20 |
| Render | 30 |

... and 1 more

Breakdown windows operate on the flattened visible rows. `Range(2, 3)` crosses the boundary between the `Build` and `Fetch` groups:

| Label | Category | Count | % |
| --- | --- | ---: | ---: |
| Build | Hot | 20 | 67 |
| Fetch | Cache | 30 | 43 |

## Validation

- `dotnet build Markout.sln -c Release`
- `dotnet run --project tests/Markout.Tests -c Release --no-build --` (5,273 passed)
- `dotnet run --project tests/Markout.Templates.Tests -c Release --no-build --` (122 passed)
- `dotnet run --project tests/MarkdownTable.Tests -c Release --no-build --` (236 passed)
- `dotnet pack src/Markout/Markout.csproj -c Release --no-build --no-restore`
- `npx markdownlint-cli docs/user-guide.md`

Fixes #178