### PR TITLE
Teach adopter-driven Markout idioms

### DIFF
--- a/skills/markout-output-formats/SKILL.md
+++ b/skills/markout-output-formats/SKILL.md
@@ -4,9 +4,10 @@ version: 0.35.2
 description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several
-  formats from a single render path (a CLI `--format` switch). Pick the format with a formatter
-  + MarkoutWriterOptions; never hand-build TSV/JSONL.
-  Don't decompile the assembly or web-search the API — the TSV/JSONL/formatter idioms are all here.
+  formats from a single render path (a CLI `--format` switch). Also covers semantic inline code
+  that renders as Markdown code spans but decodes to plain text in TSV/JSONL. Pick the format with
+  a formatter + MarkoutWriterOptions; never hand-build TSV/JSONL.
+  Don't decompile the assembly or web-search the API — the multi-format idioms are all here.
 ---
 
 # Output formats — one model, many formats
@@ -17,9 +18,9 @@ Markout project the same model to each format so columns/headers stay consistent
 
 ## Required setup
 
-Markout has **no reflection fallback**. Every report needs an annotated model, a partial context
-registering each model type, and a `Serialize` call that passes it — there is no `Serialize(obj)`
-overload, and omitting the context does not compile.
+Markout has **no reflection fallback**. Every report needs a partial context registering each model
+type and a `Serialize` call that passes it. `[MarkoutSerializable]` is optional customization, not
+a prerequisite for registration.
 
 ```csharp
 using Markout;
@@ -120,6 +121,34 @@ keep Markout for the structured formats — don't try to force it.
 - Markdown table cells normalize `|` to `&#124;` (not `\|`).
 - TSV uses stable `snake_case` headers and never embeds tabs/newlines in cells.
 - Pretty renders the same projection as TSV, aligned.
+
+## Format-neutral inline code
+
+Store code-like values with semantic `<code>...</code>` tags. XML-escape angle brackets inside
+the tags:
+
+```csharp
+row.Operation = "<code>dotnet test</code>";
+row.Signature = "<code>Result&lt;T&gt; Parse&lt;T&gt;(string value)</code>";
+```
+
+Markdown renders code spans such as `` `Result<T> Parse<T>(string value)` ``. Pretty, TSV, and
+JSONL remove the tags, decode the entities, and emit plain text. Do not store raw backticks or use
+``[MarkoutDisplayFormat("`{0}`")]``; that hard-codes Markdown into the model.
+
+JSONL must still go through Markout:
+
+```csharp
+var jsonl = new MarkoutWriterOptions
+{
+    TableMode = MarkoutTableMode.Jsonl,
+    JsonTypedValues = true,
+};
+MarkoutSerializer.Serialize(report, Console.Out, new TableFormatter(), ctx, jsonl);
+```
+
+Do not substitute `System.Text.Json`: it does not apply Markout's table projection, stable property
+names, or semantic-tag decoding.
 
 ## Guardrails
 

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -7,10 +7,11 @@ description: >-
   output. Markout is a source-generated .NET serializer: it looks like System.Text.Json
   source-gen but the rules differ (NO reflection fallback), so it needs a generated
   MarkoutSerializerContext and Markout-specific attributes. Covers the required pattern:
-  annotated models, the partial context, scalar field shaping (title, description,
-  per-value formatting), and serializing through the context. Conditional composition, output
-  formats, built-in shapes, and composite cells are covered separately. Don't decompile the
-  Markout assembly or web-search its API — every idiom you need is in the Markout skills.
+  registered models, the partial context, scalar field shaping, typed value formatters,
+  context-wide options, and serialization. For TSV/JSONL or one model serving multiple formats,
+  also invoke markout-output-formats. Conditional composition, built-in shapes, and composite
+  cells are covered separately. Don't decompile the Markout assembly or web-search its API —
+  every idiom you need is in the Markout skills.
 ---
 
 # Markout — structured output from objects
@@ -23,13 +24,16 @@ Markdown. Reach for Markout whenever a tool would otherwise build strings with
 > Markout usage — they are authoritative and version-matched to the package. This skill covers
 > the core pattern; conditional composition, output formats, built-in shapes, and composite
 > cells are covered separately.
+>
+> **Routing gate:** if the task mentions TSV, JSONL, plain/pretty/ANSI output, or one model
+> serving multiple formats, invoke `markout-output-formats` before coding.
 
-## The required pattern (3 parts — all mandatory)
+## The required pattern (registration + serialization are mandatory)
 
 ```csharp
 using Markout;
 
-// 1. Annotate every model type. List<T> -> table, scalar -> field.
+// 1. Annotate a model when you need to customize its rendering. Registration is what is required.
 [MarkoutSerializable(TitleProperty = nameof(Title))]   // TitleProperty -> the H1 heading
 public class Report
 {
@@ -50,6 +54,9 @@ public partial class ReportContext : MarkoutSerializerContext { }
 // 3. Serialize THROUGH the context.
 MarkoutSerializer.Serialize(report, Console.Out, ReportContext.Default);
 ```
+
+`[MarkoutSerializable]` is optional. Types from dependencies can remain untouched; register them
+on the context and put serializer-wide behavior on that context.
 
 ## Scalar field shaping (title, description, per-value formatting)
 
@@ -85,14 +92,56 @@ public class Component
 
 - **No reflection fallback.** There is no `Serialize(obj)` overload. EVERY `Serialize` call takes a
   `MarkoutSerializerContext`. Omitting it does not compile — the #1 mistake.
-- **Register every type.** A model missing `[MarkoutSerializable]` + `[MarkoutContext(typeof(T))]`
-  won't serialize. The context class MUST be `partial`.
+- **Register every type.** `[MarkoutContext(typeof(T))]` is mandatory; `[MarkoutSerializable]` is
+  optional customization. The context class MUST be `partial`.
 - **Markout attributes, not Json:** `[MarkoutSerializable]` (not `[JsonSerializable]`),
   `[MarkoutContext]`, `[MarkoutSection(Name=...)]`, `[MarkoutPropertyName]`, `[MarkoutIgnore]`.
 - **Type drives rendering, not markup:** `List<T>` -> table; scalar -> `Field | Value` row;
   `[MarkoutSection(Name="X")]` -> a `## X` heading above the property.
+- **Inline code needs semantic tags.** Raw backticks are escaped in table cells. Store
+  `<code>...</code>` instead; `markout-output-formats` covers its cross-format behavior.
 - **`[MarkoutIgnoreInTable]` on non-tabular list properties** (`List<Metric>`, `List<Breakdown>`,
   `List<TreeNode>`, `List<Description>`, `Callout`) or they get mistreated as table columns.
+
+## Typed custom value formatters
+
+For transformations beyond a format string, keep the property strongly typed and implement
+`IMarkoutValueFormatter<T>`:
+
+```csharp
+public sealed class ByteSizeFormatter : IMarkoutValueFormatter<long>
+{
+    public string Format(long value) => value switch
+    {
+        >= 1_073_741_824 => $"{value / 1_073_741_824.0:0.#} GB",
+        >= 1_048_576 => $"{value / 1_048_576.0:0.#} MB",
+        >= 1_024 => $"{value / 1_024.0:0.#} KB",
+        _ => $"{value} B",
+    };
+}
+
+[MarkoutPropertyName("Package Size")]
+[MarkoutValueFormatter(typeof(ByteSizeFormatter))]
+public long PackageSizeBytes { get; set; }
+```
+
+Do not replace the numeric property with a string or format it in a getter. The generated
+serializer calls `Format(T)` through the attribute.
+
+## Context-wide options and table warnings
+
+Put defaults that apply to every serialization on the generated context:
+
+```csharp
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(Report))]
+[MarkoutContext(typeof(DependencyRow))]
+public partial class ReportContext : MarkoutSerializerContext { }
+```
+
+Use `SuppressTableWarnings` when registered dependency-owned types intentionally contain
+non-tabular properties that produce `MARKOUT001`. Do not mutate those types with
+`[MarkoutIgnoreInTable]`, add a pragma, or suppress the diagnostic in the project file.
 
 ## Most common workflow: JSON API → model → report
 


### PR DESCRIPTION
## Summary

- correct the base skill's false claim that `[MarkoutSerializable]` is mandatory; context registration is required, type annotation is optional customization
- teach typed `IMarkoutValueFormatter<T>` implementations wired with `[MarkoutValueFormatter]`
- teach context-wide `[MarkoutContextOptions(SuppressTableWarnings = true)]` for dependency-owned types
- teach semantic `<code>` tags and their Markdown versus TSV/JSONL behavior
- add an explicit routing gate from the base skill to `markout-output-formats` for multi-format tasks

## Held-out evidence

Haiku, n=5, CT27-29, corrected contracts, shared pinned baseline. This is a focused marginal measurement, not a suite-level economic-gate claim (`|S| < 8`).

| Scenario | Baseline Delivered | Previous shelf Delivered | Candidate Delivered | Previous -> candidate mean IET | Expected pull |
| --- | ---: | ---: | ---: | ---: | --- |
| CT27 typed formatter | 2/5 | 2/5 | **5/5** | 173,785 -> **70,775** (-59%) | `markout` 5/5 |
| CT28 semantic code + JSONL | 0/5 | 1/5 | **5/5** | 272,010 -> **110,860** (-59%) | `markout` + `markout-output-formats` 5/5 |
| CT29 context options | 4/5 | 3/5 | **5/5** | 377,876 -> **97,225** (-74%) | `markout` detected 4/5 |

The candidate used no web, NuGet-cache archaeology, or `dotnet-inspect` in these runs.

## Regression smoke

A one-run active-suite smoke kept CT01, CT09, and CT14 functionally complete (5/5 assertions each), covering the base pattern, TSV, and typed JSONL.

Follow-up to #149.
