### PR TITLE
Teach remaining legacy Markout idioms

### DIFF
--- a/grounding/markout/eval.yaml
+++ b/grounding/markout/eval.yaml
@@ -1107,6 +1107,7 @@ scenarios:
   - name: "CT33: conditional emphasis across Markdown and TSV"
     held_out: true
     expected_skills:
+      - markout
       - markout-composite-cells-cards
       - markout-output-formats
     prompt: |

--- a/skills/markout-composite-cells-cards/SKILL.md
+++ b/skills/markout-composite-cells-cards/SKILL.md
@@ -4,7 +4,8 @@ version: 0.35.2
 description: >-
   Use when a single value must render dense in Markdown but decompose into typed columns in
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas
-  and goal polarity — or when building metric / role-matrix / verdict cards from one model
+  and goal polarity — including MarkoutNumberFormat for Change<V> counts — or when building
+  metric / role-matrix / verdict cards with threshold-based MarkoutEmphasis
   (Change<V>, Fraction, Share, Percent, Segments, Delta/Goal, MetricChange<T>, MultiSourceRow,
   Verdict). This is Markout's most advanced tier.
   Don't decompile the assembly or web-search the API — these composite types are here.
@@ -17,11 +18,15 @@ a row: Markdown renders a dense human value, and `TableFormatter` (TSV/JSONL) de
 cell into typed columns — no pre-stringifying, one declaration serves both. This replaces
 pre-formatting numbers into strings (which loses the machine-readable form).
 
+> **Routing gate:** if the task requires TSV, JSONL, plain/pretty/ANSI output, or a runtime format
+> switch, also invoke `markout-output-formats` before coding.
+
 ## Required setup
 
-Markout has **no reflection fallback**. Every report needs an annotated model, a partial context
-registering each model type, and a `Serialize` call that passes it — there is no `Serialize(obj)`
-overload, and omitting the context does not compile.
+Markout has **no reflection fallback**. Every report needs a partial context registering each model
+type and a `Serialize` call that passes it. `[MarkoutSerializable]` is optional customization, not
+a prerequisite for registration. When the report needs an H1, use a scalar title property with
+`[MarkoutSerializable(TitleProperty = nameof(Title))]`.
 
 ```csharp
 using Markout;
@@ -66,6 +71,9 @@ public class QualityCard
 - `[MarkoutDelta(Delta.Percent|Absolute|Multiple)]` appends the signed change to a numeric
   `Change<V>`: `(−38%)`, `(+120)`, `15 → 5 (3× fewer)`.
 - `[MarkoutDeltaNoun("solved")]` adds a caller noun: `4/6 → 6/6 (+2 solved)`.
+- `[MarkoutNumberFormat("N0")]` applies one .NET numeric format to scalar `Change<V>` operands and
+  an absolute/noun delta: `165 → 1,168 (+1,003)`. Structured TSV/JSONL decomposition stays numeric
+  and ungrouped. Keep the property typed; do not preformat the operands or delta.
 - `[MarkoutGoal(Goal.Higher|Lower)]` makes Markout derive two columns — a structural `direction`
   (`increased`/`decreased`/`introduced`/`resolved`/`unchanged`) and a goal-applied `status`
   (`good`/`bad`/`neutral`) — so you don't hand-code ceiling/floor polarity. `Goal.Higher, 0.001`
@@ -95,7 +103,10 @@ cell. `[MarkoutIgnoreColumnWhen]`-hidden columns drop from the decomposition too
 - `List<MultiSourceRow>` — a role matrix. `MultiSourceRow(label, params Source[])`,
   `Source(role, IMarkoutCell? value)`; roles pivot to columns in Markdown (absent role → `-`), JSONL
   emits `{role}_{side}_{field}` keys. Scalars work: `new Source("baseline", 2)`; `Source.Text(role, s)`.
-  Set the label header with `[MarkoutLabelHeader("Metric")]`.
+  Set the label header with `[MarkoutLabelHeader("Metric")]`. To declaratively bold scalar cells
+  that clear a threshold in rich output, set emphasis on the row:
+  `new MultiSourceRow(label, sources) { Emphasis = MarkoutEmphasis.AtLeast(cut) }` (or `.AtMost(cut)`).
+  Plain text and TSV/JSONL ignore emphasis and preserve raw values.
 - `Verdict(GateStatus Status, string? Label = null)` — a first-class verdict cell; use as a `Source`.
 - `[MarkoutSection(Name="…", IncludeSectionInStructuredRows = true)]` prepends a `section` column to
   TSV/JSONL — multiplex several card sections into one stream. Decomposition keys are `snake_case`.

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -3,15 +3,15 @@ name: markout
 version: 0.35.2
 description: >-
   Use when generating Markdown or other structured output (plain text, ANSI, pretty tables,
-  TSV/JSONL) from C# objects instead of hand-built strings — CLIs, tools, reports, agent
-  output. Markout is a source-generated .NET serializer: it looks like System.Text.Json
-  source-gen but the rules differ (NO reflection fallback), so it needs a generated
-  MarkoutSerializerContext and Markout-specific attributes. Covers the required pattern:
-  registered models, the partial context, scalar field shaping, typed value formatters,
-  context-wide options, and serialization. For TSV/JSONL or one model serving multiple formats,
-  also invoke markout-output-formats. Conditional composition, built-in shapes, and composite
-  cells are covered separately. Don't decompile the Markout assembly or web-search its API —
-  every idiom you need is in the Markout skills.
+  TSV/JSONL) from C# objects, or when diagnosing Markout source-generator errors such as
+  MARKOUT006. Markout replaces hand-built strings in CLIs, tools, reports, and agent output.
+  It looks like System.Text.Json source-gen but the rules differ (NO reflection fallback), so it
+  needs a generated MarkoutSerializerContext and Markout-specific attributes. Covers the required
+  pattern: registered models, the partial context, scalar field shaping, typed value formatters,
+  context-wide options, table diagnostics, semantic child rows, and serialization.
+  For TSV/JSONL or one model serving multiple formats, also invoke markout-output-formats.
+  Conditional composition, built-in shapes, and composite cells are covered separately. Don't
+  decompile the Markout assembly or web-search its API — every idiom you need is in the skills.
 ---
 
 # Markout — structured output from objects
@@ -142,6 +142,30 @@ public partial class ReportContext : MarkoutSerializerContext { }
 Use `SuppressTableWarnings` when registered dependency-owned types intentionally contain
 non-tabular properties that produce `MARKOUT001`. Do not mutate those types with
 `[MarkoutIgnoreInTable]`, add a pragma, or suppress the diagnostic in the project file.
+
+## Table-row diagnostics and semantic children
+
+`MARKOUT006` means a `List<T>` is being rendered as a table but its row type has no visible
+columns. Fix the model: expose at least one scalar property, or intentionally render the data as
+sections instead. Do not suppress the diagnostic, remove the collection, or stringify the rows.
+
+Use `[MarkoutChild]` on a bool row property when `true` rows are semantic children of the preceding
+parent:
+
+```csharp
+public sealed class OrganizationRow
+{
+    public string Name { get; set; } = "";
+    public int Count { get; set; }
+
+    [MarkoutChild]
+    public bool IsChild { get; set; }
+}
+```
+
+The flag is not a column. Rich output prefixes the first visible cell of child rows with the child
+glyph; TSV/JSONL/plain output keeps the row data unstyled. A child flag does not count as a visible
+column, so the row still needs a scalar such as `Name`.
 
 ## Most common workflow: JSON API → model → report
 


### PR DESCRIPTION
## Summary
- teach number formatting, MARKOUT006 recovery, semantic child rows, and row-level emphasis
- correct composite setup and route multi-format cards to the output-format skill
- include the base skill in CT33 expected multi-skill routing

## Held-out evidence
| Scenario | Current Delivered | Candidate Delivered | Mean IET change |
|---|---:|---:|---:|
| CT30 | 4/5 | 5/5 | 289,437 to 105,489 (-64%) |
| CT31 | 4/5 | 5/5 | 109,840 to 85,347 (-22%) |
| CT32 | 5/5 | 5/5 | 88,170 to 65,414 (-26%) |
| CT33 | 2/5 | 4/5 | 274,816 to 169,373 (-38%) |

CT30 was rerun after the final H1 clarification. Pulling remains noisy under the accepted package-documentation proxy: expected-skill activation was CT30 2/5, CT31 2/5, CT32 4/5, and full CT33 routing 3/5. Package archaeology still appeared in one run per scenario.

This PR is stacked on and depends on #210, which removes target-name bias from the held-out prompts.