### PR TITLE
Route Markout tasks across companion skills

### DIFF
--- a/skills/markout-built-in-shapes/SKILL.md
+++ b/skills/markout-built-in-shapes/SKILL.md
@@ -5,8 +5,10 @@ description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn
   ASCII or manual Markdown. Markout ships these as data types (Metric, Breakdown/Slice, Callout,
-  TreeNode, Description, CodeSection, MarkoutTable) you attach as model properties.
-  Don't decompile the assembly or web-search the API — the shape types are here.
+  TreeNode, Description, CodeSection, MarkoutTable) you attach as model properties. If the task
+  requests terminal/Unicode, plain text, ANSI, or another non-Markdown sink, also invoke
+  markout-output-formats for the formatter call. Don't decompile the assembly or web-search the
+  API — the shape types are here.
 ---
 
 # Built-in shapes — declare the meaning, get the visual
@@ -29,6 +31,23 @@ public partial class DashboardContext : MarkoutSerializerContext { }
 
 MarkoutSerializer.Serialize(dashboard, Console.Out, DashboardContext.Default);
 ```
+
+## Route visual shapes to the requested sink
+
+Default serialization is Markdown. A request for terminal or Unicode bars needs the output-format
+companion skill and an explicit formatter:
+
+```csharp
+MarkoutSerializer.Serialize(
+    dashboard,
+    Console.Out,
+    new UnicodeFormatter(),
+    DashboardContext.Default);
+```
+
+Invoke `markout-output-formats` for plain text, ANSI, pretty tables, TSV/JSONL, or multi-format
+dispatch. Do not guess a `MarkoutWriterOptions.Format` property or add an ANSI package unless the
+requested sink specifically needs it.
 
 ## The shapes
 

--- a/skills/markout-conditional-composition/SKILL.md
+++ b/skills/markout-conditional-composition/SKILL.md
@@ -106,4 +106,6 @@ modes without branching in the writer. Set the gating bools when you build the m
 
 - Prefer declaration over imperative assembly: no `if`+`AppendLine`, no manual header/row rebuilding.
 - Keep predicates (`Has*`, `Terse`) as computed properties on the model, next to the data.
+- For same-name section variants, use mutually exclusive `ShowWhenProperty` gates rather than
+  relying on empty-list omission; the gates make the selected projection explicit.
 - Empty vs absent matters: `null` list omits a section; empty list + `EmptyText` shows the fallback.

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -9,9 +9,10 @@ description: >-
   needs a generated MarkoutSerializerContext and Markout-specific attributes. Covers the required
   pattern: registered models, the partial context, scalar field shaping, typed value formatters,
   context-wide options, table diagnostics, semantic child rows, and serialization.
-  For TSV/JSONL or one model serving multiple formats, also invoke markout-output-formats.
-  Conditional composition, built-in shapes, and composite cells are covered separately. Don't
-  decompile the Markout assembly or web-search its API — every idiom you need is in the skills.
+  Route non-Markdown output to markout-output-formats; data-selected/filtered views to
+  markout-conditional-composition; and visual bars, trees, callouts, definitions, or code blocks
+  to markout-built-in-shapes. Composite cells are covered separately. Don't decompile the Markout
+  assembly or web-search its API — every idiom you need is in the skills.
 ---
 
 # Markout — structured output from objects
@@ -25,8 +26,13 @@ Markdown. Reach for Markout whenever a tool would otherwise build strings with
 > the core pattern; conditional composition, output formats, built-in shapes, and composite
 > cells are covered separately.
 >
-> **Routing gate:** if the task mentions TSV, JSONL, plain/pretty/ANSI output, or one model
-> serving multiple formats, invoke `markout-output-formats` before coding.
+> **Routing gate:** invoke the matching companion skill before coding:
+> - TSV, JSONL, plain text, Unicode/terminal, ANSI, pretty output, or multiple formats:
+>   `markout-output-formats`
+> - show/hide conditions, exactly-one section variants, selected sections, quiet/detail views:
+>   `markout-conditional-composition`
+> - bars, proportional breakdowns, trees, callouts, definitions, or code blocks:
+>   `markout-built-in-shapes`
 
 ## The required pattern (registration + serialization are mandatory)
 


### PR DESCRIPTION
## Summary

- route terminal/Unicode and other non-Markdown tasks from the base and shapes skills to `markout-output-formats`
- route adaptive, selected-section, and exactly-one-variant tasks to `markout-conditional-composition`
- make `ShowWhenProperty` the explicit same-name-section idiom
- warn against the two wrong turns observed in the diagnostic: inventing `MarkoutWriterOptions.Format` and adding an ANSI package for Unicode output

## Evidence

The fresh active-suite Haiku n=1 diagnostic found three follow-up tasks: CT10 failed terminal rendering, CT17 delivered correct output without the required conditional gate, and CT24 skipped the shelf and used web documentation. A focused rerun against the same pinned baseline now grades all three **Delivers**:

| Task | Before | After | Skills pulled after |
| --- | --- | --- | --- |
| CT10 | Fails | Delivers | built-in-shapes, output-formats |
| CT17 | Satisfies | Delivers | base, conditional-composition |
| CT24 | Fails | Delivers | base, conditional-composition |

This is the final discovery correction before the full active-suite n=5 measurement.