### PR TITLE
Support intersecting row windows

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -698,13 +698,13 @@ var options = new MarkoutWriterOptions
 {
     RowWindow = MarkoutRowWindow.Tail(20)
 };
-options.IntersectRowWindow(MarkoutRowWindow.Range(50, 80));
+options.IntersectRowWindow(MarkoutRowWindow.Range(50, 85));
 ```
 
 Every window resolves against the table's original row count before the
 resolved ranges are intersected. Selection never renumbers between constraints:
-over 100 rows, `Tail(20)` intersects `Range(50, 80)` at row 80 only. The order
-of the two constraints does not change the result.
+over 100 rows, `Tail(20)` intersects `Range(50, 85)` at rows 81 through 85. The
+order of the two constraints does not change the result.
 
 Calling `IntersectRowWindow` with no current `RowWindow` establishes the primary
 window. Assigning `RowWindow` afterwards replaces the complete selection and

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -690,6 +690,27 @@ leaving `RowWindow` null, so a negative count — usually the result of a
 subtraction that slipped below zero — fails rather than silently widening the
 table to every row.
 
+Use `IntersectRowWindow` when selection has more than one independent
+constraint:
+
+```csharp
+var options = new MarkoutWriterOptions
+{
+    RowWindow = MarkoutRowWindow.Tail(20)
+};
+options.IntersectRowWindow(MarkoutRowWindow.Range(50, 80));
+```
+
+Every window resolves against the table's original row count before the
+resolved ranges are intersected. Selection never renumbers between constraints:
+over 100 rows, `Tail(20)` intersects `Range(50, 80)` at row 80 only. The order
+of the two constraints does not change the result.
+
+Calling `IntersectRowWindow` with no current `RowWindow` establishes the primary
+window. Assigning `RowWindow` afterwards replaces the complete selection and
+clears every intersection; assigning null clears selection entirely. Read-only
+options reject both assignment and intersection.
+
 The window is resolved once, at the writer seam, so every table mode agrees on
 what it means — including TSV and JSONL, where selection alone introduces no
 ellipsis row and leaves the output machine-consumable. (Adding `MaxItems` on top
@@ -711,10 +732,11 @@ so the reported overflow count describes only what the cap dropped:
 new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(20), MaxItems = 5 }
 ```
 
-Streamed and batched output are identical. A `Tail` window buffers the rows it
-might still keep, because which rows those are is not known until the last row
-arrives; the other window kinds decide each row from its position and stream
-without buffering.
+Streamed and batched output are identical. A selection containing `Tail`
+buffers the rows it might still keep, because which rows those are is not known
+until the last row arrives. Multiple tail constraints retain only the smallest
+tail bound. Selections made entirely from `Head` and `Range` decide each row
+from its original position and stream without buffering.
 
 ### Section Level
 

--- a/src/Markout/MarkoutRowSelection.cs
+++ b/src/Markout/MarkoutRowSelection.cs
@@ -1,0 +1,82 @@
+namespace Markout;
+
+internal sealed class MarkoutRowSelection
+{
+    private readonly MarkoutRowWindow[] _windows;
+
+    public MarkoutRowSelection(MarkoutRowWindow window)
+        : this([window])
+    {
+    }
+
+    private MarkoutRowSelection(MarkoutRowWindow[] windows)
+    {
+        _windows = windows;
+        IsPositional = true;
+
+        int? retentionBound = null;
+        foreach (var window in windows)
+        {
+            if (window.IsPositional)
+                continue;
+
+            IsPositional = false;
+            retentionBound = retentionBound is int bound
+                ? Math.Min(bound, window.RetentionBound)
+                : window.RetentionBound;
+        }
+
+        RetentionBound = retentionBound ?? 0;
+    }
+
+    public MarkoutRowWindow Primary => _windows[0];
+
+    public bool IsPositional { get; }
+
+    public int RetentionBound { get; }
+
+    public MarkoutRowSelection Intersect(MarkoutRowWindow window)
+    {
+        var windows = new MarkoutRowWindow[_windows.Length + 1];
+        _windows.CopyTo(windows, 0);
+        windows[^1] = window;
+        return new MarkoutRowSelection(windows);
+    }
+
+    public (int KeepStart, int KeepEnd) Resolve(int dataCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(dataCount);
+
+        var keepStart = 0;
+        var keepEnd = dataCount;
+        foreach (var window in _windows)
+        {
+            var (windowStart, windowEnd) = window.Resolve(dataCount);
+            keepStart = Math.Max(keepStart, windowStart);
+            keepEnd = Math.Min(keepEnd, windowEnd);
+        }
+
+        if (keepEnd < keepStart)
+            keepEnd = keepStart;
+
+        return (keepStart, keepEnd);
+    }
+
+    public bool KeepsPosition(int position)
+    {
+        if (!IsPositional)
+        {
+            throw new InvalidOperationException(
+                "A row selection containing a Tail window cannot be resolved by position.");
+        }
+
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+        foreach (var window in _windows)
+        {
+            if (!window.KeepsPosition(position))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -200,8 +200,8 @@ public class MarkoutWriterOptions
     }
 
     /// <summary>
-    /// Which data rows tables emit, preserving headings and header rows.
-    /// Default is null (every row).
+    /// Gets the primary row window, or replaces the complete row selection,
+    /// preserving headings and header rows. Default is null (every row).
     ///
     /// <para>
     /// This is <em>selection</em>, not summarization, which is what separates it
@@ -213,9 +213,10 @@ public class MarkoutWriterOptions
     /// </para>
     ///
     /// <para>
-    /// Assigning this property replaces the complete selection, including any
-    /// constraints previously added through <see cref="IntersectRowWindow"/>.
-    /// Assigning null clears the selection.
+    /// The getter returns only the primary window. Assigning this property
+    /// replaces the complete selection, including any constraints previously
+    /// added through <see cref="IntersectRowWindow"/>. Assigning null clears the
+    /// selection, so reading and reassigning this property also clears intersections.
     /// </para>
     /// </summary>
     public MarkoutRowWindow? RowWindow

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -13,7 +13,7 @@ public class MarkoutWriterOptions
     private bool _boldFieldNames;
     private bool _prettyTables;
     private int? _maxItems;
-    private MarkoutRowWindow? _rowWindow;
+    private MarkoutRowSelection? _rowSelection;
     private HashSet<string>? _includeSections;
     private IReadOnlyList<string>? _sectionOrder;
     private MarkoutProjection? _projection;
@@ -44,7 +44,7 @@ public class MarkoutWriterOptions
         _boldFieldNames = source._boldFieldNames;
         _prettyTables = source._prettyTables;
         _maxItems = source._maxItems;
-        _rowWindow = source._rowWindow;
+        _rowSelection = source._rowSelection;
         _includeSections = source._includeSections;
         _sectionOrder = source._sectionOrder;
         _projection = source._projection;
@@ -211,16 +211,40 @@ public class MarkoutWriterOptions
     /// first and <see cref="MaxItems"/> then caps the selection, so any ellipsis
     /// reports only the rows the cap dropped.
     /// </para>
+    ///
+    /// <para>
+    /// Assigning this property replaces the complete selection, including any
+    /// constraints previously added through <see cref="IntersectRowWindow"/>.
+    /// Assigning null clears the selection.
+    /// </para>
     /// </summary>
     public MarkoutRowWindow? RowWindow
     {
-        get => _rowWindow;
+        get => _rowSelection?.Primary;
         set
         {
             ThrowIfReadOnly();
-            _rowWindow = value;
+            _rowSelection = value is { } window ? new MarkoutRowSelection(window) : null;
         }
     }
+
+    /// <summary>
+    /// Adds a row-window constraint to the current selection.
+    /// </summary>
+    /// <param name="window">The window to intersect with the current selection.</param>
+    /// <remarks>
+    /// Each window resolves independently against the table's original row count,
+    /// so intersection never renumbers rows selected by an earlier window. If
+    /// <see cref="RowWindow"/> is null, this method establishes the primary window.
+    /// Assigning <see cref="RowWindow"/> afterwards replaces the complete selection.
+    /// </remarks>
+    public void IntersectRowWindow(MarkoutRowWindow window)
+    {
+        ThrowIfReadOnly();
+        _rowSelection = _rowSelection?.Intersect(window) ?? new MarkoutRowSelection(window);
+    }
+
+    internal MarkoutRowSelection? RowSelection => _rowSelection;
 
     /// <summary>
     /// If set, only sections whose heading text matches are rendered.

--- a/src/Markout/TableWriter.cs
+++ b/src/Markout/TableWriter.cs
@@ -22,8 +22,9 @@ public class TableWriter
     private int _tableRowCount;
     private int _tableRowsSkipped;
     private int _dataPosition;
-    private Queue<string[]>? _tailBuffer;
+    private Queue<(int Position, string[] Values)>? _tailBuffer;
     private int _tailBound;
+    private MarkoutRowSelection? _streamingSelection;
 
     /// <summary>
     /// Creates a table writer with a batch table formatter.
@@ -63,7 +64,7 @@ public class TableWriter
     {
         ValidateHeaders(headers, headerNames);
         var renderedHeaders = FormatHeaders(headers, headerNames);
-        var (selected, skipped) = SelectRows(rows);
+        var (selected, skipped) = SelectRows(rows, _options.RowSelection);
 
         if (_batchFormatter != null)
         {
@@ -106,12 +107,12 @@ public class TableWriter
         ValidateHeaders(headers, headerNames);
         var renderedHeaders = FormatHeaders(headers, headerNames);
 
-        var window = _options.RowWindow;
+        var selection = _options.RowSelection;
         var streamingDirect =
             _streamingFormatter != null &&
             _options.TableOptions == null &&
-            (window == null || window.Value.IsPositional);
-        Queue<string[]>? tailBuffer = null;
+            (selection == null || selection.IsPositional);
+        Queue<(int Position, string[] Values)>? tailBuffer = null;
         List<string[]>? streamingRows = null;
         var tailBound = 0;
 
@@ -119,10 +120,10 @@ public class TableWriter
         {
             _streamingFormatter!.BeginTable(_writer, renderedHeaders, _options);
         }
-        else if (window is { IsPositional: false } tail)
+        else if (selection is { IsPositional: false })
         {
-            tailBound = tail.RetentionBound;
-            tailBuffer = new Queue<string[]>(Math.Min(tailBound, 1024));
+            tailBound = selection.RetentionBound;
+            tailBuffer = new Queue<(int Position, string[] Values)>(Math.Min(tailBound, 1024));
         }
         else
         {
@@ -137,6 +138,7 @@ public class TableWriter
         _tailBound = tailBound;
         _streamingRows = streamingRows;
         _streamingHeaders = renderedHeaders;
+        _streamingSelection = selection;
     }
 
     private static void ValidateHeaders(
@@ -214,7 +216,8 @@ public class TableWriter
         // A positional window is asked about this row directly; it is the same type
         // that answers Resolve, so streaming does not get its own idea of what the
         // window means. A Tail window has no answer yet and is settled at the end.
-        if (_options.RowWindow is { IsPositional: true } window && !window.KeepsPosition(position))
+        if (_streamingSelection is { IsPositional: true } selection &&
+            !selection.KeepsPosition(position))
             return;
 
         // MaxItems caps the window's selection, so it counts selected rows. Under a
@@ -240,7 +243,7 @@ public class TableWriter
             {
                 while (_tailBuffer.Count >= _tailBound)
                     _tailBuffer.Dequeue();
-                _tailBuffer.Enqueue(values.ToArray());
+                _tailBuffer.Enqueue((position, values.ToArray()));
             }
         }
         else
@@ -266,10 +269,19 @@ public class TableWriter
             // MaxItems already capped what survived, so re-running SelectRows here
             // would apply the window a second time to rows that are only the window's
             // output. Only a Tail window still has both to settle.
-            var rows = (IList<string[]>)(_tailBuffer?.ToArray() ?? (IList<string[]>?)_streamingRows ?? []);
+            IList<string[]> rows;
             var skipped = _tableRowsSkipped;
-            if (_options.RowWindow is { IsPositional: false })
-                (rows, skipped) = SelectRows(rows);
+            if (_tailBuffer != null)
+            {
+                (rows, skipped) = SelectBufferedTailRows(
+                    _tailBuffer,
+                    _streamingSelection!,
+                    _dataPosition);
+            }
+            else
+            {
+                rows = _streamingRows ?? [];
+            }
 
             if (_batchFormatter != null)
             {
@@ -290,6 +302,7 @@ public class TableWriter
         _streamingRows = null;
         _tailBuffer = null;
         _streamingDirect = false;
+        _streamingSelection = null;
     }
 
     /// <summary>
@@ -297,18 +310,20 @@ public class TableWriter
     /// wait: capping on arrival would cap the rows that came first, not the rows the
     /// window selected.
     /// </summary>
-    private bool DefersMaxItems => _options.RowWindow is { IsPositional: false };
+    private bool DefersMaxItems => _streamingSelection is { IsPositional: false };
 
-    private (IList<string[]> rows, int skipped) SelectRows(IList<string[]> rows)
+    private (IList<string[]> rows, int skipped) SelectRows(
+        IList<string[]> rows,
+        MarkoutRowSelection? selection)
     {
         var selected = rows;
 
         // Selection runs before summarization: the window says which rows exist,
         // MaxItems then says how many of those to show. Resolving here — and only
         // here — is what keeps every table mode agreeing on what a row window means.
-        if (_options.RowWindow is { } window)
+        if (selection != null)
         {
-            var (keepStart, keepEnd) = window.Resolve(rows.Count);
+            var (keepStart, keepEnd) = selection.Resolve(rows.Count);
             if (keepStart != 0 || keepEnd != rows.Count)
             {
                 var kept = new List<string[]>(keepEnd - keepStart);
@@ -316,6 +331,25 @@ public class TableWriter
                     kept.Add(rows[i]);
                 selected = kept;
             }
+        }
+
+        if (_options.MaxItems is int max && selected.Count > max)
+            return (selected.Take(max).ToList(), selected.Count - max);
+
+        return (selected, 0);
+    }
+
+    private (IList<string[]> rows, int skipped) SelectBufferedTailRows(
+        IEnumerable<(int Position, string[] Values)> rows,
+        MarkoutRowSelection selection,
+        int dataCount)
+    {
+        var (keepStart, keepEnd) = selection.Resolve(dataCount);
+        var selected = new List<string[]>(Math.Min(selection.RetentionBound, keepEnd - keepStart));
+        foreach (var (position, values) in rows)
+        {
+            if (position >= keepStart && position < keepEnd)
+                selected.Add(values);
         }
 
         if (_options.MaxItems is int max && selected.Count > max)

--- a/tests/Markout.Tests/GeneratedTableTests.cs
+++ b/tests/Markout.Tests/GeneratedTableTests.cs
@@ -1931,6 +1931,24 @@ public class GeneratedTableTests
     }
 
     [Fact]
+    public void UnwrappedTables_ResolveIntersectionsIndependentlyPerSection()
+    {
+        var options = new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(2) };
+        options.IntersectRowWindow(MarkoutRowWindow.Range(2, 2));
+
+        var mdf = MarkoutSerializer.Serialize(
+            DynamicSample(),
+            DynamicMetadataContext.Default,
+            options);
+
+        Assert.Contains("| 0x8 | Object |", mdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("| 0x1 | System |", mdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("| 0x10 | String |", mdf, StringComparison.Ordinal);
+        Assert.Contains("| 0xC | 4 |", mdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("| 0x0 | 12 |", mdf, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ComposedDocument_IsByteIdenticalToOneAssembledByHand()
     {
         // The whole point: a document whose sections come from a MarkoutTable model property must

--- a/tests/Markout.Tests/GraphTests.cs
+++ b/tests/Markout.Tests/GraphTests.cs
@@ -507,6 +507,21 @@ public class GraphTests
     }
 
     [Fact]
+    public void TableGraph_HonorsIntersectedRowWindows()
+    {
+        var options = new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(1) };
+        options.IntersectRowWindow(MarkoutRowWindow.Range(1, 1));
+        var orch = MarkoutWriter.Create(new TableFormatter(), options);
+
+        Assert.True(orch.WriteGraph(SimpleChain()));
+
+        var output = orch.ToString();
+        Assert.DoesNotContain("A", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("B", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("C", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ProjectedOutGraphTable_DoesNotMaterializeEdgeRows()
     {
         var nodes = Enumerable.Range(0, 10_001)

--- a/tests/Markout.Tests/RowWindowTests.cs
+++ b/tests/Markout.Tests/RowWindowTests.cs
@@ -70,6 +70,16 @@ public class RowWindowTests
     public static TheoryData<MarkoutTableMode> AllModes =>
         new(Enum.GetValues<MarkoutTableMode>());
 
+    private static MarkoutWriterOptions Select(
+        MarkoutTableMode mode,
+        params ReadOnlySpan<MarkoutRowWindow> windows)
+    {
+        var options = new MarkoutWriterOptions { TableMode = mode };
+        foreach (var window in windows)
+            options.IntersectRowWindow(window);
+        return options;
+    }
+
     public static TheoryData<MarkoutRowWindow, string[], string[]> MetricWindows =>
         new()
         {
@@ -164,6 +174,30 @@ public class RowWindowTests
             Assert.Contains(label, output, StringComparison.Ordinal);
         foreach (var label in excluded)
             Assert.DoesNotContain(label, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownMetrics_HonorTheCompleteIntersection()
+    {
+        var options = Select(
+            default,
+            MarkoutRowWindow.Tail(3),
+            MarkoutRowWindow.Range(2, 3));
+        var writer = MarkoutWriter.Create(new MarkdownFormatter(), options);
+
+        writer.WriteMetrics(
+        [
+            new Metric("m1", 1),
+            new Metric("m2", 2),
+            new Metric("m3", 3),
+            new Metric("m4", 4)
+        ]);
+
+        var output = writer.Complete();
+        Assert.Contains("m2", output, StringComparison.Ordinal);
+        Assert.Contains("m3", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("m1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("m4", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -370,6 +404,71 @@ public class RowWindowTests
         Assert.DoesNotContain("r4", output);
     }
 
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void EveryTableMode_IntersectsHeadAndRangeAgainstOriginalRows(MarkoutTableMode mode)
+    {
+        var output = Render(
+            Select(mode, MarkoutRowWindow.Head(4), MarkoutRowWindow.Range(3, 6)),
+            Rows(8));
+
+        Assert.DoesNotContain("r2", output);
+        Assert.Contains("r3", output);
+        Assert.Contains("r4", output);
+        Assert.DoesNotContain("r5", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void EveryTableMode_IntersectsTailAndRangeAgainstOriginalRows(MarkoutTableMode mode)
+    {
+        var output = Render(
+            Select(mode, MarkoutRowWindow.Tail(4), MarkoutRowWindow.Range(3, 6)),
+            Rows(8));
+
+        Assert.DoesNotContain("r4", output);
+        Assert.Contains("r5", output);
+        Assert.Contains("r6", output);
+        Assert.DoesNotContain("r7", output);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void DisjointAndZeroCountIntersections_EmitNoRows(MarkoutTableMode mode)
+    {
+        var disjoint = Render(
+            Select(mode, MarkoutRowWindow.Tail(3), MarkoutRowWindow.Range(1, 2)),
+            Rows(8));
+        var zero = Render(
+            Select(mode, MarkoutRowWindow.Head(0), MarkoutRowWindow.Range(1, null)),
+            Rows(8));
+
+        foreach (var row in Rows(8).Select(static row => row[0]))
+        {
+            Assert.DoesNotContain(row, disjoint);
+            Assert.DoesNotContain(row, zero);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void Intersections_AreIndependentOfOperandOrder(MarkoutTableMode mode)
+    {
+        var tailThenRange = Select(
+            mode,
+            MarkoutRowWindow.Tail(4),
+            MarkoutRowWindow.Range(3, 6));
+        var rangeThenTail = Select(
+            mode,
+            MarkoutRowWindow.Range(3, 6),
+            MarkoutRowWindow.Tail(4));
+
+        Assert.Equal(Render(tailThenRange, Rows(8)), Render(rangeThenTail, Rows(8)));
+        Assert.Equal(
+            RenderStreaming(tailThenRange, Rows(8)),
+            RenderStreaming(rangeThenTail, Rows(8)));
+    }
+
     /// <summary>
     /// A window is selection, not summarization: its output has to stay
     /// machine-consumable. An ellipsis appended to JSONL is a malformed record,
@@ -451,6 +550,24 @@ public class RowWindowTests
         Assert.Contains("r2", output);
         Assert.DoesNotContain("r3", output);
         Assert.DoesNotContain("more", output);
+    }
+
+    [Fact]
+    public void MaxItems_CapsAfterTheCompleteIntersection()
+    {
+        var options = Select(
+            default,
+            MarkoutRowWindow.Tail(5),
+            MarkoutRowWindow.Range(3, 7));
+        options.MaxItems = 2;
+
+        var output = Render(options, Rows(8));
+
+        Assert.Contains("r4", output);
+        Assert.Contains("r5", output);
+        Assert.DoesNotContain("r3", output);
+        Assert.DoesNotContain("r6", output);
+        Assert.Contains("... and 2 more", output);
     }
 
     // ── The streaming seam ──
@@ -600,6 +717,44 @@ public class RowWindowTests
         }
     }
 
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void StreamedRows_AgreeWithBatchedRowsForIntersectedWindows(MarkoutTableMode mode)
+    {
+        MarkoutRowWindow[][] selections =
+        [
+            [MarkoutRowWindow.Head(4), MarkoutRowWindow.Range(3, 6)],
+            [MarkoutRowWindow.Tail(4), MarkoutRowWindow.Range(3, 6)],
+            [MarkoutRowWindow.Tail(5), MarkoutRowWindow.Tail(2)],
+            [MarkoutRowWindow.Head(2), MarkoutRowWindow.Tail(2)],
+            [MarkoutRowWindow.Tail(3), MarkoutRowWindow.Range(1, 2)]
+        ];
+
+        foreach (var selection in selections)
+        {
+            var options = Select(mode, selection);
+            Assert.Equal(
+                Render(options, Rows(8)),
+                RenderStreaming(options, Rows(8)));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllModes))]
+    public void PositionalIntersectionsWithMaxItems_AgreeAcrossStreamingAndBatch(
+        MarkoutTableMode mode)
+    {
+        var options = Select(
+            mode,
+            MarkoutRowWindow.Head(6),
+            MarkoutRowWindow.Range(3, 6));
+        options.MaxItems = 2;
+
+        Assert.Equal(
+            Render(options, Rows(8)),
+            RenderStreaming(options, Rows(8)));
+    }
+
     // ── Options plumbing ──
 
     [Fact]
@@ -609,6 +764,51 @@ public class RowWindowTests
         options.MakeReadOnly();
 
         Assert.Throws<InvalidOperationException>(() => options.RowWindow = MarkoutRowWindow.Head(1));
+        Assert.Throws<InvalidOperationException>(
+            () => options.IntersectRowWindow(MarkoutRowWindow.Tail(1)));
+    }
+
+    [Fact]
+    public void AssigningRowWindow_ReplacesTheCompleteSelection()
+    {
+        var options = Select(
+            default,
+            MarkoutRowWindow.Head(4),
+            MarkoutRowWindow.Range(3, 3));
+
+        options.RowWindow = MarkoutRowWindow.Tail(1);
+        var output = Render(options, Rows(5));
+
+        Assert.Equal(MarkoutRowWindow.Tail(1), options.RowWindow);
+        Assert.Contains("r5", output);
+        Assert.DoesNotContain("r3", output);
+    }
+
+    [Fact]
+    public void AssigningNull_ClearsTheCompleteSelection()
+    {
+        var options = Select(
+            default,
+            MarkoutRowWindow.Head(1),
+            MarkoutRowWindow.Range(3, 3));
+
+        options.RowWindow = null;
+        var output = Render(options, Rows(3));
+
+        Assert.Null(options.RowWindow);
+        Assert.Contains("r1", output);
+        Assert.Contains("r3", output);
+    }
+
+    [Fact]
+    public void IntersectingWithoutAPrimaryWindow_EstablishesIt()
+    {
+        var options = new MarkoutWriterOptions();
+        var window = MarkoutRowWindow.Range(2, 2);
+
+        options.IntersectRowWindow(window);
+
+        Assert.Equal(window, options.RowWindow);
     }
 
     /// <summary>
@@ -627,8 +827,9 @@ public class RowWindowTests
             new MarkoutWriterOptions
             {
                 TableMode = MarkoutTableMode.Jsonl,
-                RowWindow = MarkoutRowWindow.Tail(1)
+                RowWindow = MarkoutRowWindow.Tail(2)
             });
+        writer.Options.IntersectRowWindow(MarkoutRowWindow.Range(3, 3));
 
         writer.WriteCompositeTable(
             MarkoutCompositeRow.Scalar("first", "1"),
@@ -640,6 +841,7 @@ public class RowWindowTests
         Assert.Single(lines);
         Assert.Contains("third", lines[0]);
         Assert.DoesNotContain("first", lines[0]);
+        Assert.DoesNotContain("second", lines[0]);
     }
 
     [Fact]
@@ -794,6 +996,41 @@ public class RowWindowTests
         Assert.Contains("row:r1", sw.ToString());
     }
 
+    [Fact]
+    public void ATailRangeIntersection_UsesOriginalPositionsAfterBuffering()
+    {
+        var options = Select(
+            default,
+            MarkoutRowWindow.Tail(3),
+            MarkoutRowWindow.Range(1, 10));
+
+        var output = RenderStreamingOnly(options, Rows(100));
+
+        Assert.DoesNotContain("row:", output);
+        Assert.Contains("end:0", output);
+    }
+
+    [Fact]
+    public void AStreamingTable_SnapshotsItsCompleteSelection()
+    {
+        var options = Select(
+            default,
+            MarkoutRowWindow.Head(4),
+            MarkoutRowWindow.Range(2, 2));
+        var sw = new StringWriter();
+        var writer = new TableWriter(sw, new StreamingOnlyFormatter(), options);
+        writer.WriteTableStart(Header);
+
+        options.RowWindow = MarkoutRowWindow.Tail(1);
+        foreach (var row in Rows(5))
+            writer.WriteTableRow(row);
+        writer.WriteTableEnd();
+
+        var output = sw.ToString();
+        Assert.Contains("row:r2", output);
+        Assert.DoesNotContain("row:r5", output);
+    }
+
     /// <summary>
     /// A window that keeps nothing must cost nothing per row. Tail is the only kind
     /// that retains rows at all, so it is the only one that can get this wrong, and
@@ -855,13 +1092,41 @@ public class RowWindowTests
         Assert.Equal(Bound, alive);
     }
 
+    [Fact]
+    public void MultipleTailWindows_HoldTheSmallestBound()
+    {
+        const int Rows = 1000;
+        const int Bound = 7;
+        var options = new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(100) };
+        options.IntersectRowWindow(MarkoutRowWindow.Tail(Bound));
+
+        var (writer, tracked) = FillTail(Rows, options);
+
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+
+        var alive = tracked.Count(reference => reference.IsAlive);
+        GC.KeepAlive(writer);
+
+        Assert.Equal(Bound, alive);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static (TableWriter Writer, WeakReference[] Tracked) FillTail(int rows, int bound)
+        => FillTail(
+            rows,
+            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(bound) });
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (TableWriter Writer, WeakReference[] Tracked) FillTail(
+        int rows,
+        MarkoutWriterOptions options)
     {
         var writer = new TableWriter(
             TextWriter.Null,
             new StreamingOnlyFormatter(),
-            new MarkoutWriterOptions { RowWindow = MarkoutRowWindow.Tail(bound) });
+            options);
         writer.WriteTableStart(Header);
 
         var tracked = new WeakReference[rows];


### PR DESCRIPTION
## Summary

- Add `MarkoutWriterOptions.IntersectRowWindow` while preserving `RowWindow` as the primary compatibility surface.
- Resolve every constraint against each table's original row ordinals, without renumbering between selections.
- Preserve direct streaming for positional intersections and bound tail buffering by the smallest tail constraint.

## Demo

```csharp
var options = new MarkoutWriterOptions
{
    RowWindow = MarkoutRowWindow.Tail(4)
};
options.IntersectRowWindow(MarkoutRowWindow.Range(3, 6));
```

Applied to rows 1 through 8, this emits rows 5 and 6. Notice that `Range(3, 6)` addresses the original rows rather than the four-row result of `Tail(4)`. Reversing the two constraints gives the same result, and each subsequent table resolves the selection independently.

## Consumer proof

The exact source head was consumed from dotnet-inspect's `feature/4677-universal-item-limit` worktree through local project references. Its writer seam composed item and absolute range windows across Markdown, TSV, and JSONL while preserving stable addresses; 165 focused `OutputFormatterTests` passed, and the complete Release solution graph built successfully. The absolute project references remain local and unpushed.

## Validation

- `dotnet build Markout.sln -c Release --no-restore`
- `dotnet run --project tests/Markout.Tests -c Release --no-build` — 5,301 passed; two timing-sensitive tests were rerun in isolation after shared-host contention
- `npx markdownlint-cli docs/user-guide.md`
- `git diff --check`

Closes #215