### PR TITLE
Design mapped text-diff presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ Markout was created for [dotnet-inspect](https://github.com/richlander/dotnet-in
 
 - **[User Guide](docs/user-guide.md)** — Complete tutorial with attribute reference
 - **[Shape System Design](docs/design/shape-system.md)** — Data projection model, shape tiers, admission criteria
+- **[Mapped Text Diff Design](docs/design/mapped-text-diff.md)** — Caller-issued range mappings with unified, rich, and structured presentation
 - **[Specification](docs/specification.md)** — Format grammar and type inference rules
 - **[Nested Lists Guide](docs/nested-lists-guide.md)** — Strategies for nested data structures
 

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -143,10 +143,9 @@ A valid mapped text diff satisfies all of the following:
 8. Every annotation target is contained by its declared side and enclosing
    change.
 9. A final-line-terminator assertion is present only for a non-empty sequence.
-10. When both sequences are non-empty and exactly one asserts an `absent`
-    final line terminator, the final line on that side is contained by a
-    caller-issued change. `present` and unknown are both non-marker-emitting
-    states.
+10. A final line asserting an `absent` terminator is either contained by a
+    caller-issued change or corresponds through the trailing unchanged gap to
+    the other sequence's final line, which also asserts `absent`.
 11. Collection order is significant and preserved.
 
 Equal-cardinality gaps between changes are unchanged sequence ranges whose
@@ -251,8 +250,12 @@ When an emitted final line has an `absent` final-line-terminator assertion, the
 lowering emits the conventional `\ No newline at end of file` marker
 immediately after that side's line. `present` and unknown assertions emit no
 marker. A shared final context line emits one marker only when both sides
-assert `absent`. The final line on an exactly-one-`absent` side must belong to
-a change, so a shared context line never has contradictory marker state.
+assert `absent`. Construction permits an `absent` final line in unchanged
+context only when it corresponds to that shared final line, so context never
+has contradictory marker state.
+
+Appending after an unterminated final line therefore maps that former final
+line as changed in addition to mapping the appended lines, matching GNU diff.
 
 The Markdown renderer chooses a fence longer than any fence run in the content.
 Caller text never occupies the fence language or another structural syntax

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -96,10 +96,19 @@ The range counts determine the change form:
 Replacement is a relation between ranges, not a `Changed` line kind. It may be
 one-to-one, one-to-many, many-to-one, or many-to-many.
 
-An inner mapping relates one side-local text span to another inside a
+A side-local text span identifies one sequence line and a half-open range of
+zero-based UTF-16 code-unit offsets within that line. It cannot cross a line or
+split a surrogate pair. Multi-line emphasis uses an ordered span on each
+affected line. Grapheme clusters may be subdivided because the coordinate
+contract follows .NET and editor text positions rather than display cells.
+Span positions order lexicographically by line coordinate, then UTF-16 offset.
+
+An inner mapping relates one Before text span to one After text span inside a
 replacement. An empty span on one side represents an intraline insertion or
-removal. Inner mappings provide display evidence only; Markout does not use
-them to validate or derive the enclosing line-range mapping.
+removal; two empty spans are invalid. The two line coordinates explicitly
+establish the line pairing for that mapping. Inner mappings provide display
+evidence only; Markout does not use them to validate or derive the enclosing
+line-range mapping.
 
 An annotation carries caller-issued text and targets either:
 
@@ -127,14 +136,16 @@ A valid mapped text diff satisfies all of the following:
 6. Every leading, intervening, and trailing gap has the same line count on
    Before and After. The sequence starts and ends act as implicit boundaries
    for this calculation.
-7. Inner mappings are valid only on replacements, are contained by their
-   declared side and enclosing change, and follow the same monotonic,
-   non-overlapping order on each side.
+7. Inner mappings are valid only on replacements, do not contain two empty
+   spans, are contained by their declared side and enclosing change, do not
+   split surrogate pairs, and follow the same monotonic, non-overlapping order
+   on each side.
 8. Every annotation target is contained by its declared side and enclosing
    change.
 9. A final-line-terminator assertion is present only for a non-empty sequence.
-10. When both sequences assert different final-line-terminator states, each
-    final line is contained by a caller-issued change.
+10. When both sequences are non-empty and exactly one asserts an `absent`
+    final line terminator, each final line is contained by a caller-issued
+    change. `present` and unknown are both non-marker-emitting states.
 11. Collection order is significant and preserved.
 
 Equal-cardinality gaps between changes are unchanged sequence ranges whose
@@ -154,7 +165,8 @@ Sequence lines retain their side and zero-based sequence position.
 Every lowering that expands one change into multiple physical rows or lines
 must retain enough provenance to answer:
 
-- which change produced this output;
+- which change produced this output, or that it is unchanged context or an
+  omission outside the change population;
 - whether the output belongs to Before, After, or both;
 - which sequence line or lines it presents; and
 - whether it is semantic content, annotation geometry, or an omission notice.
@@ -200,9 +212,9 @@ and `[MarkoutMaxItems]` do not trim records inside a selected diff. Section
 selection may omit the complete containing section, but it does not produce a
 partial diff.
 
-Output-size limiting is not part of context selection. If a host transport
-cannot carry every change and exact omission record, it rejects the rendering
-visibly rather than presenting a success-shaped truncated diff.
+Transport-level output-size limits are outside the mapped-diff shape.
+Markout's selected rendering is complete rather than success-shaped partial
+output.
 
 ## Formatter contract
 
@@ -237,9 +249,10 @@ and Git patch convention.
 When an emitted final line has an `absent` final-line-terminator assertion, the
 lowering emits the conventional `\ No newline at end of file` marker
 immediately after that side's line. `present` and unknown assertions emit no
-marker. Construction requires a side-specific final-line-termination
-difference to belong to a change, so a shared context line never has
-contradictory marker state.
+marker. A shared final context line emits one marker only when both sides
+assert `absent`. Construction requires exactly-one-`absent` final lines to
+belong to a change, so a shared context line never has contradictory marker
+state.
 
 The Markdown renderer chooses a fence longer than any fence run in the content.
 Caller text never occupies the fence language or another structural syntax
@@ -256,7 +269,10 @@ caller-issued inner mappings:
 ```
 
 The `~` and span delimiters above illustrate renderer chrome. They are not
-line kinds in the semantic model.
+line kinds in the semantic model. The renderer combines Before and After text
+on one display line only when caller-issued inner mappings establish that
+line pairing. Otherwise it presents the replacement sides separately rather
+than pairing lines by ordinal position.
 
 ### Side-by-side lowering
 
@@ -289,6 +305,7 @@ These are design precedents, not dependencies.
 Table, TSV, and JSONL lowerings expose fixed, unique fields sufficient to
 recover change and side provenance. The vocabulary includes:
 
+- record kind;
 - change address and form;
 - side;
 - side-local line coordinate;
@@ -298,14 +315,20 @@ recover change and side provenance. The vocabulary includes:
 - annotation target and text when present; and
 - final-line-terminator assertions when known.
 
+Change-derived records require a change address. Unchanged context records
+instead carry both corresponding side coordinates. Omission records carry
+their complete Before and After ranges and hidden count. Annotation records
+carry the address of their target change.
+
 The structured schema does not use rendered `-`, `+`, `~`, color, or spacing as
 data. Tabs, line breaks, and non-graphic text follow the formatter's existing
 machine-output containment rules.
 
-One change may lower to several side-line records. Every record carries the
-same change address, so consumers can regroup it without parsing display text.
-Mandatory provenance fields cannot be removed through generic table column
-projection, and generic row windows or caps cannot split or discard changes.
+One change may lower to several side-line records. Every record derived from
+that change carries the same change address, so consumers can regroup it
+without parsing display text. No mapped-diff record field is subject to generic
+table column projection, and generic row windows or caps cannot split or
+discard changes.
 
 ### ANSI lowering
 
@@ -366,6 +389,7 @@ inject a header, hunk, record, annotation geometry, or formatter control.
 The implementation must define and test:
 
 - malformed UTF-16;
+- text spans at valid and invalid surrogate boundaries;
 - embedded carriage returns and line feeds;
 - tabs and long lines;
 - Markdown fence runs and inline syntax;

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -1,0 +1,405 @@
+# Mapped text diff
+
+## Status and ownership
+
+This document defines the Markout-owned presentation contract for mapped text
+diffs. It is proposed by
+[issue #218](https://github.com/richlander/markout/issues/218).
+
+Markout owns validation, formatter dispatch, context projection, provenance
+through lowerings, and presentation of caller-issued mappings between two
+ordered text sequences.
+
+The caller owns:
+
+- the compared subjects and their identity;
+- the text selected for each side;
+- every equality, correspondence, replacement, movement, and annotation claim;
+- failure and availability outcomes that precede a diff; and
+- any language, syntax, or domain interpretation.
+
+The normative claim is:
+
+> Markout presents owner-issued mappings between two ordered text sequences;
+> formatters choose a rich view or a GNU-compatible unified lowering.
+
+Markout never computes a diff or infers a mapping from text.
+
+## Relationship and admission
+
+A mapped text diff is the relationship between two immutable ordered text
+sequences and an ordered set of changes mapping ranges on the first side to
+ranges on the second.
+
+It is distinct from existing shapes:
+
+- `Change<T>` compares one scalar or composite cell.
+- A table relates uniform records but does not establish correspondence between
+  two ordered sequences.
+- `CodeSection` quotes opaque text and cannot expose changes, coordinates, or
+  annotations to another formatter.
+- A graph relates deduplicated nodes through edges rather than preserving two
+  ordered sides.
+
+The shape passes the
+[shape admission criteria](shape-system.md#shape-admission-criteria):
+
+1. Its public type is recognizable by the source generator.
+2. Mapped sequence correspondence is a distinct relationship.
+3. Markdown, plain text, ANSI, and structured formatters have meaningful
+   lowerings.
+4. The shape composes as a property, section, or complete document.
+5. Source, configuration, instruction, schema, artifact, and log comparisons
+   all use the relationship.
+
+Mapped text diff is a Tier 2 semantic extension. Rich renderers may add layout
+and emphasis, but the shape itself is not a visualization.
+
+## Conceptual model
+
+One diff contains:
+
+- a **Before sequence** with an optional label and ordered logical lines;
+- an **After sequence** with an optional label and ordered logical lines; and
+- an ordered **change population** mapping non-overlapping ranges between the
+  sequences.
+
+Each line is one logical line without its line terminator. An empty string is a
+valid blank line. Sequence position is a zero-based document-local coordinate;
+human renderers normally display it as a one-based line number.
+
+Each change contains:
+
+- one half-open Before line range;
+- one half-open After line range;
+- zero or more caller-issued inner text mappings;
+- zero or more caller-issued annotations; and
+- its zero-based position in the change population.
+
+The range counts determine the change form:
+
+| Before count | After count | Form |
+| ---: | ---: | --- |
+| `0` | positive | Addition |
+| positive | `0` | Removal |
+| positive | positive | Replacement |
+| `0` | `0` | Invalid |
+
+Replacement is a relation between ranges, not a `Changed` line kind. It may be
+one-to-one, one-to-many, many-to-one, or many-to-many.
+
+An inner mapping relates one side-local text span to another inside a
+replacement. An empty span on one side represents an intraline insertion or
+removal. Inner mappings provide display evidence only; Markout does not use
+them to validate or derive the enclosing line-range mapping.
+
+An annotation carries caller-issued text and targets either:
+
+- the complete change;
+- one side-local line; or
+- one side-local text span.
+
+Annotation severity may reuse Markout's existing callout vocabulary. Domain
+categories, compiler concepts, CSS classes, colors, and arbitrary property
+bags are outside the shape.
+
+## Construction invariants
+
+A valid mapped text diff satisfies all of the following:
+
+1. Both sequence and change collections are initialized immutable snapshots.
+2. Every line is well-formed text and contains no carriage return or line feed.
+3. Every change range is within its owning sequence.
+4. No change has two empty ranges.
+5. Changes are strictly ordered by both side-local start coordinates after
+   empty-range insertion points are accounted for.
+6. Before ranges do not overlap other Before ranges.
+7. After ranges do not overlap other After ranges.
+8. Every inner mapping and annotation target is contained by its declared side
+   and enclosing change.
+9. Collection order is significant and preserved.
+
+Gaps between changes are unchanged sequence ranges. The constructor does not
+compare their text; accepting the caller's mapping is accepting the caller's
+claim that those gaps correspond.
+
+Construction rejects invalid input. It does not normalize, sort, trim, or
+repair caller data.
+
+## Population and provenance
+
+The ordered change collection is the canonical change population. A stable
+change address is its zero-based position within one immutable diff value.
+Sequence lines retain their side and zero-based sequence position.
+
+Every lowering that expands one change into multiple physical rows or lines
+must retain enough provenance to answer:
+
+- which change produced this output;
+- whether the output belongs to Before, After, or both;
+- which sequence line or lines it presents; and
+- whether it is semantic content, annotation geometry, or an omission notice.
+
+This avoids the population mismatch identified for Graph in
+[issue #175](https://github.com/richlander/markout/issues/175). Different
+layouts may enumerate different physical elements, but they must report their
+relationship to the same change and sequence populations.
+
+Shape-level cardinality means **change count**. A structured side-line
+lowering may contain more physical rows, but those rows carry their change
+address and do not redefine cardinality.
+
+Wrapping, intraline spans, annotation rows, headings, and omission notices are
+presentation elements. They never create changes.
+
+## Projection and completeness
+
+The input shape retains both complete sequences and every caller-issued change.
+Formatters may hide unchanged ranges, but they must not discard changes.
+
+A context projection selects unchanged lines around changes and produces
+explicit omitted-range records. Each omitted record names:
+
+- its Before range;
+- its After range; and
+- the number of unchanged lines hidden.
+
+Static output renders an omission notice. An interactive consumer may make the
+same range revealable. Neither represents omitted content as an ambiguous
+literal `...` line.
+
+The caller or host chooses projection policy, including context-line and
+output-size limits. Markout owns applying that policy consistently and
+reporting its exact omissions.
+
+Projection is presentation-only. It does not change the diff's exactness,
+change count, mappings, or annotations.
+
+## Formatter contract
+
+A formatter supporting mapped text diff consumes the validated shape and
+selected presentation projection. Layout is formatter policy.
+
+### GNU-compatible unified lowering
+
+Markdown and portable plain text support unified output:
+
+```diff
+--- Before
++++ After
+@@ -3,2 +3,2 @@
+-    if (value < 0)
+-        return 0;
++    if (value <= 0)
++        return 1;
+```
+
+Unified output uses only:
+
+- space for context;
+- `-` for Before lines; and
+- `+` for After lines.
+
+A replacement expands to its removed lines followed by its added lines. This
+follows the
+[GNU unified format](https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html)
+and Git patch convention.
+
+The Markdown renderer chooses a fence longer than any fence run in the content.
+Caller text never occupies the fence language or another structural syntax
+position.
+
+### Rich inline lowering
+
+A rich narrow renderer may keep one replacement together and emphasize
+caller-issued inner mappings:
+
+```text
+3 ~     if (value [-<-]{+<=+} 0)
+4 ~         return [-0-]{+1+};
+```
+
+The `~` and span delimiters above illustrate renderer chrome. They are not
+line kinds in the semantic model.
+
+### Side-by-side lowering
+
+A wide renderer may align the mapped ranges:
+
+```text
+3  if (value < 0)   |  3  if (value <= 0)
+4      return 0;    |  4      return 1;
+```
+
+Unequal range lengths use empty display cells. A formatter does not infer
+additional line-to-line correspondence inside a many-to-many replacement.
+Caller-issued inner mappings may guide emphasis without asserting a complete
+line pairing.
+
+The model is informed by the public VS Code/Monaco diff surface:
+
+- [`ILineChange`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ILineChange.html)
+  maps original and modified line ranges;
+- [`ICharChange`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.ICharChange.html)
+  retains inner text mappings; and
+- [`IDiffEditorBaseOptions`](https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor_editor_api.editor.IDiffEditorBaseOptions.html)
+  keeps unified, side-by-side, responsive, folded-context, accessibility, and
+  move presentation separate from the change model.
+
+These are design precedents, not dependencies.
+
+### Structured lowering
+
+Table, TSV, and JSONL lowerings expose fixed, unique fields sufficient to
+recover change and side provenance. The vocabulary includes:
+
+- change address and form;
+- side;
+- side-local line coordinate;
+- Before and After range coordinates;
+- text;
+- inner mapping coordinates when selected; and
+- annotation target and text when selected.
+
+The structured schema does not use rendered `-`, `+`, `~`, color, or spacing as
+data. Tabs, line breaks, and non-graphic text follow the formatter's existing
+machine-output containment rules.
+
+One change may lower to several side-line records. Every record carries the
+same change address, so consumers can regroup it without parsing display text.
+
+### ANSI lowering
+
+ANSI renderers may add:
+
+- line and side coordinates;
+- addition, removal, and intraline emphasis;
+- unified or side-by-side layout;
+- wrapping;
+- visible annotation gutters; and
+- navigation hints when the host supports interaction.
+
+The model does not contain colors or terminal escape sequences. Caller-supplied
+control text remains inert.
+
+[delta](https://github.com/dandavison/delta) demonstrates that these
+capabilities can coexist with GNU/Git compatibility: syntax and word emphasis,
+side-by-side wrapping, line numbers, navigation, copy-friendly source, and
+moved-line styling are presentation choices over conventional diff data.
+
+## Annotations
+
+Annotations never alter the sequence text or change mapping. A copy operation
+can therefore copy either exact side without removing carets, labels, or diff
+markers.
+
+A spatial renderer may place one annotation below its target:
+
+```text
++    if (value <= 0)
+                  ^^
+                  Boundary now includes zero
+```
+
+A renderer without stable spatial layout may preserve the same annotation as a
+subordinate record:
+
+```text
+After line 3: Boundary now includes zero
+```
+
+Both presentations retain the same target coordinates. The renderer may wrap
+annotation prose, but it may not move the target or silently omit the
+annotation.
+
+Interactive selection, focus, hover, activation, annotation membership, and
+editor state are consumer concerns. This shape supplies static targets only.
+
+## Safety and platform contract
+
+Mapped text diffs commonly present untrusted package, source, log, or generated
+content. Each formatter must keep caller data out of structural syntax and
+apply context-appropriate containment.
+
+The implementation must define and test:
+
+- malformed UTF-16;
+- embedded carriage returns and line feeds;
+- tabs and long lines;
+- Markdown fence runs and inline syntax;
+- table delimiters;
+- terminal escapes and non-graphic text;
+- bidirectional and zero-width controls;
+- empty sequences and files without a final line terminator; and
+- annotations containing syntax significant to each formatter.
+
+The core shape and its validation remain reflection-free,
+NativeAOT-compatible, and Browser/Wasm-compatible. A formatter may have a
+narrower platform contract only when that exception is explicit and does not
+infect the core shape.
+
+## Source generation and capability boundary
+
+The built-in mapped text diff type is recognizable by exact type identity.
+Generated serializers dispatch it as a section shape in the same manner as
+`Graph`.
+
+Imperative callers use one diff-writing operation. Formatters advertise diff
+support through a dedicated capability interface. Unsupported formatters
+return unsupported through the existing capability contract; Markout does not
+inject a foreign fallback syntax.
+
+Reusable lowerings may adapt a diff to table rows or unified lines. They retain
+the provenance contract above and do not return display strings without their
+source coordinates.
+
+## Adopter evidence
+
+The public contract is proved against at least two independent domains before
+release:
+
+1. A line-oriented source comparison projected from
+   `FindingComparison<string>`.
+2. An instruction comparison projected from `IlDiffDisplayResult`.
+
+A C# replacement projected from `CSharpDiffDisplayResult` is the preferred
+one-to-one replacement example when it fits the same development slice.
+
+The adapters retain producer-owned wording, failure outcomes, coordinates, and
+identity. They do not move comparison logic into Markout.
+
+Development follows the established peer-checkout loop:
+
+1. Develop and review Markout with the adopter using temporary source project
+   references.
+2. Merge and release Markout.
+3. Return the adopter to the released package.
+4. Raise the adopter change only against that package.
+
+## Demo contract
+
+The Markout PR demonstrates one replacement with two inner mappings and one
+annotation through:
+
+- GNU-compatible Markdown;
+- structured rows with change and side provenance; and
+- rich terminal-oriented output.
+
+It also demonstrates a neighboring instruction or configuration comparison to
+show that the public shape contains no source-language assumptions.
+
+The demo calls the public shape and formatter APIs. It does not construct
+expected output through a parallel template.
+
+## Non-goals
+
+- Computing line, word, syntax, or semantic differences.
+- Inferring replacement, movement, or correspondence.
+- Establishing whether two unchanged gaps are actually equal.
+- Replacing caller-owned failure, Finding, provenance, or annotated-document
+  models.
+- Defining an editor, merge operation, or web interaction state.
+- Requiring syntax highlighting or language parsing.
+- Converting every API, metric, or implementation comparison table into a text
+  diff.
+- Defining a general span-annotated document shape outside a mapped diff.

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -6,7 +6,7 @@ This document defines the Markout-owned presentation contract for mapped text
 diffs. It is proposed by
 [issue #218](https://github.com/richlander/markout/issues/218).
 
-Markout owns validation, formatter dispatch, context projection, provenance
+Markout owns validation, formatter dispatch, context selection, provenance
 through lowerings, and presentation of caller-issued mappings between two
 ordered text sequences.
 
@@ -59,20 +59,28 @@ and emphasis, but the shape itself is not a visualization.
 
 One diff contains:
 
-- a **Before sequence** with an optional label and ordered logical lines;
-- an **After sequence** with an optional label and ordered logical lines; and
+- a **Before sequence** with an optional label, ordered logical lines, and an
+  optional final-line-terminator assertion;
+- an **After sequence** with an optional label, ordered logical lines, and an
+  optional final-line-terminator assertion; and
 - an ordered **change population** mapping non-overlapping ranges between the
   sequences.
 
-Each line is one logical line without its line terminator. An empty string is a
-valid blank line. Sequence position is a zero-based document-local coordinate;
-human renderers normally display it as a one-based line number.
+Each line and sequence label is one logical line without its line terminator.
+An empty string is a valid blank line. Sequence position is a zero-based
+document-local coordinate; human renderers normally display it as a one-based
+line number.
+
+The optional final-line-terminator assertion is `present` or `absent` and is
+valid only for a non-empty sequence. It preserves the GNU-visible distinction
+between a terminated and unterminated final line when the producer knows it.
+It does not preserve the spelling of individual line terminators.
 
 Each change contains:
 
 - one half-open Before line range;
 - one half-open After line range;
-- zero or more caller-issued inner text mappings;
+- zero or more caller-issued inner text mappings when it is a replacement;
 - zero or more caller-issued annotations; and
 - its zero-based position in the change population.
 
@@ -108,20 +116,31 @@ bags are outside the shape.
 A valid mapped text diff satisfies all of the following:
 
 1. Both sequence and change collections are initialized immutable snapshots.
-2. Every line is well-formed text and contains no carriage return or line feed.
+2. Every line and sequence label is well-formed text and contains no carriage
+   return or line feed.
 3. Every change range is within its owning sequence.
 4. No change has two empty ranges.
-5. Changes are strictly ordered by both side-local start coordinates after
-   empty-range insertion points are accounted for.
-6. Before ranges do not overlap other Before ranges.
-7. After ranges do not overlap other After ranges.
-8. Every inner mapping and annotation target is contained by its declared side
-   and enclosing change.
-9. Collection order is significant and preserved.
+5. For each adjacent pair, the earlier change's Before end is less than or
+   equal to the later change's Before start, and its After end is less than or
+   equal to the later change's After start. Equality is valid; collection order
+   resolves ties at empty-range insertion points.
+6. Every leading, intervening, and trailing gap has the same line count on
+   Before and After. The sequence starts and ends act as implicit boundaries
+   for this calculation.
+7. Inner mappings are valid only on replacements, are contained by their
+   declared side and enclosing change, and follow the same monotonic,
+   non-overlapping order on each side.
+8. Every annotation target is contained by its declared side and enclosing
+   change.
+9. A final-line-terminator assertion is present only for a non-empty sequence.
+10. When both sequences assert different final-line-terminator states, each
+    final line is contained by a caller-issued change.
+11. Collection order is significant and preserved.
 
-Gaps between changes are unchanged sequence ranges. The constructor does not
-compare their text; accepting the caller's mapping is accepting the caller's
-claim that those gaps correspond.
+Equal-cardinality gaps between changes are unchanged sequence ranges whose
+lines correspond by position. The constructor validates their cardinality but
+does not compare their text; accepting the caller's mapping is accepting the
+caller's claim that those lines correspond.
 
 Construction rejects invalid input. It does not normalize, sort, trim, or
 repair caller data.
@@ -152,33 +171,43 @@ address and do not redefine cardinality.
 Wrapping, intraline spans, annotation rows, headings, and omission notices are
 presentation elements. They never create changes.
 
-## Projection and completeness
+## Context selection and completeness
 
 The input shape retains both complete sequences and every caller-issued change.
 Formatters may hide unchanged ranges, but they must not discard changes.
 
-A context projection selects unchanged lines around changes and produces
-explicit omitted-range records. Each omitted record names:
+A context selection selects unchanged lines around changes and produces
+explicit omission records. Each omitted record names:
 
 - its Before range;
 - its After range; and
 - the number of unchanged lines hidden.
 
-Static output renders an omission notice. An interactive consumer may make the
-same range revealable. Neither represents omitted content as an ambiguous
-literal `...` line.
+The ranges have equal cardinality because construction validates every
+unchanged gap. Static output renders an omission notice. An interactive
+consumer may make the same range revealable. Neither represents omitted
+content as an ambiguous literal `...` line.
 
-The caller or host chooses projection policy, including context-line and
-output-size limits. Markout owns applying that policy consistently and
-reporting its exact omissions.
+The caller or host chooses the context-line policy. Markout owns applying that
+policy consistently and reporting its exact omissions.
 
-Projection is presentation-only. It does not change the diff's exactness,
-change count, mappings, or annotations.
+Context selection is presentation-only. It does not change the complete input,
+change count, mappings, annotations, or final-line-terminator assertions.
+
+Mapped text diff is not a table even when a formatter internally lowers it to
+rows. `MarkoutProjection` column and field filters, `RowWindow`, `MaxItems`,
+and `[MarkoutMaxItems]` do not trim records inside a selected diff. Section
+selection may omit the complete containing section, but it does not produce a
+partial diff.
+
+Output-size limiting is not part of context selection. If a host transport
+cannot carry every change and exact omission record, it rejects the rendering
+visibly rather than presenting a success-shaped truncated diff.
 
 ## Formatter contract
 
 A formatter supporting mapped text diff consumes the validated shape and
-selected presentation projection. Layout is formatter policy.
+selected context. Layout is formatter policy.
 
 ### GNU-compatible unified lowering
 
@@ -204,6 +233,13 @@ A replacement expands to its removed lines followed by its added lines. This
 follows the
 [GNU unified format](https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html)
 and Git patch convention.
+
+When an emitted final line has an `absent` final-line-terminator assertion, the
+lowering emits the conventional `\ No newline at end of file` marker
+immediately after that side's line. `present` and unknown assertions emit no
+marker. Construction requires a side-specific final-line-termination
+difference to belong to a change, so a shared context line never has
+contradictory marker state.
 
 The Markdown renderer chooses a fence longer than any fence run in the content.
 Caller text never occupies the fence language or another structural syntax
@@ -258,8 +294,9 @@ recover change and side provenance. The vocabulary includes:
 - side-local line coordinate;
 - Before and After range coordinates;
 - text;
-- inner mapping coordinates when selected; and
-- annotation target and text when selected.
+- inner mapping coordinates when present;
+- annotation target and text when present; and
+- final-line-terminator assertions when known.
 
 The structured schema does not use rendered `-`, `+`, `~`, color, or spacing as
 data. Tabs, line breaks, and non-graphic text follow the formatter's existing
@@ -267,6 +304,8 @@ machine-output containment rules.
 
 One change may lower to several side-line records. Every record carries the
 same change address, so consumers can regroup it without parsing display text.
+Mandatory provenance fields cannot be removed through generic table column
+projection, and generic row windows or caps cannot split or discard changes.
 
 ### ANSI lowering
 
@@ -321,6 +360,9 @@ Mapped text diffs commonly present untrusted package, source, log, or generated
 content. Each formatter must keep caller data out of structural syntax and
 apply context-appropriate containment.
 
+Sequence lines, labels, and annotation text are inert caller data. They cannot
+inject a header, hunk, record, annotation geometry, or formatter control.
+
 The implementation must define and test:
 
 - malformed UTF-16;
@@ -331,7 +373,8 @@ The implementation must define and test:
 - terminal escapes and non-graphic text;
 - bidirectional and zero-width controls;
 - empty sequences and files without a final line terminator; and
-- annotations containing syntax significant to each formatter.
+- sequence labels and annotations containing syntax significant to each
+  formatter.
 
 The core shape and its validation remain reflection-free,
 NativeAOT-compatible, and Browser/Wasm-compatible. A formatter may have a
@@ -350,8 +393,8 @@ return unsupported through the existing capability contract; Markout does not
 inject a foreign fallback syntax.
 
 Reusable lowerings may adapt a diff to table rows or unified lines. They retain
-the provenance contract above and do not return display strings without their
-source coordinates.
+the provenance contract above, bypass generic table projection and row
+trimming, and do not return display strings without their source coordinates.
 
 ## Adopter evidence
 
@@ -395,7 +438,7 @@ expected output through a parallel template.
 
 - Computing line, word, syntax, or semantic differences.
 - Inferring replacement, movement, or correspondence.
-- Establishing whether two unchanged gaps are actually equal.
+- Establishing whether equal-cardinality unchanged gaps contain equal text.
 - Replacing caller-owned failure, Finding, provenance, or annotated-document
   models.
 - Defining an editor, merge operation, or web interaction state.

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -144,8 +144,9 @@ A valid mapped text diff satisfies all of the following:
    change.
 9. A final-line-terminator assertion is present only for a non-empty sequence.
 10. When both sequences are non-empty and exactly one asserts an `absent`
-    final line terminator, each final line is contained by a caller-issued
-    change. `present` and unknown are both non-marker-emitting states.
+    final line terminator, the final line on that side is contained by a
+    caller-issued change. `present` and unknown are both non-marker-emitting
+    states.
 11. Collection order is significant and preserved.
 
 Equal-cardinality gaps between changes are unchanged sequence ranges whose
@@ -235,7 +236,7 @@ Markdown and portable plain text support unified output:
 +        return 1;
 ```
 
-Unified output uses only:
+Changed sequence lines use only:
 
 - space for context;
 - `-` for Before lines; and
@@ -250,9 +251,8 @@ When an emitted final line has an `absent` final-line-terminator assertion, the
 lowering emits the conventional `\ No newline at end of file` marker
 immediately after that side's line. `present` and unknown assertions emit no
 marker. A shared final context line emits one marker only when both sides
-assert `absent`. Construction requires exactly-one-`absent` final lines to
-belong to a change, so a shared context line never has contradictory marker
-state.
+assert `absent`. The final line on an exactly-one-`absent` side must belong to
+a change, so a shared context line never has contradictory marker state.
 
 The Markdown renderer chooses a fence longer than any fence run in the content.
 Caller text never occupies the fence language or another structural syntax
@@ -283,10 +283,13 @@ A wide renderer may align the mapped ranges:
 4      return 0;    |  4      return 1;
 ```
 
-Unequal range lengths use empty display cells. A formatter does not infer
-additional line-to-line correspondence inside a many-to-many replacement.
-Caller-issued inner mappings may guide emphasis without asserting a complete
-line pairing.
+Each side's mapped range remains an independently addressed column.
+Top-aligning those range blocks and using empty display cells for unequal
+lengths is layout, not line correspondence: no row record or connector relates
+the two displayed lines. A formatter does not infer line-to-line
+correspondence inside a many-to-many replacement. Caller-issued inner mappings
+may relate specific lines and guide emphasis without asserting a complete line
+pairing.
 
 The model is informed by the public VS Code/Monaco diff surface:
 
@@ -419,6 +422,9 @@ inject a foreign fallback syntax.
 Reusable lowerings may adapt a diff to table rows or unified lines. They retain
 the provenance contract above, bypass generic table projection and row
 trimming, and do not return display strings without their source coordinates.
+The implementation updates user guidance that currently describes row windows
+as applying to every table-shaped lowering, because a mapped diff remains one
+semantic shape even when a formatter uses rows.
 
 ## Adopter evidence
 

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -245,6 +245,7 @@ Applying the admission criteria to candidates:
 | DefinitionItem | Description | ❌ #2: Same relationship as Description. | Use Description |
 | LinkItem | Reference | ⚠️ #2: Could be a format attribute on fields. | Attribute preferred |
 | OrderedList | Enumeration | ❌ #2: Visual variant of List. | Parameter on WriteArray |
+| Mapped text diff | Correspondence between ordered sequences | ✅ All five. | **Accepted design:** [Mapped text diff](mapped-text-diff.md) |
 | FlameGraph | Hierarchy + Measurement | ⚠️ #3: Hard to express in plain text. | Defer |
 | Gantt / Timeline | Measurement + Time | ⚠️ #3: Hard to express in plain text. | Defer |
 


### PR DESCRIPTION
## Summary

Define mapped text diff as a Markout-owned Tier 2 shape: callers issue immutable
Before/After sequences and exact range mappings; Markout validates and presents
them without computing correspondence.

The design:

- uses VS Code/Monaco-style mapped line ranges with optional inner spans;
- keeps GNU unified diff as the portable Markdown/plain-text lowering;
- makes replacement a range relation rather than a `Changed` line kind;
- defines one canonical change population with provenance through every
  lowering;
- covers annotations, context omission, safety, NativeAOT, and Browser/Wasm;
  and
- requires adopter evidence from independent source and instruction diff
  domains before release.

Part of #218.

## Demo

One caller-issued replacement:

```text
Before                         After
if (value < 0)                 if (value <= 0)
    return 0;                      return 1;
```

GNU-compatible Markdown:

```diff
-    if (value < 0)
-        return 0;
+    if (value <= 0)
+        return 1;
```

Rich inline presentation over the same mapping:

```text
3 ~     if (value [-<-]{+<=+} 0)
4 ~         return [-0-]{+1+};
```

Side-by-side presentation:

```text
3  if (value < 0)   |  3  if (value <= 0)
4      return 0;    |  4      return 1;
```

The `~`, inline delimiters, and side-by-side gutter are renderer chrome. The
shape retains two sequences, one replacement mapping, two inner mappings, and
any caller-issued annotations.

## Compatibility and boundaries

This adds design only. It changes no package API or current formatter behavior.

Markout does not compute line, word, syntax, semantic, replacement, or movement
correspondence. It does not replace caller-owned Finding, failure, provenance,
or annotated-document models, and it does not define web interaction state.

## Validation

```text
npx markdownlint-cli README.md docs/design/shape-system.md docs/design/mapped-text-diff.md
git diff --check
```
