### PR TITLE
Add mapped text diff presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Each property on a model maps to a data relationship, not a visual element. Rend
 | **Measurement** | `List<Metric>` | Comparative quantities | `Label ████░░ 45` | Colored bars |
 | **Composition** | `List<Breakdown>` | Parts of a whole | `██▓▓▒░` stacked | Colored segments |
 | **Hierarchy** | `List<TreeNode>` | Parent-child structure | `├── node` | Box-drawing tree |
+| **Correspondence** | `MappedTextDiff` | Mapped ordered text sequences | GNU-compatible diff | Numbered rich diff |
 | **Quotation** | `CodeSection` | Verbatim content | ` ```code``` ` | Syntax display |
 | **Attention** | `Callout` | Important messages | `> [!WARNING]` | Colored label |
 
@@ -298,6 +299,7 @@ new Description("dotnet-inspect", "API surface inspection tool")  // term + expl
 new Breakdown("Jan 2025", [new("Critical", 1), new("High", 3)])  // proportional composition
 new Callout(CalloutSeverity.Warning, "3 vulnerabilities found")   // attention
 new CodeSection("csharp", "public class Foo { }")                 // verbatim content
+new MappedTextDiff(before, after, changes)                        // caller-issued text correspondence
 ```
 
 ## Renderers
@@ -306,10 +308,10 @@ Markout ships five formatters. The serializer writes through `MarkoutWriter` (th
 
 | Formatter | Output | Use case |
 |---|---|---|
-| **MarkdownFormatter** | GitHub-Flavored Markdown; graphs as edge tables or fenced Mermaid | Documentation, LLM tool output, rendered reports |
-| **PlainTextFormatter** | Plain text without markup | Minimal output, no syntax characters |
-| **UnicodeFormatter** | Box-drawing characters | Rich tables with borders, no color |
-| **TableFormatter** | Tables, lists, fields | Compact summaries, pretty tables, TSV/JSONL rows |
+| **MarkdownFormatter** | GitHub-Flavored Markdown; graphs and fenced GNU-compatible diffs | Documentation, LLM tool output, rendered reports |
+| **PlainTextFormatter** | Plain text and GNU-compatible diffs without Markdown fences | Minimal output, no syntax characters |
+| **UnicodeFormatter** | Box drawing and numbered rich diffs | Rich terminal output without color |
+| **TableFormatter** | Tables plus structured diff provenance | Compact summaries, pretty tables, TSV/JSONL rows |
 | **DiagramFormatter** | Trees and structural diagrams | Dependency graphs, file trees |
 
 Optional packages:

--- a/docs/design/data-writer-model.md
+++ b/docs/design/data-writer-model.md
@@ -25,6 +25,7 @@ The `MarkoutShape` enum defines the vocabulary of data relationships:
 | **Lists** | Ordered/unordered items | Features, steps, options |
 | **Trees** | Hierarchical parent-child | Org charts, file structures |
 | **Graphs** | Directed relationships between deduplicated nodes | Call graphs, dependency graphs |
+| **TextDiffs** | Correspondence between ordered text sequences | Source, instruction, configuration diffs |
 | **Descriptions** | Term with explanation | Glossaries, definitions |
 | **Metrics** | Labeled measurements | Test counts, performance data |
 | **Breakdowns** | Proportional composition | Category distributions |

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -246,6 +246,12 @@ follows the
 [GNU unified format](https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html)
 and Git patch convention.
 
+When the final emitted plain-text unified line contains caller-significant
+trailing whitespace, in-memory completion preserves that line and its
+terminator instead of applying the writer's ordinary document-end trim. This
+includes a whitespace-only final context line; removing it would contradict
+the hunk's declared line count and produce an invalid patch.
+
 When an emitted final line has an `absent` final-line-terminator assertion, the
 lowering emits the conventional `\ No newline at end of file` marker
 immediately after that side's line. `present` and unknown assertions emit no

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -396,6 +396,10 @@ apply context-appropriate containment.
 
 Sequence lines, labels, and annotation text are inert caller data. They cannot
 inject a header, hunk, record, annotation geometry, or formatter control.
+Containment classifies complete Unicode scalar values rather than individual
+UTF-16 code units. A textual rich renderer escapes any literal source token
+that would otherwise be indistinguishable from renderer-added intraline
+markup.
 
 The implementation must define and test:
 

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -380,6 +380,11 @@ Both presentations retain the same target coordinates. The renderer may wrap
 annotation prose, but it may not move the target or silently omit the
 annotation.
 
+Human lowerings identify a change-level annotation by the owning change's
+one-based display number. An empty span is a valid static insertion-point
+target and renders as `insertion point at column N`, where `N` is the
+one-based form of the span's zero-based offset.
+
 Interactive selection, focus, hover, activation, annotation membership, and
 editor state are consumer concerns. This shape supplies static targets only.
 
@@ -401,6 +406,7 @@ The implementation must define and test:
 - Markdown fence runs and inline syntax;
 - table delimiters;
 - terminal escapes and non-graphic text;
+- Unicode line and paragraph separators;
 - bidirectional and zero-width controls;
 - empty sequences and files without a final line terminator; and
 - sequence labels and annotations containing syntax significant to each

--- a/docs/design/mapped-text-diff.md
+++ b/docs/design/mapped-text-diff.md
@@ -283,6 +283,11 @@ on one display line only when caller-issued inner mappings establish that
 line pairing. Otherwise it presents the replacement sides separately rather
 than pairing lines by ordinal position.
 
+An empty side of an inner mapping remains visible at its exact UTF-16 offset.
+A textual renderer may use adjacent empty delimiters such as `[--]` or `{++}`;
+an ANSI renderer may use distinct point chrome. It does not omit the empty side
+or infer its position from the non-empty span.
+
 ### Side-by-side lowering
 
 A wide renderer may align the mapped ranges:

--- a/docs/design/shape-system.md
+++ b/docs/design/shape-system.md
@@ -128,6 +128,7 @@ These add meaning beyond raw document structure. They represent specific data re
 | **Callouts** | Attention | `WriteCallout` | `Callout` |
 | **Trees** | Hierarchy | `WriteTree` | `TreeNode` |
 | **Graphs** | Directed relationship | `WriteGraph` | `Graph` |
+| **Text diffs** | Correspondence between ordered sequences | `WriteTextDiff` | `MappedTextDiff` |
 
 ### Tier 3: Data Visualizations
 
@@ -245,7 +246,7 @@ Applying the admission criteria to candidates:
 | DefinitionItem | Description | ❌ #2: Same relationship as Description. | Use Description |
 | LinkItem | Reference | ⚠️ #2: Could be a format attribute on fields. | Attribute preferred |
 | OrderedList | Enumeration | ❌ #2: Visual variant of List. | Parameter on WriteArray |
-| Mapped text diff | Correspondence between ordered sequences | ✅ All five. | **Accepted design:** [Mapped text diff](mapped-text-diff.md) |
+| ~~Mapped text diff~~ | Correspondence between ordered sequences | ✅ All five. | **Shipped:** [Mapped text diff](mapped-text-diff.md) |
 | FlameGraph | Hierarchy + Measurement | ⚠️ #3: Hard to express in plain text. | Defer |
 | Gantt / Timeline | Measurement + Time | ⚠️ #3: Hard to express in plain text. | Defer |
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,6 +18,9 @@ Markout is a source-generated .NET serializer for projecting object graphs into 
 - Markdown renders `Graph` as an edge table by default. Pass
   `MarkdownGraphMode.Mermaid` to `MarkdownFormatter` to embed the same graph as
   a fenced Mermaid diagram.
+- Mapped text diffs retain producer-issued correspondence. Markdown and plain
+  text use GNU-compatible unified form, rich formatters add display detail,
+  and table modes expose fixed provenance records.
 - `TableFormatter` renders compact table projections. `MarkoutTableMode.Pretty` uses display headers and space-padded columns. `MarkoutTableMode.Tsv` emits normalized TSV with stable snake_case headers.
 - Markdown table cell pipes are normalized to `&#124;`, not escaped as `\|`.
 - TSV cells never contain embedded tabs or newlines.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1004,6 +1004,10 @@ around each change. Set it to `null` to retain every unchanged line or to zero
 to show only changed lines. Context selection emits exact omission records and
 never discards a change or annotation.
 
+Human formatters visibly escape control and format scalars. The Unicode
+formatter also escapes literal `[-` and `{+` openings so caller text cannot
+imitate its intraline markers.
+
 A `MappedTextDiff` property is recognized directly by the source generator:
 
 ```csharp

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1005,8 +1005,8 @@ to show only changed lines. Context selection emits exact omission records and
 never discards a change or annotation.
 
 Human formatters visibly escape control and format scalars. The Unicode
-formatter also escapes literal `[-` and `{+` openings so caller text cannot
-imitate its intraline markers.
+formatter also escapes literal `[-`, `-]`, `{+`, and `+}` tokens so caller text
+cannot imitate or terminate its intraline markers.
 
 A `MappedTextDiff` property is recognized directly by the source generator:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,6 +14,8 @@ Markout is a source-generated .NET library that serializes objects to clean, rea
 - [Section Field Order](#section-field-order)
 - [Tables](#tables)
 - [Trees](#trees)
+- [Graphs](#graphs)
+- [Mapped Text Diffs](#mapped-text-diffs)
 - [Links](#links)
 - [Custom Value Formatters](#custom-value-formatters)
 - [Writer Options](#writer-options)
@@ -700,7 +702,10 @@ The window applies to tables written through the writer — `WriteTable`,
 Table-shaped formatter lowerings use the same pipeline: graph edge tables and
 Markdown metric and breakdown tables honor the window over their visible rows,
 and `MaxItems` caps those rows. Visual bar and diagram renderers are not tables,
-so row windows and table caps do not apply to them.
+so row windows and table caps do not apply to them. A mapped text diff is also
+one semantic shape rather than a table: its structured lowering bypasses
+generic row windows, item caps, and column projection so a selected diff never
+loses changes or provenance.
 
 When both are set, **the window selects and `MaxItems` then caps the selection**,
 so the reported overflow count describes only what the cap dropped:
@@ -937,6 +942,78 @@ sink with no way to express it renders the node unchanged.
 Construction is validated: a null node or edge element, a duplicate key, an edge naming a key with
 no node, an empty node label, or a `focusKey` naming no node all throw, so a malformed graph fails
 where it is built rather than rendering as a plausible-looking but wrong diagram.
+
+## Mapped Text Diffs
+
+Use `MappedTextDiff` when another component already owns comparison and
+correspondence. Markout validates and presents the supplied ranges; it never
+computes a line, word, syntax, semantic, replacement, or movement diff.
+
+```csharp
+var diff = new MappedTextDiff(
+    new TextDiffSequence(
+        ["if (value < 0)", "    return 0;"],
+        "Before",
+        TextDiffLineTerminator.Present),
+    new TextDiffSequence(
+        ["if (value <= 0)", "    return 1;"],
+        "After",
+        TextDiffLineTerminator.Present),
+    [
+        new TextDiffChange(
+            new TextDiffRange(0, 2),
+            new TextDiffRange(0, 2),
+            [
+                new TextDiffInnerMapping(
+                    new TextDiffSpan(0, 10, 1),
+                    new TextDiffSpan(0, 10, 2))
+            ],
+            [
+                TextDiffAnnotation.ForSpan(
+                    TextDiffSide.After,
+                    new TextDiffSpan(0, 10, 2),
+                    "Boundary now includes zero",
+                    CalloutSeverity.Warning)
+            ])
+    ]);
+
+writer.WriteTextDiff(diff);
+```
+
+Line ranges are zero-based and half-open. A change form is derived from range
+cardinality: empty Before means addition, empty After means removal, and two
+non-empty ranges mean replacement. Inner spans are single-line, half-open
+UTF-16 code-unit ranges and cannot split a surrogate pair.
+
+An empty annotation span marks an insertion point and human formatters spell it
+as `insertion point at column N`. Change-level annotations name their owning
+one-based change number so annotations remain unambiguous in a multi-hunk diff.
+
+Each formatter owns its lowering:
+
+| Formatter | Mapped-diff lowering |
+| --- | --- |
+| `MarkdownFormatter` | Dynamically fenced GNU-compatible unified diff |
+| `PlainTextFormatter` | GNU-compatible unified diff without a Markdown fence |
+| `TableFormatter` | Fixed provenance records in pretty, TSV, or JSONL form |
+| `UnicodeFormatter` | Line numbers, side markers, intraline markers, annotations |
+| `SpectreFormatter` | ANSI side color and intraline emphasis |
+
+`MarkoutWriterOptions.TextDiffContextLines` defaults to three unchanged lines
+around each change. Set it to `null` to retain every unchanged line or to zero
+to show only changed lines. Context selection emits exact omission records and
+never discards a change or annotation.
+
+A `MappedTextDiff` property is recognized directly by the source generator:
+
+```csharp
+[MarkoutSection(Name = "Source Diff", EmptyText = "No changes.")]
+public MappedTextDiff? SourceDiff { get; set; }
+```
+
+A null value omits the section. A value with an empty change population uses
+`EmptyText`. Generic `Projection`, `RowWindow`, `MaxItems`, and
+`[MarkoutMaxItems]` do not trim records inside a selected mapped diff.
 
 ## Links
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1006,7 +1006,14 @@ never discards a change or annotation.
 
 Human formatters visibly escape control and format scalars. The Unicode
 formatter also escapes literal `[-`, `-]`, `{+`, and `+}` tokens so caller text
-cannot imitate or terminate its intraline markers.
+cannot imitate or terminate its intraline markers. Caller backslashes are
+doubled so the marker escapes remain unambiguous.
+
+When a plain-text mapped diff ends in caller-significant whitespace,
+`Complete()` and `ToString()` preserve that trailing line exactly. This keeps a
+whitespace-only final unified line, or caller-significant trailing spaces,
+consistent with the hunk header instead of applying the writer's ordinary
+document-end trim.
 
 A `MappedTextDiff` property is recognized directly by the source generator:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1007,7 +1007,9 @@ never discards a change or annotation.
 Human formatters visibly escape control and format scalars. The Unicode
 formatter also escapes literal `[-`, `-]`, `{+`, and `+}` tokens so caller text
 cannot imitate or terminate its intraline markers. Caller backslashes are
-doubled so the marker escapes remain unambiguous.
+doubled so the marker escapes remain unambiguous. Empty mapped sides remain
+visible at their exact offsets: Unicode uses `[--]` or `{++}`, while Spectre
+uses an underlined inverse point marker.
 
 When a plain-text mapped diff ends in caller-significant whitespace,
 `Complete()` and `ToString()` preserve that trailing line exactly. This keeps a

--- a/skills/markout-built-in-shapes/SKILL.md
+++ b/skills/markout-built-in-shapes/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn
   ASCII or manual Markdown. Markout ships these as data types (Metric, Breakdown/Slice, Callout,
-  TreeNode, Description, CodeSection, MarkoutTable) you attach as model properties. If the task
+  TreeNode, Description, CodeSection, MarkoutTable, MappedTextDiff) you attach as model properties. If the task
   requests terminal/Unicode, plain text, ANSI, or another non-Markdown sink, also invoke
   markout-output-formats for the formatter call. Don't decompile the assembly or web-search the
   API — the shape types are here.
@@ -89,6 +89,11 @@ public class Dashboard
     [MarkoutSection(Name = "Metadata"), MarkoutIgnoreInTable]
     public MarkoutTable? Metadata { get; set; }
     // new MarkoutTable(["Property", "Value"], [["Machine", "Amd64"]])
+
+    // Caller-issued correspondence between complete ordered text sequences. Markout validates
+    // and presents the mapping; it never computes a diff.
+    [MarkoutSection(Name = "Source Diff"), MarkoutIgnoreInTable]
+    public MappedTextDiff? SourceDiff { get; set; }
 }
 ```
 
@@ -148,6 +153,8 @@ public class MetadataDocument
 - **`Callout` and `CodeSection` are value types** — declare them non-nullable and pair with
   `[MarkoutSkipDefault]` so an unset one disappears. `Callout?` / `CodeSection?` does not compile.
 - Do not hand-draw bars/trees; if you're building glyphs by hand you're using the wrong tool.
+- Do not ask `MappedTextDiff` to compare text. Supply complete `TextDiffSequence` values and
+  caller-owned `TextDiffChange` ranges; use `TextDiffContextLines` only to hide unchanged context.
 
 ## Shape cheat-sheet
 
@@ -160,3 +167,4 @@ public class MetadataDocument
 | `Description` | term + text | `new Description("API", "…")` |
 | `CodeSection` | fenced code block | `new CodeSection("csharp", "…")` |
 | `MarkoutTable` | runtime-column table | `new MarkoutTable(["Property", "Value"], [["Machine", "Amd64"]])` |
+| `MappedTextDiff` | mapped ordered text correspondence | `new MappedTextDiff(before, after, changes)` |

--- a/src/Markout.Ansi.Spectre/SpectreFormatter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreFormatter.cs
@@ -196,33 +196,50 @@ public class SpectreFormatter : IMarkoutFormatter,
     private static string EscapeTextDiff(string value)
     {
         StringBuilder? builder = null;
-        for (var i = 0; i < value.Length; i++)
+        for (var i = 0; i < value.Length;)
         {
             var c = value[i];
-            string? replacement = c switch
+            var width = char.IsHighSurrogate(c) ? 2 : 1;
+            string? replacement;
+            if (width == 2)
             {
-                '\t' => "\\t",
-                '\r' => "\\r",
-                '\n' => "\\n",
-                _ when char.GetUnicodeCategory(c) is UnicodeCategory.Control
-                    or UnicodeCategory.Format
-                    or UnicodeCategory.LineSeparator
-                    or UnicodeCategory.ParagraphSeparator
-                    => $"\\u{(int)c:X4}",
-                _ => null
-            };
+                var rune = new Rune(c, value[i + 1]);
+                replacement = IsEscapedCategory(Rune.GetUnicodeCategory(rune))
+                    ? $"\\U{rune.Value:X8}"
+                    : null;
+            }
+            else
+            {
+                replacement = c switch
+                {
+                    '\t' => "\\t",
+                    '\r' => "\\r",
+                    '\n' => "\\n",
+                    _ when IsEscapedCategory(char.GetUnicodeCategory(c))
+                        => $"\\u{(int)c:X4}",
+                    _ => null
+                };
+            }
             if (replacement is null)
             {
                 if (builder is not null)
-                    builder.Append(c);
+                    builder.Append(value, i, width);
+                i += width;
                 continue;
             }
 
             builder ??= new StringBuilder(value.Length + 8).Append(value, 0, i);
             builder.Append(replacement);
+            i += width;
         }
         return builder?.ToString() ?? value;
     }
+
+    private static bool IsEscapedCategory(UnicodeCategory category)
+        => category is UnicodeCategory.Control
+            or UnicodeCategory.Format
+            or UnicodeCategory.LineSeparator
+            or UnicodeCategory.ParagraphSeparator;
 
     void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
     {

--- a/src/Markout.Ansi.Spectre/SpectreFormatter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreFormatter.cs
@@ -1,5 +1,7 @@
 using Markout.Formatting;
 using Spectre.Console;
+using System.Globalization;
+using System.Text;
 
 namespace Markout.Ansi.Spectre;
 
@@ -7,7 +9,7 @@ namespace Markout.Ansi.Spectre;
 /// A formatter that renders output as rich ANSI terminal text using Spectre.Console.
 /// </summary>
 public class SpectreFormatter : IMarkoutFormatter,
-    IDocumentFormatter, IMetricsFormatter, IGlyphFormatter
+    IDocumentFormatter, IMetricsFormatter, IGlyphFormatter, ITextDiffFormatter
 {
     private const int ColumnGap = 2;
     private readonly IAnsiConsole _console;
@@ -83,6 +85,144 @@ public class SpectreFormatter : IMarkoutFormatter,
     private const int SgrWhite = 37;
 
     private static readonly int[] DistributionSgrColors = [SgrRed, SgrYellow, SgrCyan, SgrGreen, SgrMagenta, SgrBlue];
+
+    void ITextDiffFormatter.FormatTextDiff(
+        TextWriter w,
+        MappedTextDiff diff,
+        MarkoutWriterOptions options)
+    {
+        foreach (var line in MappedTextDiffLowering.ToDisplayLines(diff, options.TextDiffContextLines))
+        {
+            switch (line.Kind)
+            {
+                case TextDiffDisplayLineKind.Context:
+                    Sgr(w, SgrDarkGray);
+                    w.Write($"{line.BeforeLine!.Value + 1,4} {line.AfterLine!.Value + 1,4}   ");
+                    SgrReset(w);
+                    w.WriteLine(EscapeTextDiff(line.BeforeText!));
+                    break;
+
+                case TextDiffDisplayLineKind.Removal:
+                    Sgr(w, SgrDarkGray);
+                    w.Write($"{line.BeforeLine!.Value + 1,4}      ");
+                    Sgr(w, SgrRed);
+                    w.Write("- ");
+                    WriteDiffText(w, diff, line);
+                    SgrReset(w);
+                    w.WriteLine();
+                    break;
+
+                case TextDiffDisplayLineKind.Addition:
+                    Sgr(w, SgrDarkGray);
+                    w.Write($"     {line.AfterLine!.Value + 1,4} ");
+                    Sgr(w, SgrGreen);
+                    w.Write("+ ");
+                    WriteDiffText(w, diff, line);
+                    SgrReset(w);
+                    w.WriteLine();
+                    break;
+
+                case TextDiffDisplayLineKind.Omission:
+                    Sgr(w, SgrDarkGray);
+                    w.Write("         ... ");
+                    w.Write(line.BeforeRange!.Value.Count);
+                    w.WriteLine(" unchanged lines");
+                    SgrReset(w);
+                    break;
+
+                case TextDiffDisplayLineKind.Annotation:
+                    Sgr(w, SgrYellow);
+                    w.Write("         > ");
+                    w.Write(line.Annotation!.Severity);
+                    w.Write(" - ");
+                    w.Write(AnnotationTarget(line.Annotation, line.ChangeAddress));
+                    w.Write(": ");
+                    w.Write(EscapeTextDiff(line.Annotation.Text));
+                    SgrReset(w);
+                    w.WriteLine();
+                    break;
+            }
+        }
+    }
+
+    private static void WriteDiffText(
+        TextWriter w,
+        MappedTextDiff diff,
+        TextDiffDisplayLine line)
+    {
+        var raw = line.Side == TextDiffSide.Before ? line.BeforeText! : line.AfterText!;
+        var spans = line.ChangeAddress is { } address
+            ? diff.Changes[address].InnerMappings
+                .Select(mapping => line.Side == TextDiffSide.Before ? mapping.Before : mapping.After)
+                .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine) && !span.IsEmpty)
+                .ToArray()
+            : [];
+        if (spans.Length == 0)
+        {
+            w.Write(EscapeTextDiff(raw));
+            return;
+        }
+
+        var cursor = 0;
+        foreach (var span in spans)
+        {
+            w.Write(EscapeTextDiff(raw[cursor..span.Start]));
+            Sgr(w, 7);
+            w.Write(EscapeTextDiff(raw[span.Start..span.End]));
+            Sgr(w, 27);
+            cursor = span.End;
+        }
+        w.Write(EscapeTextDiff(raw[cursor..]));
+    }
+
+    private static string AnnotationTarget(
+        TextDiffAnnotation annotation,
+        int? changeAddress)
+        => annotation.TargetKind switch
+        {
+            TextDiffAnnotationTargetKind.Change =>
+                changeAddress is { } address ? $"change {address + 1}" : "change",
+            TextDiffAnnotationTargetKind.Line =>
+                $"{annotation.Side} line {annotation.Line!.Value + 1}",
+            TextDiffAnnotationTargetKind.Span =>
+                annotation.Span!.Value.IsEmpty
+                    ? $"{annotation.Side} line {annotation.Span.Value.Line + 1}, "
+                        + $"insertion point at column {annotation.Span.Value.Start + 1}"
+                    : $"{annotation.Side} line {annotation.Span.Value.Line + 1}, "
+                        + $"columns {annotation.Span.Value.Start + 1}-{annotation.Span.Value.End}",
+            _ => "annotation"
+        };
+
+    private static string EscapeTextDiff(string value)
+    {
+        StringBuilder? builder = null;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            string? replacement = c switch
+            {
+                '\t' => "\\t",
+                '\r' => "\\r",
+                '\n' => "\\n",
+                _ when char.GetUnicodeCategory(c) is UnicodeCategory.Control
+                    or UnicodeCategory.Format
+                    or UnicodeCategory.LineSeparator
+                    or UnicodeCategory.ParagraphSeparator
+                    => $"\\u{(int)c:X4}",
+                _ => null
+            };
+            if (replacement is null)
+            {
+                if (builder is not null)
+                    builder.Append(c);
+                continue;
+            }
+
+            builder ??= new StringBuilder(value.Length + 8).Append(value, 0, i);
+            builder.Append(replacement);
+        }
+        return builder?.ToString() ?? value;
+    }
 
     void IHeadingFormatter.FormatHeading(TextWriter w, int level, string text, string? context)
     {

--- a/src/Markout.Ansi.Spectre/SpectreFormatter.cs
+++ b/src/Markout.Ansi.Spectre/SpectreFormatter.cs
@@ -83,6 +83,10 @@ public class SpectreFormatter : IMarkoutFormatter,
     private const int SgrMagenta = 35;
     private const int SgrBlue = 34;
     private const int SgrWhite = 37;
+    private const int SgrUnderline = 4;
+    private const int SgrUnderlineOff = 24;
+    private const int SgrInverse = 7;
+    private const int SgrInverseOff = 27;
 
     private static readonly int[] DistributionSgrColors = [SgrRed, SgrYellow, SgrCyan, SgrGreen, SgrMagenta, SgrBlue];
 
@@ -154,7 +158,7 @@ public class SpectreFormatter : IMarkoutFormatter,
         var spans = line.ChangeAddress is { } address
             ? diff.Changes[address].InnerMappings
                 .Select(mapping => line.Side == TextDiffSide.Before ? mapping.Before : mapping.After)
-                .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine) && !span.IsEmpty)
+                .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine))
                 .ToArray()
             : [];
         if (spans.Length == 0)
@@ -167,9 +171,18 @@ public class SpectreFormatter : IMarkoutFormatter,
         foreach (var span in spans)
         {
             w.Write(EscapeTextDiff(raw[cursor..span.Start]));
-            Sgr(w, 7);
-            w.Write(EscapeTextDiff(raw[span.Start..span.End]));
-            Sgr(w, 27);
+            Sgr(w, SgrInverse);
+            if (span.IsEmpty)
+            {
+                Sgr(w, SgrUnderline);
+                w.Write('│');
+                Sgr(w, SgrUnderlineOff);
+            }
+            else
+            {
+                w.Write(EscapeTextDiff(raw[span.Start..span.End]));
+            }
+            Sgr(w, SgrInverseOff);
             cursor = span.End;
         }
         w.Write(EscapeTextDiff(raw[cursor..]));

--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -1,4 +1,5 @@
 using Markout;
+using Markout.Formatting;
 
 namespace Markout.Demo;
 
@@ -16,10 +17,10 @@ public static class Demos
         ["nested"] = Nested,
         ["pivot"] = Pivot,
         ["tree"] = Tree,
-        ["text-diff"] = TextDiff,
-        ["text-diff-il"] = TextDiffIl,
-        ["text-diff-jsonl"] = TextDiffJsonl,
-        ["text-diff-unicode"] = TextDiffUnicode,
+        ["textdiff"] = TextDiff,
+        ["textdiffil"] = TextDiffIl,
+        ["textdiffjsonl"] = TextDiffJsonl,
+        ["textdiffunicode"] = TextDiffUnicode,
         ["schema"] = Schema,
     };
 
@@ -32,10 +33,10 @@ public static class Demos
         "nested",
         "pivot",
         "tree",
-        "text-diff",
-        "text-diff-il",
-        "text-diff-jsonl",
-        "text-diff-unicode",
+        "textdiff",
+        "textdiffil",
+        "textdiffjsonl",
+        "textdiffunicode",
         "schema"
     ];
 
@@ -191,6 +192,7 @@ public static class Demos
             output,
             new MarkdownFormatter(),
             new MarkoutWriterOptions { TextDiffContextLines = 0 });
+        writer.WriteHeading(1, "Mapped Text Diff");
         writer.WriteTextDiff(SampleDiff());
         writer.Flush();
     }
@@ -198,8 +200,11 @@ public static class Demos
     /// <summary>Mapped text diff demo: structured JSONL provenance records.</summary>
     private static void TextDiffJsonl(TextWriter output)
     {
-        var writer = new MarkoutWriter(
+        WriteEmbeddedDiff(
             output,
+            "Mapped Text Diff — JSONL",
+            "jsonl",
+            SampleDiff(),
             new TableFormatter(),
             new MarkoutWriterOptions
             {
@@ -207,8 +212,6 @@ public static class Demos
                 OmitEmptyJsonFields = true,
                 TextDiffContextLines = 0
             });
-        writer.WriteTextDiff(SampleDiff());
-        writer.Flush();
     }
 
     /// <summary>Mapped text diff demo: the same shape applied to IL instructions.</summary>
@@ -218,23 +221,44 @@ public static class Demos
             new TextDiffSequence(["IL_0000: ldc.i4.0", "IL_0001: ret"], "Before IL"),
             new TextDiffSequence(["IL_0000: ldc.i4.1", "IL_0001: ret"], "After IL"),
             [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
-        var writer = new MarkoutWriter(
+        WriteEmbeddedDiff(
             output,
+            "Mapped Text Diff — IL",
+            "text",
+            diff,
             new UnicodeFormatter(),
             new MarkoutWriterOptions { TextDiffContextLines = 1 });
-        writer.WriteTextDiff(diff);
-        writer.Flush();
     }
 
     /// <summary>Mapped text diff demo: rich Unicode terminal lowering.</summary>
     private static void TextDiffUnicode(TextWriter output)
     {
-        var writer = new MarkoutWriter(
+        WriteEmbeddedDiff(
             output,
+            "Mapped Text Diff — Unicode",
+            "text",
+            SampleDiff(),
             new UnicodeFormatter(),
             new MarkoutWriterOptions { TextDiffContextLines = 0 });
-        writer.WriteTextDiff(SampleDiff());
-        writer.Flush();
+    }
+
+    private static void WriteEmbeddedDiff(
+        TextWriter output,
+        string title,
+        string language,
+        MappedTextDiff diff,
+        IMarkoutFormatter formatter,
+        MarkoutWriterOptions options)
+    {
+        var rendered = MarkoutWriter.Create(formatter, options);
+        rendered.WriteTextDiff(diff);
+
+        var document = new MarkoutWriter(output, new MarkdownFormatter());
+        document.WriteHeading(1, title);
+        document.WriteCodeStart(language);
+        document.WriteParagraph(rendered.ToString());
+        document.WriteCodeEnd();
+        document.Flush();
     }
 
     private static MappedTextDiff SampleDiff() => new(

--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -16,10 +16,28 @@ public static class Demos
         ["nested"] = Nested,
         ["pivot"] = Pivot,
         ["tree"] = Tree,
+        ["text-diff"] = TextDiff,
+        ["text-diff-il"] = TextDiffIl,
+        ["text-diff-jsonl"] = TextDiffJsonl,
+        ["text-diff-unicode"] = TextDiffUnicode,
         ["schema"] = Schema,
     };
 
-    private static readonly string[] _orderedNames = ["simple", "sections", "list", "table", "nested", "pivot", "tree", "schema"];
+    private static readonly string[] _orderedNames =
+    [
+        "simple",
+        "sections",
+        "list",
+        "table",
+        "nested",
+        "pivot",
+        "tree",
+        "text-diff",
+        "text-diff-il",
+        "text-diff-jsonl",
+        "text-diff-unicode",
+        "schema"
+    ];
 
     public static IEnumerable<string> List() => _orderedNames;
 
@@ -165,4 +183,87 @@ public static class Demos
         writer.WriteCodeEnd();
         writer.Flush();
     }
+
+    /// <summary>Mapped text diff demo: GNU-compatible Markdown lowering.</summary>
+    private static void TextDiff(TextWriter output)
+    {
+        var writer = new MarkoutWriter(
+            output,
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 });
+        writer.WriteTextDiff(SampleDiff());
+        writer.Flush();
+    }
+
+    /// <summary>Mapped text diff demo: structured JSONL provenance records.</summary>
+    private static void TextDiffJsonl(TextWriter output)
+    {
+        var writer = new MarkoutWriter(
+            output,
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = MarkoutTableMode.Jsonl,
+                OmitEmptyJsonFields = true,
+                TextDiffContextLines = 0
+            });
+        writer.WriteTextDiff(SampleDiff());
+        writer.Flush();
+    }
+
+    /// <summary>Mapped text diff demo: the same shape applied to IL instructions.</summary>
+    private static void TextDiffIl(TextWriter output)
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["IL_0000: ldc.i4.0", "IL_0001: ret"], "Before IL"),
+            new TextDiffSequence(["IL_0000: ldc.i4.1", "IL_0001: ret"], "After IL"),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = new MarkoutWriter(
+            output,
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 1 });
+        writer.WriteTextDiff(diff);
+        writer.Flush();
+    }
+
+    /// <summary>Mapped text diff demo: rich Unicode terminal lowering.</summary>
+    private static void TextDiffUnicode(TextWriter output)
+    {
+        var writer = new MarkoutWriter(
+            output,
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 });
+        writer.WriteTextDiff(SampleDiff());
+        writer.Flush();
+    }
+
+    private static MappedTextDiff SampleDiff() => new(
+        new TextDiffSequence(
+            ["if (value < 0)", "    return 0;"],
+            "Before",
+            TextDiffLineTerminator.Present),
+        new TextDiffSequence(
+            ["if (value <= 0)", "    return 1;"],
+            "After",
+            TextDiffLineTerminator.Present),
+        [
+            new TextDiffChange(
+                new TextDiffRange(0, 2),
+                new TextDiffRange(0, 2),
+                [
+                    new TextDiffInnerMapping(
+                        new TextDiffSpan(0, 10, 1),
+                        new TextDiffSpan(0, 10, 2)),
+                    new TextDiffInnerMapping(
+                        new TextDiffSpan(1, 11, 1),
+                        new TextDiffSpan(1, 11, 1))
+                ],
+                [
+                    TextDiffAnnotation.ForSpan(
+                        TextDiffSide.After,
+                        new TextDiffSpan(0, 10, 2),
+                        "Boundary now includes zero",
+                        CalloutSeverity.Warning)
+                ])
+        ]);
 }

--- a/src/Markout.Demo/README.md
+++ b/src/Markout.Demo/README.md
@@ -214,17 +214,18 @@ compute a diff.
 formatters:
 
 ```bash
-dotnet run --project src/Markout.Demo -- text-diff
-dotnet run --project src/Markout.Demo -- text-diff-jsonl
-dotnet run --project src/Markout.Demo -- text-diff-unicode
-dotnet run --project src/Markout.Demo -- text-diff-il
+dotnet run --project src/Markout.Demo -- textdiff
+dotnet run --project src/Markout.Demo -- textdiffjsonl
+dotnet run --project src/Markout.Demo -- textdiffunicode
+dotnet run --project src/Markout.Demo -- textdiffil
 ```
 
-The first command emits a GNU-compatible fenced diff, the second emits
-structured provenance records, and the third adds line numbers, intraline
-markers, and the caller-issued annotation. The IL example applies the same
-shape to instructions, demonstrating that the contract has no source-language
-assumptions.
+Each command emits a lintable Markdown demo document. The first contains the
+GNU-compatible diff directly; the JSONL, Unicode, and IL commands embed the
+actual selected formatter output in code fences. The rich output adds line
+numbers, intraline markers, and the caller-issued annotation. The IL example
+applies the same shape to instructions, demonstrating that the contract has no
+source-language assumptions.
 
 ---
 

--- a/src/Markout.Demo/README.md
+++ b/src/Markout.Demo/README.md
@@ -178,6 +178,8 @@ This demonstrates that when you need custom formatting, you project your data to
 
 **Approach:** **Custom projection** to `TreeNode`. Project data to `List<TreeNode>` where each node has a label and optional children. Markout's `WriteTree()` handles the connector logic (`├─`, `└─`, `│`).
 
+---
+
 ```csharp
 var tree = shoes.Select(s => new TreeNode(
     $"{s.Model} ({s.Category}, ${s.Price})",
@@ -200,6 +202,29 @@ writer.WriteTree(tree);
 ```
 
 This follows the same pattern as `list`: reshape data to a Markout-recognized type, serializer does the right thing.
+
+---
+
+### text-diff
+
+**Intent:** Present caller-issued correspondence without asking Markout to
+compute a diff.
+
+**Approach:** Build one `MappedTextDiff` and render it through several
+formatters:
+
+```bash
+dotnet run --project src/Markout.Demo -- text-diff
+dotnet run --project src/Markout.Demo -- text-diff-jsonl
+dotnet run --project src/Markout.Demo -- text-diff-unicode
+dotnet run --project src/Markout.Demo -- text-diff-il
+```
+
+The first command emits a GNU-compatible fenced diff, the second emits
+structured provenance records, and the third adds line numbers, intraline
+markers, and the caller-issued annotation. The IL example applies the same
+shape to instructions, demonstrating that the contract has no source-language
+assumptions.
 
 ---
 

--- a/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
+++ b/src/Markout.SourceGeneration/Emitter/SerializerEmitter.cs
@@ -635,6 +635,16 @@ internal static class SerializerEmitter
             sb.AppendLine($"{indent}}}");
             EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
         }
+        else if (prop.Kind == PropertyKind.TextDiff)
+        {
+            sb.AppendLine($"{indent}if ({propAccess} != null && !{propAccess}.IsEmpty)");
+            sb.AppendLine($"{indent}{{");
+            sb.AppendLine($"{indent}    writer.WriteSectionStart({effectiveSectionLevel}, \"{EmitHelpers.EscapeString(sectionName)}\"{headlessArg});");
+            sb.AppendLine($"{indent}    writer.WriteTextDiff({propAccess});");
+            sb.AppendLine($"{indent}    writer.WriteSectionEnd();");
+            sb.AppendLine($"{indent}}}");
+            EmitSectionEmptyFallback(sb, prop, propAccess, indent, effectiveSectionLevel, sectionName);
+        }
         else if (prop.Kind == PropertyKind.Table)
         {
             // An empty table (no columns) is treated the same as an empty collection: it falls
@@ -896,6 +906,11 @@ internal static class SerializerEmitter
             case PropertyKind.Graph:
                 sb.AppendLine($"{indent}if ({propAccess} != null && !{propAccess}.IsEmpty)");
                 sb.AppendLine($"{indent}    writer.WriteGraph({propAccess});");
+                break;
+
+            case PropertyKind.TextDiff:
+                sb.AppendLine($"{indent}if ({propAccess} != null && !{propAccess}.IsEmpty)");
+                sb.AppendLine($"{indent}    writer.WriteTextDiff({propAccess});");
                 break;
 
             case PropertyKind.Table:
@@ -1177,6 +1192,8 @@ internal static class SerializerEmitter
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (code block)";
             if (prop.Kind == PropertyKind.Graph)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (graph)";
+            if (prop.Kind == PropertyKind.TextDiff)
+                return $"H{prop.SectionLevel} Section \"{sectionName}\" (mapped text diff)";
             if (prop.Kind == PropertyKind.Table)
                 return $"H{prop.SectionLevel} Section \"{sectionName}\" (table)";
             if (prop.Kind == PropertyKind.Breakdown)
@@ -1208,6 +1225,7 @@ internal static class SerializerEmitter
             PropertyKind.Description => "Description",
             PropertyKind.CodeSection => "Code",
             PropertyKind.Graph => "Graph",
+            PropertyKind.TextDiff => "MappedTextDiff",
             PropertyKind.Table => "Table",
             PropertyKind.Callout => "Callout",
             PropertyKind.Breakdown => "Breakdown",

--- a/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
+++ b/src/Markout.SourceGeneration/Parser/KnownTypeSymbols.cs
@@ -19,6 +19,9 @@ internal sealed class KnownTypeSymbols
     private INamedTypeSymbol? _graph;
     private bool _graphResolved;
 
+    private INamedTypeSymbol? _mappedTextDiff;
+    private bool _mappedTextDiffResolved;
+
     private INamedTypeSymbol? _markoutTable;
     private bool _markoutTableResolved;
 
@@ -76,6 +79,7 @@ internal sealed class KnownTypeSymbols
     public INamedTypeSymbol? MarkoutField => Resolve(ref _markoutField, ref _markoutFieldResolved, "Markout.MarkoutField");
     public INamedTypeSymbol? TreeNode => Resolve(ref _treeNode, ref _treeNodeResolved, "Markout.TreeNode");
     public INamedTypeSymbol? Graph => Resolve(ref _graph, ref _graphResolved, "Markout.Graph");
+    public INamedTypeSymbol? MappedTextDiff => Resolve(ref _mappedTextDiff, ref _mappedTextDiffResolved, "Markout.MappedTextDiff");
     public INamedTypeSymbol? MarkoutTable => Resolve(ref _markoutTable, ref _markoutTableResolved, "Markout.MarkoutTable");
     public INamedTypeSymbol? Metric => Resolve(ref _metric, ref _metricResolved, "Markout.Metric");
     public INamedTypeSymbol? Description => Resolve(ref _description, ref _descriptionResolved, "Markout.Description");

--- a/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeMetadata.cs
@@ -516,6 +516,7 @@ internal enum PropertyKind
     FieldCollection,
     Tree,
     Graph,
+    TextDiff,
     Metric,
     Description,
     CodeSection,

--- a/src/Markout.SourceGeneration/Parser/TypeParser.cs
+++ b/src/Markout.SourceGeneration/Parser/TypeParser.cs
@@ -739,6 +739,10 @@ internal static class TypeParser
         if (knownTypes.Graph is not null && SymbolEqualityComparer.Default.Equals(type, knownTypes.Graph))
             return (PropertyKind.Graph, null, null, false, null, null, true, FieldLayoutKind.Table, false);
 
+        // MappedTextDiff type - lowered by the writer without computing correspondence
+        if (knownTypes.MappedTextDiff is not null && SymbolEqualityComparer.Default.Equals(type, knownTypes.MappedTextDiff))
+            return (PropertyKind.TextDiff, null, null, false, null, null, true, FieldLayoutKind.Table, false);
+
         // MarkoutTable type - a table whose columns are runtime data, rendered by the writer
         if (knownTypes.MarkoutTable is not null && SymbolEqualityComparer.Default.Equals(type, knownTypes.MarkoutTable))
             return (PropertyKind.Table, null, null, false, null, null, true, FieldLayoutKind.Table, false);
@@ -1013,6 +1017,7 @@ internal static class TypeParser
              (p.Kind == PropertyKind.ComplexArray && p.JoinSeparator == null) ||
              p.Kind == PropertyKind.FieldCollection || p.Kind == PropertyKind.Tree ||
              p.Kind == PropertyKind.Graph ||
+             p.Kind == PropertyKind.TextDiff ||
              p.Kind == PropertyKind.Table ||
              p.Kind == PropertyKind.Description || p.Kind == PropertyKind.Metric ||
              p.Kind == PropertyKind.CodeSection || p.Kind == PropertyKind.Breakdown ||

--- a/src/Markout/Formatting/ITextDiffFormatter.cs
+++ b/src/Markout/Formatting/ITextDiffFormatter.cs
@@ -1,0 +1,8 @@
+namespace Markout.Formatting;
+
+/// <summary>Capability interface for rendering a mapped text diff.</summary>
+public interface ITextDiffFormatter
+{
+    /// <summary>Renders a validated mapped text diff.</summary>
+    void FormatTextDiff(TextWriter writer, MappedTextDiff diff, MarkoutWriterOptions options);
+}

--- a/src/Markout/MappedTextDiff.cs
+++ b/src/Markout/MappedTextDiff.cs
@@ -1,0 +1,304 @@
+using System.Collections.Immutable;
+
+namespace Markout;
+
+/// <summary>
+/// A validated mapping between two immutable ordered logical-line sequences.
+/// </summary>
+/// <remarks>
+/// Markout validates and presents the caller-issued mapping. It does not compare
+/// the text, infer correspondence, or repair malformed ranges.
+/// </remarks>
+public sealed class MappedTextDiff
+{
+    /// <summary>The Before sequence.</summary>
+    public TextDiffSequence Before { get; }
+
+    /// <summary>The After sequence.</summary>
+    public TextDiffSequence After { get; }
+
+    /// <summary>The canonical ordered change population.</summary>
+    public ImmutableArray<TextDiffChange> Changes { get; }
+
+    /// <summary>Whether the canonical change population is empty.</summary>
+    public bool IsEmpty => Changes.IsEmpty;
+
+    /// <summary>Creates and validates a mapped text diff.</summary>
+    public MappedTextDiff(
+        TextDiffSequence before,
+        TextDiffSequence after,
+        IEnumerable<TextDiffChange> changes)
+    {
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+        ArgumentNullException.ThrowIfNull(changes);
+
+        Before = before;
+        After = after;
+        Changes = [.. changes];
+
+        ValidateChanges();
+        ValidateAbsentFinalLine(Before, After, TextDiffSide.Before);
+        ValidateAbsentFinalLine(After, Before, TextDiffSide.After);
+    }
+
+    private void ValidateChanges()
+    {
+        var beforeCursor = 0;
+        var afterCursor = 0;
+
+        for (var address = 0; address < Changes.Length; address++)
+        {
+            var change = Changes[address];
+            if (change is null)
+                throw new ArgumentException($"Change at index {address} is null.", nameof(Changes));
+
+            ValidateRange(change.Before, Before.Lines.Length, address, TextDiffSide.Before);
+            ValidateRange(change.After, After.Lines.Length, address, TextDiffSide.After);
+
+            if (change.Before.Start < beforeCursor || change.After.Start < afterCursor)
+            {
+                throw new ArgumentException(
+                    $"Change at index {address} is not monotonic and non-overlapping on both sides.",
+                    nameof(Changes));
+            }
+
+            var beforeGap = change.Before.Start - beforeCursor;
+            var afterGap = change.After.Start - afterCursor;
+            if (beforeGap != afterGap)
+            {
+                throw new ArgumentException(
+                    $"The unchanged gap before change {address} has different Before and After counts.",
+                    nameof(Changes));
+            }
+
+            ValidateInnerMappings(change, address);
+            ValidateAnnotations(change, address);
+            beforeCursor = change.Before.End;
+            afterCursor = change.After.End;
+        }
+
+        if (Before.Lines.Length - beforeCursor != After.Lines.Length - afterCursor)
+        {
+            throw new ArgumentException(
+                "The trailing unchanged gap has different Before and After counts.",
+                nameof(Changes));
+        }
+    }
+
+    private static void ValidateRange(
+        TextDiffRange range,
+        int lineCount,
+        int address,
+        TextDiffSide side)
+    {
+        if (range.End > lineCount)
+        {
+            throw new ArgumentException(
+                $"{side} range for change {address} extends beyond its sequence.",
+                nameof(Changes));
+        }
+    }
+
+    private void ValidateInnerMappings(TextDiffChange change, int address)
+    {
+        if (change.InnerMappings.IsEmpty)
+            return;
+        if (change.Form != TextDiffChangeForm.Replacement)
+        {
+            throw new ArgumentException(
+                $"Only replacement change {address} may contain inner mappings.",
+                nameof(Changes));
+        }
+
+        TextDiffSpan? previousBefore = null;
+        TextDiffSpan? previousAfter = null;
+        for (var i = 0; i < change.InnerMappings.Length; i++)
+        {
+            var mapping = change.InnerMappings[i];
+            ValidateSpan(
+                mapping.Before,
+                Before,
+                change.Before,
+                address,
+                i,
+                TextDiffSide.Before,
+                "inner mapping");
+            ValidateSpan(
+                mapping.After,
+                After,
+                change.After,
+                address,
+                i,
+                TextDiffSide.After,
+                "inner mapping");
+
+            if (previousBefore is { } before && !EndsBeforeOrAt(before, mapping.Before))
+            {
+                throw new ArgumentException(
+                    $"Before span for inner mapping {i} in change {address} is not monotonic.",
+                    nameof(Changes));
+            }
+            if (previousAfter is { } after && !EndsBeforeOrAt(after, mapping.After))
+            {
+                throw new ArgumentException(
+                    $"After span for inner mapping {i} in change {address} is not monotonic.",
+                    nameof(Changes));
+            }
+
+            previousBefore = mapping.Before;
+            previousAfter = mapping.After;
+        }
+    }
+
+    private static void ValidateSpan(
+        TextDiffSpan span,
+        TextDiffSequence sequence,
+        TextDiffRange changeRange,
+        int address,
+        int targetIndex,
+        TextDiffSide side,
+        string targetKind)
+    {
+        if (!changeRange.Contains(span.Line))
+        {
+            throw new ArgumentException(
+                $"{side} span for {targetKind} {targetIndex} in change {address} is outside the change.",
+                nameof(Changes));
+        }
+
+        var line = sequence.Lines[span.Line];
+        if (span.End > line.Length)
+        {
+            throw new ArgumentException(
+                $"{side} span for {targetKind} {targetIndex} in change {address} extends beyond its line.",
+                nameof(Changes));
+        }
+        if (!TextDiffValidation.IsUtf16Boundary(line, span.Start)
+            || !TextDiffValidation.IsUtf16Boundary(line, span.End))
+        {
+            throw new ArgumentException(
+                $"{side} span for {targetKind} {targetIndex} in change {address} splits a surrogate pair.",
+                nameof(Changes));
+        }
+    }
+
+    private void ValidateAnnotations(TextDiffChange change, int address)
+    {
+        for (var i = 0; i < change.Annotations.Length; i++)
+        {
+            var annotation = change.Annotations[i];
+            switch (annotation.TargetKind)
+            {
+                case TextDiffAnnotationTargetKind.Change:
+                    break;
+
+                case TextDiffAnnotationTargetKind.Line:
+                {
+                    var side = annotation.Side!.Value;
+                    var line = annotation.Line!.Value;
+                    if (!RangeFor(change, side).Contains(line))
+                    {
+                        throw new ArgumentException(
+                            $"Line annotation {i} in change {address} is outside the change.",
+                            nameof(Changes));
+                    }
+                    break;
+                }
+
+                case TextDiffAnnotationTargetKind.Span:
+                {
+                    var side = annotation.Side!.Value;
+                    var span = annotation.Span!.Value;
+                    ValidateSpan(
+                        span,
+                        SequenceFor(side),
+                        RangeFor(change, side),
+                        address,
+                        i,
+                        side,
+                        "annotation");
+                    break;
+                }
+
+                default:
+                    throw new ArgumentException(
+                        $"Annotation {i} in change {address} has an invalid target kind.",
+                        nameof(Changes));
+            }
+        }
+    }
+
+    private void ValidateAbsentFinalLine(
+        TextDiffSequence sequence,
+        TextDiffSequence other,
+        TextDiffSide side)
+    {
+        if (sequence.FinalLineTerminator != TextDiffLineTerminator.Absent)
+            return;
+
+        var finalLine = sequence.Lines.Length - 1;
+        if (Changes.Any(change => RangeFor(change, side).Contains(finalLine)))
+            return;
+
+        if (!TryMapUnchangedLine(side, finalLine, out var otherLine)
+            || otherLine != other.Lines.Length - 1
+            || other.FinalLineTerminator != TextDiffLineTerminator.Absent)
+        {
+            throw new ArgumentException(
+                $"The {side} unterminated final line must be changed or correspond to an unterminated final line.",
+                nameof(Changes));
+        }
+    }
+
+    private bool TryMapUnchangedLine(TextDiffSide side, int line, out int otherLine)
+    {
+        var beforeCursor = 0;
+        var afterCursor = 0;
+
+        foreach (var change in Changes)
+        {
+            var beforeGap = new TextDiffRange(beforeCursor, change.Before.Start - beforeCursor);
+            var afterGap = new TextDiffRange(afterCursor, change.After.Start - afterCursor);
+            if (side == TextDiffSide.Before && beforeGap.Contains(line))
+            {
+                otherLine = afterGap.Start + (line - beforeGap.Start);
+                return true;
+            }
+            if (side == TextDiffSide.After && afterGap.Contains(line))
+            {
+                otherLine = beforeGap.Start + (line - afterGap.Start);
+                return true;
+            }
+
+            beforeCursor = change.Before.End;
+            afterCursor = change.After.End;
+        }
+
+        var trailingBefore = new TextDiffRange(beforeCursor, Before.Lines.Length - beforeCursor);
+        var trailingAfter = new TextDiffRange(afterCursor, After.Lines.Length - afterCursor);
+        if (side == TextDiffSide.Before && trailingBefore.Contains(line))
+        {
+            otherLine = trailingAfter.Start + (line - trailingBefore.Start);
+            return true;
+        }
+        if (side == TextDiffSide.After && trailingAfter.Contains(line))
+        {
+            otherLine = trailingBefore.Start + (line - trailingAfter.Start);
+            return true;
+        }
+
+        otherLine = -1;
+        return false;
+    }
+
+    private TextDiffSequence SequenceFor(TextDiffSide side)
+        => side == TextDiffSide.Before ? Before : After;
+
+    private static TextDiffRange RangeFor(TextDiffChange change, TextDiffSide side)
+        => side == TextDiffSide.Before ? change.Before : change.After;
+
+    private static bool EndsBeforeOrAt(TextDiffSpan earlier, TextDiffSpan later)
+        => earlier.Line < later.Line
+            || (earlier.Line == later.Line && earlier.End <= later.Start);
+}

--- a/src/Markout/MappedTextDiffLowering.cs
+++ b/src/Markout/MappedTextDiffLowering.cs
@@ -292,28 +292,42 @@ internal static class TextDiffEscaping
         bool escapeTab)
     {
         StringBuilder? builder = null;
-        for (var i = 0; i < value.Length; i++)
+        for (var i = 0; i < value.Length;)
         {
             var c = value[i];
-            var replacement = Replacement(c, escapeBackslash, escapeTab);
+            var width = char.IsHighSurrogate(c) ? 2 : 1;
+            var replacement = Replacement(value, i, width, escapeBackslash, escapeTab);
             if (replacement is null)
             {
                 if (builder is not null)
-                    builder.Append(c);
+                    builder.Append(value, i, width);
+                i += width;
                 continue;
             }
 
             builder ??= new StringBuilder(value.Length + 8).Append(value, 0, i);
             builder.Append(replacement);
+            i += width;
         }
         return builder?.ToString() ?? value;
     }
 
     private static string? Replacement(
-        char c,
+        string value,
+        int index,
+        int width,
         bool escapeBackslash,
         bool escapeTab)
     {
+        if (width == 2)
+        {
+            var rune = new Rune(value[index], value[index + 1]);
+            return IsEscapedCategory(Rune.GetUnicodeCategory(rune))
+                ? $"\\U{rune.Value:X8}"
+                : null;
+        }
+
+        var c = value[index];
         if (escapeBackslash && c == '\\')
             return "\\\\";
         if (c == '\t')
@@ -323,12 +337,14 @@ internal static class TextDiffEscaping
         if (c == '\n')
             return "\\n";
 
-        var category = char.GetUnicodeCategory(c);
-        return category is UnicodeCategory.Control
-            or UnicodeCategory.Format
-            or UnicodeCategory.LineSeparator
-            or UnicodeCategory.ParagraphSeparator
+        return IsEscapedCategory(char.GetUnicodeCategory(c))
             ? $"\\u{(int)c:X4}"
             : null;
     }
+
+    private static bool IsEscapedCategory(UnicodeCategory category)
+        => category is UnicodeCategory.Control
+            or UnicodeCategory.Format
+            or UnicodeCategory.LineSeparator
+            or UnicodeCategory.ParagraphSeparator;
 }

--- a/src/Markout/MappedTextDiffLowering.cs
+++ b/src/Markout/MappedTextDiffLowering.cs
@@ -1,0 +1,334 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+
+namespace Markout;
+
+/// <summary>Shared format-neutral lowerings for a <see cref="MappedTextDiff"/>.</summary>
+public static class MappedTextDiffLowering
+{
+    /// <summary>
+    /// Projects a diff into context, change, omission, and annotation records.
+    /// </summary>
+    /// <param name="diff">The validated mapped diff.</param>
+    /// <param name="contextLines">
+    /// The number of unchanged lines retained on each side of a change, or
+    /// <c>null</c> to retain every unchanged line.
+    /// </param>
+    public static ImmutableArray<TextDiffDisplayLine> ToDisplayLines(
+        MappedTextDiff diff,
+        int? contextLines = 3)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        ValidateContextLines(contextLines);
+        if (diff.IsEmpty)
+            return [];
+
+        var hunks = SelectHunks(diff, contextLines);
+        var records = ImmutableArray.CreateBuilder<TextDiffDisplayLine>();
+        var beforeCursor = 0;
+        var afterCursor = 0;
+
+        foreach (var hunk in hunks)
+        {
+            AddOmission(
+                records,
+                new TextDiffRange(beforeCursor, hunk.Before.Start - beforeCursor),
+                new TextDiffRange(afterCursor, hunk.After.Start - afterCursor));
+            records.AddRange(hunk.Lines);
+            beforeCursor = hunk.Before.End;
+            afterCursor = hunk.After.End;
+        }
+
+        AddOmission(
+            records,
+            new TextDiffRange(beforeCursor, diff.Before.Lines.Length - beforeCursor),
+            new TextDiffRange(afterCursor, diff.After.Lines.Length - afterCursor));
+        return records.ToImmutable();
+    }
+
+    internal static ImmutableArray<TextDiffHunk> SelectHunks(
+        MappedTextDiff diff,
+        int? contextLines)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        ValidateContextLines(contextLines);
+        if (diff.IsEmpty)
+            return [];
+
+        var hunks = ImmutableArray.CreateBuilder<TextDiffHunk>();
+        var firstAddress = 0;
+        while (firstAddress < diff.Changes.Length)
+        {
+            var lastAddress = firstAddress;
+            if (contextLines is null)
+            {
+                lastAddress = diff.Changes.Length - 1;
+            }
+            else
+            {
+                while (lastAddress + 1 < diff.Changes.Length)
+                {
+                    var current = diff.Changes[lastAddress];
+                    var next = diff.Changes[lastAddress + 1];
+                    var gap = next.Before.Start - current.Before.End;
+                    if ((long)gap > (long)contextLines.Value * 2)
+                        break;
+                    lastAddress++;
+                }
+            }
+
+            var first = diff.Changes[firstAddress];
+            var last = diff.Changes[lastAddress];
+            var previousBeforeEnd = firstAddress == 0 ? 0 : diff.Changes[firstAddress - 1].Before.End;
+            var previousAfterEnd = firstAddress == 0 ? 0 : diff.Changes[firstAddress - 1].After.End;
+            var nextBeforeStart = lastAddress + 1 == diff.Changes.Length
+                ? diff.Before.Lines.Length
+                : diff.Changes[lastAddress + 1].Before.Start;
+            var nextAfterStart = lastAddress + 1 == diff.Changes.Length
+                ? diff.After.Lines.Length
+                : diff.Changes[lastAddress + 1].After.Start;
+
+            var leading = contextLines is null
+                ? first.Before.Start - previousBeforeEnd
+                : Math.Min(contextLines.Value, first.Before.Start - previousBeforeEnd);
+            var trailing = contextLines is null
+                ? nextBeforeStart - last.Before.End
+                : Math.Min(contextLines.Value, nextBeforeStart - last.Before.End);
+            var before = new TextDiffRange(
+                first.Before.Start - leading,
+                last.Before.End + trailing - (first.Before.Start - leading));
+            var after = new TextDiffRange(
+                first.After.Start - leading,
+                last.After.End + trailing - (first.After.Start - leading));
+
+            hunks.Add(new TextDiffHunk(
+                before,
+                after,
+                BuildHunkLines(diff, firstAddress, lastAddress, before, after)));
+            firstAddress = lastAddress + 1;
+        }
+
+        return hunks.ToImmutable();
+    }
+
+    private static ImmutableArray<TextDiffDisplayLine> BuildHunkLines(
+        MappedTextDiff diff,
+        int firstAddress,
+        int lastAddress,
+        TextDiffRange beforeRange,
+        TextDiffRange afterRange)
+    {
+        var lines = ImmutableArray.CreateBuilder<TextDiffDisplayLine>();
+        var beforeCursor = beforeRange.Start;
+        var afterCursor = afterRange.Start;
+
+        for (var address = firstAddress; address <= lastAddress; address++)
+        {
+            var change = diff.Changes[address];
+            AddContext(lines, diff, beforeCursor, afterCursor, change.Before.Start - beforeCursor);
+
+            for (var line = change.Before.Start; line < change.Before.End; line++)
+            {
+                lines.Add(new TextDiffDisplayLine(
+                    TextDiffDisplayLineKind.Removal,
+                    TextDiffSide.Before,
+                    address,
+                    change.Form,
+                    beforeLine: line,
+                    beforeText: diff.Before.Lines[line]));
+            }
+
+            for (var line = change.After.Start; line < change.After.End; line++)
+            {
+                lines.Add(new TextDiffDisplayLine(
+                    TextDiffDisplayLineKind.Addition,
+                    TextDiffSide.After,
+                    address,
+                    change.Form,
+                    afterLine: line,
+                    afterText: diff.After.Lines[line]));
+            }
+
+            foreach (var annotation in change.Annotations)
+                lines.Add(CreateAnnotationLine(address, change.Form, annotation));
+
+            beforeCursor = change.Before.End;
+            afterCursor = change.After.End;
+        }
+
+        AddContext(lines, diff, beforeCursor, afterCursor, beforeRange.End - beforeCursor);
+        return lines.ToImmutable();
+    }
+
+    private static TextDiffDisplayLine CreateAnnotationLine(
+        int address,
+        TextDiffChangeForm form,
+        TextDiffAnnotation annotation)
+    {
+        var side = annotation.Side ?? TextDiffSide.Both;
+        int? beforeLine = null;
+        int? afterLine = null;
+        if (side == TextDiffSide.Before)
+            beforeLine = annotation.Line ?? annotation.Span?.Line;
+        else if (side == TextDiffSide.After)
+            afterLine = annotation.Line ?? annotation.Span?.Line;
+
+        return new TextDiffDisplayLine(
+            TextDiffDisplayLineKind.Annotation,
+            side,
+            address,
+            form,
+            beforeLine,
+            afterLine,
+            annotation: annotation);
+    }
+
+    private static void AddContext(
+        ImmutableArray<TextDiffDisplayLine>.Builder lines,
+        MappedTextDiff diff,
+        int beforeStart,
+        int afterStart,
+        int count)
+    {
+        for (var offset = 0; offset < count; offset++)
+        {
+            var beforeLine = beforeStart + offset;
+            var afterLine = afterStart + offset;
+            lines.Add(new TextDiffDisplayLine(
+                TextDiffDisplayLineKind.Context,
+                TextDiffSide.Both,
+                beforeLine: beforeLine,
+                afterLine: afterLine,
+                beforeText: diff.Before.Lines[beforeLine],
+                afterText: diff.After.Lines[afterLine]));
+        }
+    }
+
+    private static void AddOmission(
+        ImmutableArray<TextDiffDisplayLine>.Builder records,
+        TextDiffRange before,
+        TextDiffRange after)
+    {
+        if (before.IsEmpty)
+            return;
+
+        records.Add(new TextDiffDisplayLine(
+            TextDiffDisplayLineKind.Omission,
+            TextDiffSide.Both,
+            beforeRange: before,
+            afterRange: after));
+    }
+
+    private static void ValidateContextLines(int? contextLines)
+    {
+        if (contextLines < 0)
+            throw new ArgumentOutOfRangeException(nameof(contextLines));
+    }
+}
+
+internal sealed class TextDiffHunk
+{
+    public TextDiffRange Before { get; }
+    public TextDiffRange After { get; }
+    public ImmutableArray<TextDiffDisplayLine> Lines { get; }
+
+    public TextDiffHunk(
+        TextDiffRange before,
+        TextDiffRange after,
+        ImmutableArray<TextDiffDisplayLine> lines)
+    {
+        Before = before;
+        After = after;
+        Lines = lines;
+    }
+}
+
+internal static class TextDiffEscaping
+{
+    public static string Unified(string value)
+        => Escape(value, escapeBackslash: false, escapeTab: false);
+
+    public static string Human(string value)
+        => Escape(value, escapeBackslash: false, escapeTab: true);
+
+    public static string Structured(string value)
+        => Escape(value, escapeBackslash: true, escapeTab: true);
+
+    public static string MarkdownInline(string value)
+        => Human(value)
+            .Replace("\\", "\\\\")
+            .Replace("*", "\\*")
+            .Replace("_", "\\_")
+            .Replace("~", "\\~")
+            .Replace("[", "\\[")
+            .Replace("]", "\\]");
+
+    public static int LongestBacktickRun(IEnumerable<string> values)
+    {
+        var longest = 0;
+        foreach (var value in values)
+        {
+            var current = 0;
+            foreach (var c in value)
+            {
+                if (c == '`')
+                {
+                    current++;
+                    longest = Math.Max(longest, current);
+                }
+                else
+                {
+                    current = 0;
+                }
+            }
+        }
+        return longest;
+    }
+
+    private static string Escape(
+        string value,
+        bool escapeBackslash,
+        bool escapeTab)
+    {
+        StringBuilder? builder = null;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            var replacement = Replacement(c, escapeBackslash, escapeTab);
+            if (replacement is null)
+            {
+                if (builder is not null)
+                    builder.Append(c);
+                continue;
+            }
+
+            builder ??= new StringBuilder(value.Length + 8).Append(value, 0, i);
+            builder.Append(replacement);
+        }
+        return builder?.ToString() ?? value;
+    }
+
+    private static string? Replacement(
+        char c,
+        bool escapeBackslash,
+        bool escapeTab)
+    {
+        if (escapeBackslash && c == '\\')
+            return "\\\\";
+        if (c == '\t')
+            return escapeTab ? "\\t" : null;
+        if (c == '\r')
+            return "\\r";
+        if (c == '\n')
+            return "\\n";
+
+        var category = char.GetUnicodeCategory(c);
+        return category is UnicodeCategory.Control
+            or UnicodeCategory.Format
+            or UnicodeCategory.LineSeparator
+            or UnicodeCategory.ParagraphSeparator
+            ? $"\\u{(int)c:X4}"
+            : null;
+    }
+}

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -581,13 +581,11 @@ public class MarkdownFormatter : IMarkoutFormatter,
             w.WriteLine(line);
         w.WriteLine(fence);
 
-        var wroteAnnotation = false;
         for (var address = 0; address < diff.Changes.Length; address++)
         {
             var change = diff.Changes[address];
             foreach (var annotation in change.Annotations)
             {
-                wroteAnnotation = true;
                 w.WriteLine();
                 w.Write("> **");
                 w.Write(annotation.Severity.ToString().ToUpperInvariant());
@@ -599,9 +597,6 @@ public class MarkdownFormatter : IMarkoutFormatter,
                 w.WriteLine();
             }
         }
-
-        if (wroteAnnotation)
-            w.WriteLine();
     }
 
     // ── ITreeFormatter ──

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -11,7 +11,7 @@ namespace Markout;
 /// </summary>
 public class MarkdownFormatter : IMarkoutFormatter,
     IDocumentFormatter, IMetricsFormatter, IStreamingTableFormatter, IGlyphFormatter, IEmphasisFormatter,
-    IGraphFormatter
+    IGraphFormatter, ITextDiffFormatter
 {
     private const int CellPadding = 2; // leading space + trailing space
     private static readonly string[] HeadingPrefixes = ["", "#", "##", "###", "####", "#####", "######"];
@@ -564,6 +564,44 @@ public class MarkdownFormatter : IMarkoutFormatter,
             graph,
             node => node.Emphasized ? ((IEmphasisFormatter)this).Emphasize(node.Label) : node.Label);
         return true;
+    }
+
+    // ── ITextDiffFormatter ──
+
+    void ITextDiffFormatter.FormatTextDiff(
+        TextWriter w,
+        MappedTextDiff diff,
+        MarkoutWriterOptions options)
+    {
+        var lines = TextDiffFormatterHelpers.UnifiedLines(diff, options.TextDiffContextLines);
+        var fence = new string('`', Math.Max(3, TextDiffEscaping.LongestBacktickRun(lines) + 1));
+        w.Write(fence);
+        w.WriteLine("diff");
+        foreach (var line in lines)
+            w.WriteLine(line);
+        w.WriteLine(fence);
+
+        var wroteAnnotation = false;
+        for (var address = 0; address < diff.Changes.Length; address++)
+        {
+            var change = diff.Changes[address];
+            foreach (var annotation in change.Annotations)
+            {
+                wroteAnnotation = true;
+                w.WriteLine();
+                w.Write("> **");
+                w.Write(annotation.Severity.ToString().ToUpperInvariant());
+                w.Write(" — ");
+                w.Write(FormatHelper.EscapeMarkdownText(
+                    TextDiffFormatterHelpers.AnnotationTarget(annotation, address)));
+                w.Write(":** ");
+                w.Write(FormatHelper.EscapeMarkdownText(TextDiffEscaping.MarkdownInline(annotation.Text)));
+                w.WriteLine();
+            }
+        }
+
+        if (wroteAnnotation)
+            w.WriteLine();
     }
 
     // ── ITreeFormatter ──

--- a/src/Markout/MarkoutShape.cs
+++ b/src/Markout/MarkoutShape.cs
@@ -58,6 +58,11 @@ public enum MarkoutShape
     /// </summary>
     Graphs = 16384,
 
+    /// <summary>
+    /// Mapped correspondence between two ordered logical-line sequences.
+    /// </summary>
+    TextDiffs = 32768,
+
     /// <summary>All shapes supported.</summary>
-    All = Headings | Paragraphs | Fields | Tables | Lists | Trees | Code | Metrics | Descriptions | Callouts | Breakdowns | Quotation | Graphs
+    All = Headings | Paragraphs | Fields | Tables | Lists | Trees | Code | Metrics | Descriptions | Callouts | Breakdowns | Quotation | Graphs | TextDiffs
 }

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -26,6 +26,10 @@ public class MarkoutWriter
     // State
     private bool _hasContentValue;
     private bool _needsBlankLine;
+    // Some shape output carries significant trailing whitespace. This floor lets
+    // document completion trim later whitespace without crossing that boundary.
+    private bool _preserveNextContentTrailingWhitespace;
+    private int _trailingWhitespacePreservationLength;
 
     private bool _inTable;
     private bool _inCode;
@@ -1832,11 +1836,18 @@ public class MarkoutWriter
         if (_formatter is not ITextDiffFormatter formatter)
             return false;
 
+        var preservesTrailingWhitespace =
+            _formatter is PlainTextFormatter
+            && TextDiffFormatterHelpers.PlainTextEndsWithSignificantWhitespace(
+                diff,
+                _options.TextDiffContextLines);
+
         EnsureBlankLineIfNeeded();
         formatter.FormatTextDiff(_writer, diff, _options);
         _needsBlankLine = _formatter is TableFormatter
             ? TableLeavesBlankLinePending
             : true;
+        _preserveNextContentTrailingWhitespace = preservesTrailingWhitespace;
         _hasContent = true;
         return true;
     }
@@ -1915,7 +1926,8 @@ public class MarkoutWriter
     }
 
     /// <summary>
-    /// Completes an in-memory document and returns its output, trimming trailing whitespace.
+    /// Completes an in-memory document and returns its output, trimming trailing whitespace
+    /// unless the final block requires exact trailing content.
     /// </summary>
     /// <remarks>
     /// Completion closes an open streaming table, reports an unsatisfied projection, and emits
@@ -1935,12 +1947,15 @@ public class MarkoutWriter
         }
 
         Flush();
-        return sw.ToString().TrimEnd();
+        var preservationLength = _sectionBuffer?.EmittedTrailingWhitespacePreservationLength
+            ?? _trailingWhitespacePreservationLength;
+        return CompleteInMemoryOutput(sw.ToString(), preservationLength);
     }
 
     /// <summary>
     /// Returns a side-effect-free preview of the output currently available from a
-    /// <see cref="StringWriter"/>-backed writer, trimming trailing whitespace.
+    /// <see cref="StringWriter"/>-backed writer, trimming trailing whitespace unless the final
+    /// block requires exact trailing content.
     /// </summary>
     /// <remarks>
     /// This method does not close an open table, report document-level projection diagnostics,
@@ -1961,8 +1976,26 @@ public class MarkoutWriter
         if (_target is not StringWriter sw)
             return base.ToString() ?? "";
 
-        var preview = _sectionBuffer?.RenderOrdered(_options.SectionOrder, _needsBlankLine);
-        return (sw.ToString() + preview).TrimEnd();
+        var preservationLength = _trailingWhitespacePreservationLength;
+        var preview = _sectionBuffer?.RenderOrdered(
+            _options.SectionOrder,
+            _needsBlankLine,
+            out preservationLength);
+        return CompleteInMemoryOutput(
+            sw.ToString() + preview,
+            preservationLength);
+    }
+
+    private static string CompleteInMemoryOutput(
+        string output,
+        int trailingWhitespacePreservationLength)
+    {
+        var length = output.Length;
+        var minimumLength = Math.Min(length, trailingWhitespacePreservationLength);
+        while (length > minimumLength && char.IsWhiteSpace(output[length - 1]))
+            length--;
+
+        return length == output.Length ? output : output[..length];
     }
 
     // ── Projection ──
@@ -2306,7 +2339,17 @@ public class MarkoutWriter
             _hasContentValue = value;
 
             if (value)
-                _sectionBuffer?.NoteContent();
+            {
+                if (_preserveNextContentTrailingWhitespace
+                    && _sectionBuffer is null
+                    && _target is StringWriter sw)
+                {
+                    _trailingWhitespacePreservationLength = sw.GetStringBuilder().Length;
+                }
+
+                _sectionBuffer?.NoteContent(_preserveNextContentTrailingWhitespace);
+                _preserveNextContentTrailingWhitespace = false;
+            }
         }
     }
 

--- a/src/Markout/MarkoutWriter.cs
+++ b/src/Markout/MarkoutWriter.cs
@@ -1812,6 +1812,35 @@ public class MarkoutWriter
         return true;
     }
 
+    // ── Mapped text diffs ──
+
+    /// <summary>
+    /// Writes caller-issued mappings between two ordered logical-line
+    /// sequences. The formatter chooses its own unified, structured, or rich
+    /// lowering.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if rendered or filtered; <c>false</c> if the formatter does
+    /// not support mapped text diffs.
+    /// </returns>
+    public bool WriteTextDiff(MappedTextDiff diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+
+        if (diff.IsEmpty || _sectionExcluded)
+            return true;
+        if (_formatter is not ITextDiffFormatter formatter)
+            return false;
+
+        EnsureBlankLineIfNeeded();
+        formatter.FormatTextDiff(_writer, diff, _options);
+        _needsBlankLine = _formatter is TableFormatter
+            ? TableLeavesBlankLinePending
+            : true;
+        _hasContent = true;
+        return true;
+    }
+
     // ── Link definitions ──
 
     /// <summary>

--- a/src/Markout/MarkoutWriterOptions.cs
+++ b/src/Markout/MarkoutWriterOptions.cs
@@ -30,6 +30,7 @@ public class MarkoutWriterOptions
     private MarkoutGlyphs _glyphs = MarkoutGlyphs.Default;
     private Func<GlyphContext, string>? _composeGlyph;
     private string _newLine = Environment.NewLine;
+    private int? _textDiffContextLines = 3;
 
     /// <summary>Creates a new, writable options instance with default values.</summary>
     public MarkoutWriterOptions()
@@ -61,6 +62,7 @@ public class MarkoutWriterOptions
         _glyphs = source._glyphs;
         _composeGlyph = source._composeGlyph;
         _newLine = source._newLine;
+        _textDiffContextLines = source._textDiffContextLines;
     }
 
     /// <summary>
@@ -196,6 +198,24 @@ public class MarkoutWriterOptions
         {
             ThrowIfReadOnly();
             _maxItems = value;
+        }
+    }
+
+    /// <summary>
+    /// The number of unchanged lines retained on each side of a mapped text
+    /// diff change. Defaults to 3. Set to <c>null</c> to retain every unchanged
+    /// line. Unlike <see cref="MaxItems"/>, this hides only unchanged context
+    /// and produces exact omission records.
+    /// </summary>
+    public int? TextDiffContextLines
+    {
+        get => _textDiffContextLines;
+        set
+        {
+            ThrowIfReadOnly();
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value));
+            _textDiffContextLines = value;
         }
     }
 

--- a/src/Markout/PlainTextFormatter.cs
+++ b/src/Markout/PlainTextFormatter.cs
@@ -9,7 +9,8 @@ namespace Markout;
 /// </summary>
 public class PlainTextFormatter : IMarkoutFormatter,
     IHeadingFormatter, IFieldFormatter, IBlockFormatter,
-    IListFormatter, ITableFormatter, ICodeBlockFormatter, ITreeFormatter, IGraphFormatter
+    IListFormatter, ITableFormatter, ICodeBlockFormatter, ITreeFormatter, IGraphFormatter,
+    ITextDiffFormatter
 {
     // ── IGraphFormatter ──
 
@@ -25,6 +26,30 @@ public class PlainTextFormatter : IMarkoutFormatter,
 
         ((ITreeFormatter)this).FormatTree(w, GraphLowering.ToTree(graph).AsSpan(), options);
     }
+
+    // ── ITextDiffFormatter ──
+
+    void ITextDiffFormatter.FormatTextDiff(
+        TextWriter w,
+        MappedTextDiff diff,
+        MarkoutWriterOptions options)
+    {
+        foreach (var line in TextDiffFormatterHelpers.UnifiedLines(diff, options.TextDiffContextLines))
+            w.WriteLine(line);
+
+        for (var address = 0; address < diff.Changes.Length; address++)
+        {
+            var change = diff.Changes[address];
+            foreach (var annotation in change.Annotations)
+            {
+                w.Write("Annotation (");
+                w.Write(TextDiffFormatterHelpers.AnnotationTarget(annotation, address));
+                w.Write("): ");
+                w.WriteLine(TextDiffEscaping.Human(annotation.Text));
+            }
+        }
+    }
+
     private const int ColumnGap = 2;
 
     // ── IHeadingFormatter ──

--- a/src/Markout/SectionBufferingWriter.cs
+++ b/src/Markout/SectionBufferingWriter.cs
@@ -86,6 +86,7 @@ internal sealed class SectionBufferingWriter : TextWriter
     private Chunk _preamble;
     private Chunk _current;
     private bool _emitted;
+    private int _emittedTrailingWhitespacePreservationLength;
 
     public SectionBufferingWriter(TextWriter target)
     {
@@ -134,6 +135,12 @@ internal sealed class SectionBufferingWriter : TextWriter
         /// itself from those.
         /// </summary>
         public bool ContainsContent { get; set; }
+
+        /// <summary>
+        /// The position through which document-end trimming must preserve this chunk.
+        /// Later whitespace in the same chunk remains ordinary trim candidates.
+        /// </summary>
+        public int TrailingWhitespacePreservationLength { get; set; }
 
         /// <summary>
         /// Whether <see cref="SeparatorNewLine"/> has been observed yet. The first
@@ -205,7 +212,15 @@ internal sealed class SectionBufferingWriter : TextWriter
     /// Records that the section now open holds content — something a block after it
     /// would separate itself from, as opposed to blank lines, which it would not.
     /// </summary>
-    public void NoteContent() => _current.ContainsContent = true;
+    public void NoteContent(bool preservesTrailingWhitespaceAtEnd)
+    {
+        _current.ContainsContent = true;
+        if (preservesTrailingWhitespaceAtEnd)
+        {
+            _current.TrailingWhitespacePreservationLength =
+                _current.Content.Length;
+        }
+    }
 
     /// <summary>
     /// Writes a blank line the caller asked for at a section seam, and records that the
@@ -403,9 +418,18 @@ internal sealed class SectionBufferingWriter : TextWriter
         if (_emitted)
             return;
 
-        if (!WriteOrdered(_target, order, endsNeedingBlankLine))
+        var targetLength = TargetLength();
+        if (!WriteOrdered(
+                _target,
+                order,
+                endsNeedingBlankLine,
+                out var relativePreservationLength))
             return;
 
+        _emittedTrailingWhitespacePreservationLength =
+            relativePreservationLength == 0
+                ? 0
+                : targetLength + relativePreservationLength;
         _emitted = true;
 
         // Drop the buffers rather than clearing them: StringBuilder.Clear allocates a
@@ -420,24 +444,45 @@ internal sealed class SectionBufferingWriter : TextWriter
     /// Renders the currently buffered document without emitting it or making the writer
     /// read-only. Used by <see cref="MarkoutWriter.ToString"/> for side-effect-free previews.
     /// </summary>
-    public string RenderOrdered(IReadOnlyList<string>? order, bool endsNeedingBlankLine)
+    public string RenderOrdered(
+        IReadOnlyList<string>? order,
+        bool endsNeedingBlankLine,
+        out int trailingWhitespacePreservationLength)
     {
         if (_emitted)
+        {
+            trailingWhitespacePreservationLength =
+                _emittedTrailingWhitespacePreservationLength;
             return "";
+        }
 
         var preview = new StringWriter(_target.FormatProvider)
         {
             NewLine = _target.NewLine
         };
-        WriteOrdered(preview, order, endsNeedingBlankLine);
+        WriteOrdered(
+            preview,
+            order,
+            endsNeedingBlankLine,
+            out var relativePreservationLength);
+        trailingWhitespacePreservationLength =
+            relativePreservationLength == 0
+                ? 0
+                : TargetLength() + relativePreservationLength;
         return preview.ToString();
     }
+
+    public int EmittedTrailingWhitespacePreservationLength
+        => _emittedTrailingWhitespacePreservationLength;
 
     private bool WriteOrdered(
         TextWriter output,
         IReadOnlyList<string>? order,
-        bool currentEndsNeedingBlankLine)
+        bool currentEndsNeedingBlankLine,
+        out int trailingWhitespacePreservationLength)
     {
+        trailingWhitespacePreservationLength = 0;
+        var outputLength = 0;
         var rank = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         if (order != null)
         {
@@ -480,6 +525,7 @@ internal sealed class SectionBufferingWriter : TextWriter
                 if (blankLinePending)
                 {
                     output.Write(chunk.SeparatorNewLine);
+                    outputLength += chunk.SeparatorNewLine.Length;
                     blankLinePending = false;
                     emitted = true;
                 }
@@ -487,7 +533,14 @@ internal sealed class SectionBufferingWriter : TextWriter
 
             if (chunk.Content.Length > 0)
             {
+                if (chunk.TrailingWhitespacePreservationLength > 0)
+                {
+                    trailingWhitespacePreservationLength =
+                        outputLength + chunk.TrailingWhitespacePreservationLength;
+                }
+
                 output.Write(chunk.Content);
+                outputLength += chunk.Content.Length;
                 emitted = true;
             }
 
@@ -515,6 +568,9 @@ internal sealed class SectionBufferingWriter : TextWriter
 
         return emitted;
     }
+
+    private int TargetLength()
+        => _target is StringWriter sw ? sw.GetStringBuilder().Length : 0;
 
     private static IEnumerable<Chunk> Prepend(Chunk first, IEnumerable<Chunk> rest)
     {

--- a/src/Markout/TableFormatter.cs
+++ b/src/Markout/TableFormatter.cs
@@ -11,7 +11,7 @@ namespace Markout;
 /// space-padded table from the same row/column projection.
 /// </summary>
 public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatter, IListFormatter,
-    ICompositeCellFormatter, IGraphFormatter
+    ICompositeCellFormatter, IGraphFormatter, ITextDiffFormatter
 {
     // ── IGraphFormatter ──
 
@@ -34,6 +34,32 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
     {
         table = GraphLowering.ToDeferredEdgeTable(graph);
         return true;
+    }
+
+    // ── ITextDiffFormatter ──
+
+    void ITextDiffFormatter.FormatTextDiff(
+        TextWriter w,
+        MappedTextDiff diff,
+        MarkoutWriterOptions options)
+    {
+        var table = TextDiffFormatterHelpers.StructuredTable(
+            diff,
+            options.TextDiffContextLines);
+        var structuredOptions = options.WithJsonIdentityColumnIndices(
+            TextDiffFormatterHelpers.JsonStringColumnIndices);
+        switch (options.TableMode)
+        {
+            case MarkoutTableMode.Tsv:
+                WriteTsvTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, renderInline: false);
+                break;
+            case MarkoutTableMode.Jsonl:
+                WriteJsonlTable(w, table.Headers.AsSpan(), table.Rows, structuredOptions, renderInline: false);
+                break;
+            default:
+                WritePrettyTable(w, table.Headers.AsSpan(), table.Rows, skippedRows: 0, renderInline: false);
+                break;
+        }
     }
 
     private const int ColumnGap = 2;
@@ -106,41 +132,56 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
             w.WriteLine(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(item)));
     }
 
-    private void WriteTsvTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows)
+    private void WriteTsvTable(
+        TextWriter w,
+        ReadOnlySpan<string> headers,
+        IList<string[]> rows,
+        int skippedRows,
+        bool renderInline = true)
     {
         if (_showHeader)
-            WriteTsvRow(w, headers);
+            WriteTsvRow(w, headers, renderInline);
 
         foreach (var row in rows)
-            WriteTsvRow(w, row);
+            WriteTsvRow(w, row, renderInline);
 
         if (skippedRows > 0)
             FormatHelper.WriteTruncationFooter(w, skippedRows);
     }
 
-    private void WritePrettyTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, int skippedRows)
+    private void WritePrettyTable(
+        TextWriter w,
+        ReadOnlySpan<string> headers,
+        IList<string[]> rows,
+        int skippedRows,
+        bool renderInline = true)
     {
         var widths = new int[headers.Length];
         for (int i = 0; i < headers.Length; i++)
-            widths[i] = FormatHelper.NormalizeTableCell(headers[i]).Length;
+            widths[i] = PrepareTableCell(headers[i], renderInline).Length;
 
         foreach (var row in rows)
         {
             for (int i = 0; i < Math.Min(row.Length, widths.Length); i++)
-                widths[i] = Math.Max(widths[i], FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(row[i])).Length);
+                widths[i] = Math.Max(widths[i], PrepareTableCell(row[i], renderInline).Length);
         }
 
         if (_showHeader)
-            WritePrettyRow(w, headers, widths);
+            WritePrettyRow(w, headers, widths, renderInline);
 
         foreach (var row in rows)
-            WritePrettyRow(w, row, widths);
+            WritePrettyRow(w, row, widths, renderInline);
 
         if (skippedRows > 0)
             FormatHelper.WriteTruncationFooter(w, skippedRows);
     }
 
-    private static void WriteJsonlTable(TextWriter w, ReadOnlySpan<string> headers, IList<string[]> rows, MarkoutWriterOptions options)
+    private static void WriteJsonlTable(
+        TextWriter w,
+        ReadOnlySpan<string> headers,
+        IList<string[]> rows,
+        MarkoutWriterOptions options,
+        bool renderInline = true)
     {
         foreach (var row in rows)
         {
@@ -149,7 +190,9 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
             json.WriteStartObject();
             for (int i = 0; i < headers.Length; i++)
             {
-                var value = i < row.Length ? FormatHelper.RenderInlinePlainText(row[i]) : "";
+                var value = i < row.Length
+                    ? PrepareJsonValue(row[i], renderInline)
+                    : "";
 
                 // Heterogeneous records: drop empty fields when opted in.
                 if (options.OmitEmptyJsonFields && string.IsNullOrEmpty(value))
@@ -257,33 +300,43 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         return i == n;
     }
 
-    private static void WriteTsvRow(TextWriter w, ReadOnlySpan<string> values)
+    private static void WriteTsvRow(
+        TextWriter w,
+        ReadOnlySpan<string> values,
+        bool renderInline)
     {
         for (int i = 0; i < values.Length; i++)
         {
             if (i > 0)
                 w.Write('\t');
-            w.Write(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i])));
+            w.Write(PrepareTableCell(values[i], renderInline));
         }
         w.WriteLine();
     }
 
-    private static void WriteTsvRow(TextWriter w, string[] values)
+    private static void WriteTsvRow(
+        TextWriter w,
+        string[] values,
+        bool renderInline)
     {
         for (int i = 0; i < values.Length; i++)
         {
             if (i > 0)
                 w.Write('\t');
-            w.Write(FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i])));
+            w.Write(PrepareTableCell(values[i], renderInline));
         }
         w.WriteLine();
     }
 
-    private static void WritePrettyRow(TextWriter w, ReadOnlySpan<string> values, int[] widths)
+    private static void WritePrettyRow(
+        TextWriter w,
+        ReadOnlySpan<string> values,
+        int[] widths,
+        bool renderInline)
     {
         for (int i = 0; i < values.Length; i++)
         {
-            var value = FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i]));
+            var value = PrepareTableCell(values[i], renderInline);
             if (i < values.Length - 1)
                 w.Write(value.PadRight(widths[i] + ColumnGap));
             else
@@ -292,11 +345,15 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         w.WriteLine();
     }
 
-    private static void WritePrettyRow(TextWriter w, string[] values, int[] widths)
+    private static void WritePrettyRow(
+        TextWriter w,
+        string[] values,
+        int[] widths,
+        bool renderInline)
     {
         for (int i = 0; i < values.Length; i++)
         {
-            var value = FormatHelper.NormalizeTableCell(FormatHelper.RenderInlinePlainText(values[i]));
+            var value = PrepareTableCell(values[i], renderInline);
             if (i < values.Length - 1)
                 w.Write(value.PadRight(widths[i] + ColumnGap));
             else
@@ -304,4 +361,11 @@ public class TableFormatter : IMarkoutFormatter, ITableFormatter, IFieldFormatte
         }
         w.WriteLine();
     }
+
+    private static string PrepareTableCell(string? value, bool renderInline)
+        => FormatHelper.NormalizeTableCell(
+            renderInline ? FormatHelper.RenderInlinePlainText(value) : value ?? "");
+
+    private static string PrepareJsonValue(string? value, bool renderInline)
+        => renderInline ? FormatHelper.RenderInlinePlainText(value) : value ?? "";
 }

--- a/src/Markout/TextDiffFormatterHelpers.cs
+++ b/src/Markout/TextDiffFormatterHelpers.cs
@@ -105,31 +105,35 @@ internal static class TextDiffFormatterHelpers
     {
         var raw = line.Side == TextDiffSide.Before ? line.BeforeText! : line.AfterText!;
         if (line.ChangeAddress is not { } address)
-            return TextDiffEscaping.Human(raw);
+            return EscapeIntralineMarkerLiterals(raw);
 
         var spans = diff.Changes[address].InnerMappings
             .Select(mapping => line.Side == TextDiffSide.Before ? mapping.Before : mapping.After)
             .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine) && !span.IsEmpty)
             .ToArray();
         if (spans.Length == 0)
-            return EscapeMarkedLiteral(raw, open);
+            return EscapeIntralineMarkerLiterals(raw);
 
         var writer = new StringWriter();
         var cursor = 0;
         foreach (var span in spans)
         {
-            writer.Write(EscapeMarkedLiteral(raw[cursor..span.Start], open));
+            writer.Write(EscapeIntralineMarkerLiterals(raw[cursor..span.Start]));
             writer.Write(open);
-            writer.Write(EscapeMarkedLiteral(raw[span.Start..span.End], open));
+            writer.Write(EscapeIntralineMarkerLiterals(raw[span.Start..span.End]));
             writer.Write(close);
             cursor = span.End;
         }
-        writer.Write(EscapeMarkedLiteral(raw[cursor..], open));
+        writer.Write(EscapeIntralineMarkerLiterals(raw[cursor..]));
         return writer.ToString();
     }
 
-    private static string EscapeMarkedLiteral(string value, string open)
-        => TextDiffEscaping.Human(value).Replace(open, "\\" + open);
+    internal static string EscapeIntralineMarkerLiterals(string value)
+        => TextDiffEscaping.Human(value)
+            .Replace("[-", "\\[-")
+            .Replace("-]", "\\-]")
+            .Replace("{+", "\\{+")
+            .Replace("+}", "\\+}");
 
     internal static string SideName(TextDiffSide side)
         => side switch

--- a/src/Markout/TextDiffFormatterHelpers.cs
+++ b/src/Markout/TextDiffFormatterHelpers.cs
@@ -120,7 +120,7 @@ internal static class TextDiffFormatterHelpers
 
         var spans = diff.Changes[address].InnerMappings
             .Select(mapping => line.Side == TextDiffSide.Before ? mapping.Before : mapping.After)
-            .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine) && !span.IsEmpty)
+            .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine))
             .ToArray();
         if (spans.Length == 0)
             return EscapeIntralineMarkerLiterals(raw);
@@ -131,10 +131,13 @@ internal static class TextDiffFormatterHelpers
         {
             writer.Write(EscapeIntralineMarkerLiterals(raw[cursor..span.Start]));
             writer.Write(open);
-            writer.Write(EscapeMarkedPayload(
-                raw[span.Start..span.End],
-                open,
-                close));
+            if (!span.IsEmpty)
+            {
+                writer.Write(EscapeMarkedPayload(
+                    raw[span.Start..span.End],
+                    open,
+                    close));
+            }
             writer.Write(close);
             cursor = span.End;
         }

--- a/src/Markout/TextDiffFormatterHelpers.cs
+++ b/src/Markout/TextDiffFormatterHelpers.cs
@@ -112,21 +112,24 @@ internal static class TextDiffFormatterHelpers
             .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine) && !span.IsEmpty)
             .ToArray();
         if (spans.Length == 0)
-            return TextDiffEscaping.Human(raw);
+            return EscapeMarkedLiteral(raw, open);
 
         var writer = new StringWriter();
         var cursor = 0;
         foreach (var span in spans)
         {
-            writer.Write(TextDiffEscaping.Human(raw[cursor..span.Start]));
+            writer.Write(EscapeMarkedLiteral(raw[cursor..span.Start], open));
             writer.Write(open);
-            writer.Write(TextDiffEscaping.Human(raw[span.Start..span.End]));
+            writer.Write(EscapeMarkedLiteral(raw[span.Start..span.End], open));
             writer.Write(close);
             cursor = span.End;
         }
-        writer.Write(TextDiffEscaping.Human(raw[cursor..]));
+        writer.Write(EscapeMarkedLiteral(raw[cursor..], open));
         return writer.ToString();
     }
+
+    private static string EscapeMarkedLiteral(string value, string open)
+        => TextDiffEscaping.Human(value).Replace(open, "\\" + open);
 
     internal static string SideName(TextDiffSide side)
         => side switch

--- a/src/Markout/TextDiffFormatterHelpers.cs
+++ b/src/Markout/TextDiffFormatterHelpers.cs
@@ -45,6 +45,17 @@ internal static class TextDiffFormatterHelpers
         return lines;
     }
 
+    internal static bool PlainTextEndsWithSignificantWhitespace(
+        MappedTextDiff diff,
+        int? contextLines)
+    {
+        if (diff.Changes.Any(change => !change.Annotations.IsEmpty))
+            return false;
+
+        var lines = UnifiedLines(diff, contextLines);
+        return lines.Count > 0 && char.IsWhiteSpace(lines[^1][^1]);
+    }
+
     internal static StructuredTextDiffTable StructuredTable(
         MappedTextDiff diff,
         int? contextLines)
@@ -120,7 +131,10 @@ internal static class TextDiffFormatterHelpers
         {
             writer.Write(EscapeIntralineMarkerLiterals(raw[cursor..span.Start]));
             writer.Write(open);
-            writer.Write(EscapeIntralineMarkerLiterals(raw[span.Start..span.End]));
+            writer.Write(EscapeMarkedPayload(
+                raw[span.Start..span.End],
+                open,
+                close));
             writer.Write(close);
             cursor = span.End;
         }
@@ -129,11 +143,24 @@ internal static class TextDiffFormatterHelpers
     }
 
     internal static string EscapeIntralineMarkerLiterals(string value)
-        => TextDiffEscaping.Human(value)
+        => TextDiffEscaping.Human(value.Replace("\\", "\\\\"))
             .Replace("[-", "\\[-")
             .Replace("-]", "\\-]")
             .Replace("{+", "\\{+")
             .Replace("+}", "\\+}");
+
+    private static string EscapeMarkedPayload(
+        string value,
+        string open,
+        string close)
+    {
+        var escaped = EscapeIntralineMarkerLiterals(value);
+        if (value[0] == close[^1])
+            escaped = "\\" + escaped;
+        if (value[^1] == open[0])
+            escaped = escaped[..^1] + "\\" + escaped[^1];
+        return escaped;
+    }
 
     internal static string SideName(TextDiffSide side)
         => side switch

--- a/src/Markout/TextDiffFormatterHelpers.cs
+++ b/src/Markout/TextDiffFormatterHelpers.cs
@@ -1,0 +1,319 @@
+using System.Collections.Immutable;
+
+namespace Markout;
+
+internal static class TextDiffFormatterHelpers
+{
+    internal static List<string> UnifiedLines(
+        MappedTextDiff diff,
+        int? contextLines)
+    {
+        var lines = new List<string>
+        {
+            $"--- {TextDiffEscaping.Human(diff.Before.Label ?? "Before")}",
+            $"+++ {TextDiffEscaping.Human(diff.After.Label ?? "After")}"
+        };
+
+        foreach (var hunk in MappedTextDiffLowering.SelectHunks(diff, contextLines))
+        {
+            lines.Add($"@@ -{FormatRange(hunk.Before)} +{FormatRange(hunk.After)} @@");
+            foreach (var line in hunk.Lines)
+            {
+                switch (line.Kind)
+                {
+                    case TextDiffDisplayLineKind.Context:
+                        lines.Add(" " + TextDiffEscaping.Unified(line.BeforeText!));
+                        if (IsSharedUnterminatedFinalLine(diff, line))
+                            lines.Add(@"\ No newline at end of file");
+                        break;
+
+                    case TextDiffDisplayLineKind.Removal:
+                        lines.Add("-" + TextDiffEscaping.Unified(line.BeforeText!));
+                        if (IsUnterminatedFinalLine(diff.Before, line.BeforeLine))
+                            lines.Add(@"\ No newline at end of file");
+                        break;
+
+                    case TextDiffDisplayLineKind.Addition:
+                        lines.Add("+" + TextDiffEscaping.Unified(line.AfterText!));
+                        if (IsUnterminatedFinalLine(diff.After, line.AfterLine))
+                            lines.Add(@"\ No newline at end of file");
+                        break;
+                }
+            }
+        }
+
+        return lines;
+    }
+
+    internal static StructuredTextDiffTable StructuredTable(
+        MappedTextDiff diff,
+        int? contextLines)
+    {
+        var rows = new List<string[]>();
+        AddSequenceRow(rows, TextDiffSide.Before, diff.Before);
+        AddSequenceRow(rows, TextDiffSide.After, diff.After);
+
+        foreach (var line in MappedTextDiffLowering.ToDisplayLines(diff, contextLines))
+            rows.Add(ToStructuredRow(diff, line));
+
+        for (var address = 0; address < diff.Changes.Length; address++)
+        {
+            var change = diff.Changes[address];
+            foreach (var mapping in change.InnerMappings)
+            {
+                var row = EmptyRow();
+                row[RecordKind] = "inner_mapping";
+                row[ChangeAddress] = address.ToString();
+                row[ChangeForm] = Form(change.Form);
+                row[Side] = "both";
+                row[BeforeLine] = mapping.Before.Line.ToString();
+                row[AfterLine] = mapping.After.Line.ToString();
+                row[BeforeOffset] = mapping.Before.Start.ToString();
+                row[BeforeLength] = mapping.Before.Count.ToString();
+                row[AfterOffset] = mapping.After.Start.ToString();
+                row[AfterLength] = mapping.After.Count.ToString();
+                rows.Add(row);
+            }
+        }
+
+        return new StructuredTextDiffTable(Headers, rows);
+    }
+
+    internal static string AnnotationTarget(
+        TextDiffAnnotation annotation,
+        int? changeAddress = null)
+        => annotation.TargetKind switch
+        {
+            TextDiffAnnotationTargetKind.Change =>
+                changeAddress is { } address ? $"change {address + 1}" : "change",
+            TextDiffAnnotationTargetKind.Line => $"{SideName(annotation.Side!.Value)} line {annotation.Line!.Value + 1}",
+            TextDiffAnnotationTargetKind.Span =>
+                SpanTarget(annotation.Side!.Value, annotation.Span!.Value),
+            _ => "annotation"
+        };
+
+    private static string SpanTarget(TextDiffSide side, TextDiffSpan span)
+        => span.IsEmpty
+            ? $"{SideName(side)} line {span.Line + 1}, insertion point at column {span.Start + 1}"
+            : $"{SideName(side)} line {span.Line + 1}, columns {span.Start + 1}-{span.End}";
+
+    internal static string FormatMarkedLine(
+        MappedTextDiff diff,
+        TextDiffDisplayLine line,
+        string open,
+        string close)
+    {
+        var raw = line.Side == TextDiffSide.Before ? line.BeforeText! : line.AfterText!;
+        if (line.ChangeAddress is not { } address)
+            return TextDiffEscaping.Human(raw);
+
+        var spans = diff.Changes[address].InnerMappings
+            .Select(mapping => line.Side == TextDiffSide.Before ? mapping.Before : mapping.After)
+            .Where(span => span.Line == (line.BeforeLine ?? line.AfterLine) && !span.IsEmpty)
+            .ToArray();
+        if (spans.Length == 0)
+            return TextDiffEscaping.Human(raw);
+
+        var writer = new StringWriter();
+        var cursor = 0;
+        foreach (var span in spans)
+        {
+            writer.Write(TextDiffEscaping.Human(raw[cursor..span.Start]));
+            writer.Write(open);
+            writer.Write(TextDiffEscaping.Human(raw[span.Start..span.End]));
+            writer.Write(close);
+            cursor = span.End;
+        }
+        writer.Write(TextDiffEscaping.Human(raw[cursor..]));
+        return writer.ToString();
+    }
+
+    internal static string SideName(TextDiffSide side)
+        => side switch
+        {
+            TextDiffSide.Before => "Before",
+            TextDiffSide.After => "After",
+            _ => "Both"
+        };
+
+    private static string[] ToStructuredRow(
+        MappedTextDiff diff,
+        TextDiffDisplayLine line)
+    {
+        var row = EmptyRow();
+        row[RecordKind] = line.Kind switch
+        {
+            TextDiffDisplayLineKind.Context => "context",
+            TextDiffDisplayLineKind.Removal => "removal",
+            TextDiffDisplayLineKind.Addition => "addition",
+            TextDiffDisplayLineKind.Omission => "omission",
+            TextDiffDisplayLineKind.Annotation => "annotation",
+            _ => ""
+        };
+        row[Side] = line.Side switch
+        {
+            TextDiffSide.Before => "before",
+            TextDiffSide.After => "after",
+            _ => "both"
+        };
+        if (line.ChangeAddress is { } address)
+        {
+            var change = diff.Changes[address];
+            row[ChangeAddress] = address.ToString();
+            row[ChangeForm] = Form(change.Form);
+            SetRange(row, change.Before, change.After);
+        }
+        if (line.BeforeLine is { } beforeLine)
+            row[BeforeLine] = beforeLine.ToString();
+        if (line.AfterLine is { } afterLine)
+            row[AfterLine] = afterLine.ToString();
+        if (line.BeforeRange is { } beforeRange && line.AfterRange is { } afterRange)
+        {
+            SetRange(row, beforeRange, afterRange);
+            row[HiddenCount] = beforeRange.Count.ToString();
+        }
+        if (line.BeforeText is not null)
+            row[BeforeText] = TextDiffEscaping.Structured(line.BeforeText);
+        if (line.AfterText is not null)
+            row[AfterText] = TextDiffEscaping.Structured(line.AfterText);
+        if (line.Annotation is { } annotation)
+        {
+            row[Annotation] = TextDiffEscaping.Structured(annotation.Text);
+            row[Target] = AnnotationTarget(annotation);
+            row[Severity] = annotation.Severity.ToString().ToLowerInvariant();
+            if (annotation.Span is { } span)
+            {
+                if (annotation.Side == TextDiffSide.Before)
+                {
+                    row[BeforeOffset] = span.Start.ToString();
+                    row[BeforeLength] = span.Count.ToString();
+                }
+                else
+                {
+                    row[AfterOffset] = span.Start.ToString();
+                    row[AfterLength] = span.Count.ToString();
+                }
+            }
+        }
+        return row;
+    }
+
+    private static void AddSequenceRow(
+        List<string[]> rows,
+        TextDiffSide side,
+        TextDiffSequence sequence)
+    {
+        var row = EmptyRow();
+        row[RecordKind] = "sequence";
+        row[Side] = side == TextDiffSide.Before ? "before" : "after";
+        row[Label] = TextDiffEscaping.Structured(sequence.Label ?? SideName(side));
+        row[LineCount] = sequence.Lines.Length.ToString();
+        row[Terminator] = sequence.FinalLineTerminator.ToString().ToLowerInvariant();
+        rows.Add(row);
+    }
+
+    private static void SetRange(
+        string[] row,
+        TextDiffRange before,
+        TextDiffRange after)
+    {
+        row[BeforeStart] = before.Start.ToString();
+        row[BeforeCount] = before.Count.ToString();
+        row[AfterStart] = after.Start.ToString();
+        row[AfterCount] = after.Count.ToString();
+    }
+
+    private static string Form(TextDiffChangeForm form)
+        => form.ToString().ToLowerInvariant();
+
+    private static string FormatRange(TextDiffRange range)
+    {
+        var start = range.Count == 0 ? range.Start : range.Start + 1;
+        return range.Count == 1 ? start.ToString() : $"{start},{range.Count}";
+    }
+
+    private static bool IsUnterminatedFinalLine(
+        TextDiffSequence sequence,
+        int? line)
+        => sequence.FinalLineTerminator == TextDiffLineTerminator.Absent
+            && line == sequence.Lines.Length - 1;
+
+    private static bool IsSharedUnterminatedFinalLine(
+        MappedTextDiff diff,
+        TextDiffDisplayLine line)
+        => diff.Before.FinalLineTerminator == TextDiffLineTerminator.Absent
+            && diff.After.FinalLineTerminator == TextDiffLineTerminator.Absent
+            && line.BeforeLine == diff.Before.Lines.Length - 1
+            && line.AfterLine == diff.After.Lines.Length - 1;
+
+    private static string[] EmptyRow() => new string[Headers.Length];
+
+    private const int RecordKind = 0;
+    private const int ChangeAddress = 1;
+    private const int ChangeForm = 2;
+    private const int Side = 3;
+    private const int BeforeLine = 4;
+    private const int AfterLine = 5;
+    private const int BeforeStart = 6;
+    private const int BeforeCount = 7;
+    private const int AfterStart = 8;
+    private const int AfterCount = 9;
+    private const int HiddenCount = 10;
+    private const int BeforeOffset = 11;
+    private const int BeforeLength = 12;
+    private const int AfterOffset = 13;
+    private const int AfterLength = 14;
+    private const int BeforeText = 15;
+    private const int AfterText = 16;
+    private const int Annotation = 17;
+    private const int Target = 18;
+    private const int Severity = 19;
+    private const int Label = 20;
+    private const int LineCount = 21;
+    private const int Terminator = 22;
+
+    private static readonly ImmutableArray<string> Headers =
+    [
+        "record_kind",
+        "change_address",
+        "change_form",
+        "side",
+        "before_line",
+        "after_line",
+        "before_start",
+        "before_count",
+        "after_start",
+        "after_count",
+        "hidden_count",
+        "before_offset",
+        "before_length",
+        "after_offset",
+        "after_length",
+        "before_text",
+        "after_text",
+        "annotation",
+        "target",
+        "severity",
+        "label",
+        "line_count",
+        "terminator"
+    ];
+
+    internal static readonly IReadOnlySet<int> JsonStringColumnIndices = new HashSet<int>
+    {
+        RecordKind,
+        ChangeForm,
+        Side,
+        BeforeText,
+        AfterText,
+        Annotation,
+        Target,
+        Severity,
+        Label,
+        Terminator
+    };
+}
+
+internal readonly record struct StructuredTextDiffTable(
+    ImmutableArray<string> Headers,
+    List<string[]> Rows);

--- a/src/Markout/TextDiffPrimitives.cs
+++ b/src/Markout/TextDiffPrimitives.cs
@@ -1,0 +1,431 @@
+using System.Collections.Immutable;
+
+namespace Markout;
+
+/// <summary>Whether the producer knows how the final logical line is terminated.</summary>
+public enum TextDiffLineTerminator
+{
+    /// <summary>The producer does not assert final-line termination.</summary>
+    Unknown,
+
+    /// <summary>The final logical line ends with a line terminator.</summary>
+    Present,
+
+    /// <summary>The final logical line does not end with a line terminator.</summary>
+    Absent
+}
+
+/// <summary>The side of a mapped text diff.</summary>
+public enum TextDiffSide
+{
+    /// <summary>The Before sequence.</summary>
+    Before,
+
+    /// <summary>The After sequence.</summary>
+    After,
+
+    /// <summary>Both corresponding sequences.</summary>
+    Both
+}
+
+/// <summary>The form derived from the two mapped line-range counts.</summary>
+public enum TextDiffChangeForm
+{
+    /// <summary>An empty Before range maps to a non-empty After range.</summary>
+    Addition,
+
+    /// <summary>A non-empty Before range maps to an empty After range.</summary>
+    Removal,
+
+    /// <summary>Two non-empty ranges are related as a replacement.</summary>
+    Replacement
+}
+
+/// <summary>The target form of a static diff annotation.</summary>
+public enum TextDiffAnnotationTargetKind
+{
+    /// <summary>The complete mapped change.</summary>
+    Change,
+
+    /// <summary>One side-local logical line.</summary>
+    Line,
+
+    /// <summary>One side-local span within a logical line.</summary>
+    Span
+}
+
+/// <summary>The semantic kind of one projected display record.</summary>
+public enum TextDiffDisplayLineKind
+{
+    /// <summary>One corresponding unchanged line from both sequences.</summary>
+    Context,
+
+    /// <summary>One line from a change's Before range.</summary>
+    Removal,
+
+    /// <summary>One line from a change's After range.</summary>
+    Addition,
+
+    /// <summary>An exact pair of omitted unchanged ranges.</summary>
+    Omission,
+
+    /// <summary>A caller-issued annotation.</summary>
+    Annotation
+}
+
+/// <summary>A zero-based half-open range within one logical line sequence.</summary>
+public readonly record struct TextDiffRange
+{
+    /// <summary>The zero-based first line.</summary>
+    public int Start { get; }
+
+    /// <summary>The number of lines.</summary>
+    public int Count { get; }
+
+    /// <summary>The exclusive zero-based end.</summary>
+    public int End => checked(Start + Count);
+
+    /// <summary>Whether the range is empty.</summary>
+    public bool IsEmpty => Count == 0;
+
+    /// <summary>Creates a half-open line range.</summary>
+    public TextDiffRange(int start, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        _ = checked(start + count);
+        Start = start;
+        Count = count;
+    }
+
+    /// <summary>Returns whether the range contains the zero-based line.</summary>
+    public bool Contains(int line) => line >= Start && line < End;
+}
+
+/// <summary>
+/// A zero-based half-open UTF-16 span within one side-local logical line.
+/// </summary>
+public readonly record struct TextDiffSpan
+{
+    /// <summary>The zero-based sequence line.</summary>
+    public int Line { get; }
+
+    /// <summary>The zero-based UTF-16 code-unit offset.</summary>
+    public int Start { get; }
+
+    /// <summary>The number of UTF-16 code units.</summary>
+    public int Count { get; }
+
+    /// <summary>The exclusive UTF-16 code-unit end.</summary>
+    public int End => checked(Start + Count);
+
+    /// <summary>Whether the span is empty.</summary>
+    public bool IsEmpty => Count == 0;
+
+    /// <summary>Creates a side-local text span.</summary>
+    public TextDiffSpan(int line, int start, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(line);
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        _ = checked(start + count);
+        Line = line;
+        Start = start;
+        Count = count;
+    }
+}
+
+/// <summary>A caller-issued mapping between one Before span and one After span.</summary>
+public sealed class TextDiffInnerMapping
+{
+    /// <summary>The Before span.</summary>
+    public TextDiffSpan Before { get; }
+
+    /// <summary>The After span.</summary>
+    public TextDiffSpan After { get; }
+
+    /// <summary>Creates an inner text mapping.</summary>
+    public TextDiffInnerMapping(TextDiffSpan before, TextDiffSpan after)
+    {
+        if (before.IsEmpty && after.IsEmpty)
+            throw new ArgumentException("An inner mapping cannot contain two empty spans.");
+
+        Before = before;
+        After = after;
+    }
+}
+
+/// <summary>A caller-issued static annotation attached to a mapped change.</summary>
+public sealed class TextDiffAnnotation
+{
+    /// <summary>The annotation text.</summary>
+    public string Text { get; }
+
+    /// <summary>The annotation severity.</summary>
+    public CalloutSeverity Severity { get; }
+
+    /// <summary>The target form.</summary>
+    public TextDiffAnnotationTargetKind TargetKind { get; }
+
+    /// <summary>The target side for line and span annotations.</summary>
+    public TextDiffSide? Side { get; }
+
+    /// <summary>The target zero-based line for line annotations.</summary>
+    public int? Line { get; }
+
+    /// <summary>The target span for span annotations.</summary>
+    public TextDiffSpan? Span { get; }
+
+    private TextDiffAnnotation(
+        string text,
+        CalloutSeverity severity,
+        TextDiffAnnotationTargetKind targetKind,
+        TextDiffSide? side,
+        int? line,
+        TextDiffSpan? span)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(text);
+        TextDiffValidation.ValidateText(text, nameof(text));
+        if (!Enum.IsDefined(severity))
+            throw new ArgumentOutOfRangeException(nameof(severity));
+
+        Text = text;
+        Severity = severity;
+        TargetKind = targetKind;
+        Side = side;
+        Line = line;
+        Span = span;
+    }
+
+    /// <summary>Creates an annotation targeting the complete change.</summary>
+    public static TextDiffAnnotation ForChange(
+        string text,
+        CalloutSeverity severity = CalloutSeverity.Note)
+        => new(text, severity, TextDiffAnnotationTargetKind.Change, null, null, null);
+
+    /// <summary>Creates an annotation targeting one side-local line.</summary>
+    public static TextDiffAnnotation ForLine(
+        TextDiffSide side,
+        int line,
+        string text,
+        CalloutSeverity severity = CalloutSeverity.Note)
+    {
+        TextDiffValidation.ValidateSingleSide(side, nameof(side));
+        ArgumentOutOfRangeException.ThrowIfNegative(line);
+        return new(text, severity, TextDiffAnnotationTargetKind.Line, side, line, null);
+    }
+
+    /// <summary>Creates an annotation targeting one side-local span.</summary>
+    public static TextDiffAnnotation ForSpan(
+        TextDiffSide side,
+        TextDiffSpan span,
+        string text,
+        CalloutSeverity severity = CalloutSeverity.Note)
+    {
+        TextDiffValidation.ValidateSingleSide(side, nameof(side));
+        return new(text, severity, TextDiffAnnotationTargetKind.Span, side, null, span);
+    }
+}
+
+/// <summary>One immutable logical-line sequence in a mapped text diff.</summary>
+public sealed class TextDiffSequence
+{
+    /// <summary>The optional display label.</summary>
+    public string? Label { get; }
+
+    /// <summary>The logical lines in sequence order.</summary>
+    public ImmutableArray<string> Lines { get; }
+
+    /// <summary>The producer's final-line-terminator assertion.</summary>
+    public TextDiffLineTerminator FinalLineTerminator { get; }
+
+    /// <summary>Whether the sequence contains no logical lines.</summary>
+    public bool IsEmpty => Lines.IsEmpty;
+
+    /// <summary>Creates an immutable logical-line sequence.</summary>
+    public TextDiffSequence(
+        IEnumerable<string> lines,
+        string? label = null,
+        TextDiffLineTerminator finalLineTerminator = TextDiffLineTerminator.Unknown)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        if (!Enum.IsDefined(finalLineTerminator))
+            throw new ArgumentOutOfRangeException(nameof(finalLineTerminator));
+        if (label is not null)
+            TextDiffValidation.ValidateLogicalLine(label, nameof(label), "Sequence label");
+
+        Lines = [.. lines];
+        for (var i = 0; i < Lines.Length; i++)
+        {
+            var line = Lines[i];
+            if (line is null)
+                throw new ArgumentException($"Line at index {i} is null.", nameof(lines));
+            TextDiffValidation.ValidateLogicalLine(line, nameof(lines), $"Line at index {i}");
+        }
+
+        if (Lines.IsEmpty && finalLineTerminator != TextDiffLineTerminator.Unknown)
+        {
+            throw new ArgumentException(
+                "An empty sequence cannot assert a final-line terminator.",
+                nameof(finalLineTerminator));
+        }
+
+        Label = label;
+        FinalLineTerminator = finalLineTerminator;
+    }
+}
+
+/// <summary>One caller-issued mapping between Before and After line ranges.</summary>
+public sealed class TextDiffChange
+{
+    /// <summary>The mapped Before range.</summary>
+    public TextDiffRange Before { get; }
+
+    /// <summary>The mapped After range.</summary>
+    public TextDiffRange After { get; }
+
+    /// <summary>The caller-issued intraline mappings.</summary>
+    public ImmutableArray<TextDiffInnerMapping> InnerMappings { get; }
+
+    /// <summary>The caller-issued annotations.</summary>
+    public ImmutableArray<TextDiffAnnotation> Annotations { get; }
+
+    /// <summary>The form derived from the mapped range counts.</summary>
+    public TextDiffChangeForm Form => Before.IsEmpty
+        ? TextDiffChangeForm.Addition
+        : After.IsEmpty
+            ? TextDiffChangeForm.Removal
+            : TextDiffChangeForm.Replacement;
+
+    /// <summary>Creates one mapped change.</summary>
+    public TextDiffChange(
+        TextDiffRange before,
+        TextDiffRange after,
+        IEnumerable<TextDiffInnerMapping>? innerMappings = null,
+        IEnumerable<TextDiffAnnotation>? annotations = null)
+    {
+        if (before.IsEmpty && after.IsEmpty)
+            throw new ArgumentException("A change cannot contain two empty ranges.");
+
+        Before = before;
+        After = after;
+        InnerMappings = innerMappings is null ? [] : [.. innerMappings];
+        Annotations = annotations is null ? [] : [.. annotations];
+
+        for (var i = 0; i < InnerMappings.Length; i++)
+        {
+            if (InnerMappings[i] is null)
+                throw new ArgumentException($"Inner mapping at index {i} is null.", nameof(innerMappings));
+        }
+
+        for (var i = 0; i < Annotations.Length; i++)
+        {
+            if (Annotations[i] is null)
+                throw new ArgumentException($"Annotation at index {i} is null.", nameof(annotations));
+        }
+    }
+}
+
+/// <summary>One context-selected record projected from a mapped text diff.</summary>
+public sealed class TextDiffDisplayLine
+{
+    /// <summary>The record kind.</summary>
+    public TextDiffDisplayLineKind Kind { get; }
+
+    /// <summary>The zero-based change address, when derived from a change.</summary>
+    public int? ChangeAddress { get; }
+
+    /// <summary>The mapped change form, when derived from a change.</summary>
+    public TextDiffChangeForm? ChangeForm { get; }
+
+    /// <summary>The side represented by this record.</summary>
+    public TextDiffSide Side { get; }
+
+    /// <summary>The zero-based Before line, when present.</summary>
+    public int? BeforeLine { get; }
+
+    /// <summary>The zero-based After line, when present.</summary>
+    public int? AfterLine { get; }
+
+    /// <summary>The exact Before range represented by an omission.</summary>
+    public TextDiffRange? BeforeRange { get; }
+
+    /// <summary>The exact After range represented by an omission.</summary>
+    public TextDiffRange? AfterRange { get; }
+
+    /// <summary>The Before text, when present.</summary>
+    public string? BeforeText { get; }
+
+    /// <summary>The After text, when present.</summary>
+    public string? AfterText { get; }
+
+    /// <summary>The annotation, for annotation records.</summary>
+    public TextDiffAnnotation? Annotation { get; }
+
+    internal TextDiffDisplayLine(
+        TextDiffDisplayLineKind kind,
+        TextDiffSide side,
+        int? changeAddress = null,
+        TextDiffChangeForm? changeForm = null,
+        int? beforeLine = null,
+        int? afterLine = null,
+        TextDiffRange? beforeRange = null,
+        TextDiffRange? afterRange = null,
+        string? beforeText = null,
+        string? afterText = null,
+        TextDiffAnnotation? annotation = null)
+    {
+        Kind = kind;
+        Side = side;
+        ChangeAddress = changeAddress;
+        ChangeForm = changeForm;
+        BeforeLine = beforeLine;
+        AfterLine = afterLine;
+        BeforeRange = beforeRange;
+        AfterRange = afterRange;
+        BeforeText = beforeText;
+        AfterText = afterText;
+        Annotation = annotation;
+    }
+}
+
+internal static class TextDiffValidation
+{
+    public static void ValidateSingleSide(TextDiffSide side, string paramName)
+    {
+        if (side is not TextDiffSide.Before and not TextDiffSide.After)
+            throw new ArgumentOutOfRangeException(paramName);
+    }
+
+    public static void ValidateLogicalLine(string value, string paramName, string description)
+    {
+        ValidateText(value, paramName);
+        if (value.AsSpan().IndexOfAny('\r', '\n') >= 0)
+            throw new ArgumentException($"{description} contains a carriage return or line feed.", paramName);
+    }
+
+    public static void ValidateText(string value, string paramName)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (char.IsHighSurrogate(value[i]))
+            {
+                if (i + 1 >= value.Length || !char.IsLowSurrogate(value[i + 1]))
+                    throw new ArgumentException("Text contains malformed UTF-16.", paramName);
+                i++;
+            }
+            else if (char.IsLowSurrogate(value[i]))
+            {
+                throw new ArgumentException("Text contains malformed UTF-16.", paramName);
+            }
+        }
+    }
+
+    public static bool IsUtf16Boundary(string value, int offset)
+        => offset >= 0
+            && offset <= value.Length
+            && (offset == 0
+                || offset == value.Length
+                || !char.IsHighSurrogate(value[offset - 1])
+                || !char.IsLowSurrogate(value[offset]));
+}

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -37,7 +37,7 @@ public class UnicodeFormatter : IMarkoutFormatter,
             {
                 case TextDiffDisplayLineKind.Context:
                     w.Write($"{line.BeforeLine!.Value + 1,4} {line.AfterLine!.Value + 1,4}   ");
-                    w.WriteLine(TextDiffEscaping.Human(line.BeforeText!));
+                    w.WriteLine(TextDiffFormatterHelpers.EscapeIntralineMarkerLiterals(line.BeforeText!));
                     break;
 
                 case TextDiffDisplayLineKind.Removal:

--- a/src/Markout/UnicodeFormatter.cs
+++ b/src/Markout/UnicodeFormatter.cs
@@ -8,7 +8,7 @@ namespace Markout;
 /// Uses ─│├└╭╮╰╯ for borders, █▆▄▂ for bars, and other Unicode decorations.
 /// </summary>
 public class UnicodeFormatter : IMarkoutFormatter,
-    IDocumentFormatter, IMetricsFormatter, IGlyphFormatter, IGraphFormatter
+    IDocumentFormatter, IMetricsFormatter, IGlyphFormatter, IGraphFormatter, ITextDiffFormatter
 {
     // ── IGraphFormatter ──
 
@@ -23,6 +23,64 @@ public class UnicodeFormatter : IMarkoutFormatter,
 
         ((ITreeFormatter)this).FormatTree(w, GraphLowering.ToTree(graph).AsSpan(), options);
     }
+
+    // ── ITextDiffFormatter ──
+
+    void ITextDiffFormatter.FormatTextDiff(
+        TextWriter w,
+        MappedTextDiff diff,
+        MarkoutWriterOptions options)
+    {
+        foreach (var line in MappedTextDiffLowering.ToDisplayLines(diff, options.TextDiffContextLines))
+        {
+            switch (line.Kind)
+            {
+                case TextDiffDisplayLineKind.Context:
+                    w.Write($"{line.BeforeLine!.Value + 1,4} {line.AfterLine!.Value + 1,4}   ");
+                    w.WriteLine(TextDiffEscaping.Human(line.BeforeText!));
+                    break;
+
+                case TextDiffDisplayLineKind.Removal:
+                    w.Write($"{line.BeforeLine!.Value + 1,4}      - ");
+                    w.WriteLine(TextDiffFormatterHelpers.FormatMarkedLine(diff, line, "[-", "-]"));
+                    break;
+
+                case TextDiffDisplayLineKind.Addition:
+                    w.Write($"     {line.AfterLine!.Value + 1,4} + ");
+                    w.WriteLine(TextDiffFormatterHelpers.FormatMarkedLine(diff, line, "{+", "+}"));
+                    break;
+
+                case TextDiffDisplayLineKind.Omission:
+                    w.Write("         … ");
+                    w.Write(line.BeforeRange!.Value.Count);
+                    w.Write(" unchanged lines (Before ");
+                    WriteRange(w, line.BeforeRange.Value);
+                    w.Write(", After ");
+                    WriteRange(w, line.AfterRange!.Value);
+                    w.WriteLine(")");
+                    break;
+
+                case TextDiffDisplayLineKind.Annotation:
+                    w.Write("         ↳ ");
+                    w.Write(line.Annotation!.Severity);
+                    w.Write(" — ");
+                    w.Write(TextDiffFormatterHelpers.AnnotationTarget(
+                        line.Annotation,
+                        line.ChangeAddress));
+                    w.Write(": ");
+                    w.WriteLine(TextDiffEscaping.Human(line.Annotation.Text));
+                    break;
+            }
+        }
+    }
+
+    private static void WriteRange(TextWriter w, TextDiffRange range)
+    {
+        w.Write(range.Start + 1);
+        w.Write('–');
+        w.Write(range.End);
+    }
+
     private const int ColumnGap = 2;
     private int _consoleWidth = 80;
 

--- a/tests/Markout.Tests/GeneratedMappedTextDiffTests.cs
+++ b/tests/Markout.Tests/GeneratedMappedTextDiffTests.cs
@@ -1,0 +1,62 @@
+using Markout;
+
+namespace Markout.Tests;
+
+[MarkoutSerializable]
+public class MappedTextDiffContainer
+{
+    public string? Member { get; set; }
+
+    [MarkoutSection(Name = "Source Diff", EmptyText = "No changes.")]
+    public MappedTextDiff? SourceDiff { get; set; }
+}
+
+[MarkoutContext(typeof(MappedTextDiffContainer))]
+public partial class MappedTextDiffContext : MarkoutSerializerContext;
+
+public class GeneratedMappedTextDiffTests
+{
+    [Fact]
+    public void MappedTextDiffPropertyRendersAsASection()
+    {
+        var model = new MappedTextDiffContainer
+        {
+            Member = "M",
+            SourceDiff = MappedTextDiffTests.Sample()
+        };
+
+        var output = MarkoutSerializer.Serialize(model, MappedTextDiffContext.Default);
+
+        Assert.Contains("## Source Diff", output, StringComparison.Ordinal);
+        Assert.Contains("```diff", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("No changes.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmptyMappedTextDiffUsesSectionFallback()
+    {
+        var model = new MappedTextDiffContainer
+        {
+            SourceDiff = new MappedTextDiff(
+                new TextDiffSequence(["same"]),
+                new TextDiffSequence(["same"]),
+                [])
+        };
+
+        var output = MarkoutSerializer.Serialize(model, MappedTextDiffContext.Default);
+
+        Assert.Contains("## Source Diff", output, StringComparison.Ordinal);
+        Assert.Contains("No changes.", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("```diff", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NullMappedTextDiffOmitsSection()
+    {
+        var output = MarkoutSerializer.Serialize(
+            new MappedTextDiffContainer { SourceDiff = null },
+            MappedTextDiffContext.Default);
+
+        Assert.DoesNotContain("Source Diff", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/Markout.Tests/MappedTextDiffTests.cs
+++ b/tests/Markout.Tests/MappedTextDiffTests.cs
@@ -165,8 +165,9 @@ public partial class MappedTextDiffTests
     [Fact]
     public void MarkdownPreservesTabsAndContainsTerminalControls()
     {
+        var supplementaryFormat = char.ConvertFromUtf32(0xE0001);
         var diff = new MappedTextDiff(
-            new TextDiffSequence(["\told\u001b[31m\u202e\u2028"]),
+            new TextDiffSequence(["\told\u001b[31m\u202e\u2028" + supplementaryFormat]),
             new TextDiffSequence(["\tnew\u200b\u2029"]),
             [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
         var writer = MarkoutWriter.Create(
@@ -176,13 +177,14 @@ public partial class MappedTextDiffTests
         writer.WriteTextDiff(diff);
         var output = Normalize(writer.ToString());
 
-        Assert.Contains("-\told\\u001B[31m\\u202E\\u2028", output);
+        Assert.Contains("-\told\\u001B[31m\\u202E\\u2028\\U000E0001", output);
         Assert.Contains("+\tnew\\u200B\\u2029", output);
         Assert.True(output.IndexOf('\u001b') < 0, $"Raw ESC at {output.IndexOf('\u001b')}");
         Assert.True(output.IndexOf('\u202e') < 0, $"Raw bidi control at {output.IndexOf('\u202e')}");
         Assert.True(output.IndexOf('\u200b') < 0, $"Raw zero-width control at {output.IndexOf('\u200b')}");
         Assert.True(output.IndexOf('\u2028') < 0, $"Raw line separator at {output.IndexOf('\u2028')}");
         Assert.True(output.IndexOf('\u2029') < 0, $"Raw paragraph separator at {output.IndexOf('\u2029')}");
+        Assert.DoesNotContain(supplementaryFormat, output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -231,21 +233,19 @@ public partial class MappedTextDiffTests
     [Fact]
     public void MarkdownTerminatesDiffBeforeTheFollowingBlock()
     {
-        var diff = new MappedTextDiff(
-            new TextDiffSequence(["old"]),
-            new TextDiffSequence(["new"]),
-            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
         using var output = new StringWriter();
         var writer = new MarkoutWriter(
             output,
             new MarkdownFormatter(),
             new MarkoutWriterOptions { NewLine = "\n" });
 
-        writer.WriteTextDiff(diff);
+        writer.WriteTextDiff(Sample());
         writer.WriteHeading(2, "Following");
         writer.Flush();
 
-        Assert.Contains("```\n\n## Following", Normalize(output.ToString()));
+        var normalized = Normalize(output.ToString());
+        Assert.Contains("Includes zero\n\n## Following", normalized);
+        Assert.DoesNotContain("\n\n\n", normalized);
     }
 
     [Fact]
@@ -323,6 +323,26 @@ public partial class MappedTextDiffTests
     }
 
     [Fact]
+    public void UnicodeEscapesLiteralIntralineMarkerTokens()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["literal [-not mapped-]"]),
+            new TextDiffSequence(["literal {+not mapped+}"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 });
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+
+        Assert.Contains(@"literal \[-not mapped-]", output);
+        Assert.Contains(@"literal \{+not mapped+}", output);
+        Assert.DoesNotContain(" - literal [-", output);
+        Assert.DoesNotContain(" + literal {+", output);
+    }
+
+    [Fact]
     public void TableDiffIgnoresGenericProjectionAndRowLimits()
     {
         var writer = MarkoutWriter.Create(
@@ -376,8 +396,12 @@ public partial class MappedTextDiffTests
     public void StructuredDiffPreservesInlineSyntaxAndContainsNonGraphicText(
         MarkoutTableMode mode)
     {
+        var supplementaryFormat = char.ConvertFromUtf32(0xE0001);
         var longSuffix = new string('x', 4096);
-        var before = "<code>x</code>\t| \u001b \u202e \u200b \u2028 \u2029 " + longSuffix;
+        var before = "<code>x</code>\t| \u001b \u202e \u200b \u2028 \u2029 "
+            + supplementaryFormat
+            + " "
+            + longSuffix;
         var diff = new MappedTextDiff(
             new TextDiffSequence([before], "Before <code>"),
             new TextDiffSequence(["after"], "After |"),
@@ -398,7 +422,9 @@ public partial class MappedTextDiffTests
             : output;
 
         Assert.Contains(
-            "<code>x</code>\\t| \\u001B \\u202E \\u200B \\u2028 \\u2029 " + longSuffix,
+            "<code>x</code>\\t| \\u001B \\u202E \\u200B \\u2028 \\u2029 "
+            + "\\U000E0001 "
+            + longSuffix,
             visibleOutput);
         Assert.Contains("Before <code>", output);
         Assert.Contains("After |", output);
@@ -407,6 +433,7 @@ public partial class MappedTextDiffTests
         Assert.True(output.IndexOf('\u200b') < 0, $"Raw zero-width control at {output.IndexOf('\u200b')}");
         Assert.True(output.IndexOf('\u2028') < 0, $"Raw line separator at {output.IndexOf('\u2028')}");
         Assert.True(output.IndexOf('\u2029') < 0, $"Raw paragraph separator at {output.IndexOf('\u2029')}");
+        Assert.DoesNotContain(supplementaryFormat, output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -497,6 +524,23 @@ public partial class MappedTextDiffTests
         Assert.Contains("\u001b[32m", output);
         Assert.Contains("\u001b[7m<\u001b[27m", output);
         Assert.Contains("Includes zero", output);
+    }
+
+    [Fact]
+    public void SpectreContainsSupplementaryFormatScalars()
+    {
+        var supplementaryFormat = char.ConvertFromUtf32(0xE0001);
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old" + supplementaryFormat]),
+            new TextDiffSequence(["new"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(NewSpectreFormatter());
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+
+        Assert.Contains("\\U000E0001", output);
+        Assert.DoesNotContain(supplementaryFormat, output, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Markout.Tests/MappedTextDiffTests.cs
+++ b/tests/Markout.Tests/MappedTextDiffTests.cs
@@ -326,9 +326,45 @@ public partial class MappedTextDiffTests
     public void UnicodeEscapesLiteralIntralineMarkerTokens()
     {
         var diff = new MappedTextDiff(
-            new TextDiffSequence(["literal [-not mapped-]"]),
-            new TextDiffSequence(["literal {+not mapped+}"]),
-            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+            new TextDiffSequence(
+                [
+                    "context [-before-open-] -] {+after-open+} +}",
+                    "old [-before-open-] -] {+after-open+} +}"
+                ]),
+            new TextDiffSequence(
+                [
+                    "context [-before-open-] -] {+after-open+} +}",
+                    "new [-before-open-] -] {+after-open+} +}"
+                ]),
+            [new TextDiffChange(new TextDiffRange(1, 1), new TextDiffRange(1, 1))]);
+        var writer = MarkoutWriter.Create(
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 1 });
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+
+        Assert.Contains(@"context \[-before-open\-] \-] \{+after-open\+} \+}", output);
+        Assert.Contains(@"old \[-before-open\-] \-] \{+after-open\+} \+}", output);
+        Assert.Contains(@"new \[-before-open\-] \-] \{+after-open\+} \+}", output);
+    }
+
+    [Fact]
+    public void UnicodeEscapesLiteralClosingTokensInsideIntralineMappings()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["value -] tail"]),
+            new TextDiffSequence(["value +} tail"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    [
+                        new TextDiffInnerMapping(
+                            new TextDiffSpan(0, 6, 2),
+                            new TextDiffSpan(0, 6, 2))
+                    ])
+            ]);
         var writer = MarkoutWriter.Create(
             new UnicodeFormatter(),
             new MarkoutWriterOptions { TextDiffContextLines = 0 });
@@ -336,10 +372,8 @@ public partial class MappedTextDiffTests
         writer.WriteTextDiff(diff);
         var output = writer.ToString();
 
-        Assert.Contains(@"literal \[-not mapped-]", output);
-        Assert.Contains(@"literal \{+not mapped+}", output);
-        Assert.DoesNotContain(" - literal [-", output);
-        Assert.DoesNotContain(" + literal {+", output);
+        Assert.Contains(@"value [-\-]-] tail", output);
+        Assert.Contains(@"value {+\+}+} tail", output);
     }
 
     [Fact]

--- a/tests/Markout.Tests/MappedTextDiffTests.cs
+++ b/tests/Markout.Tests/MappedTextDiffTests.cs
@@ -436,6 +436,56 @@ public partial class MappedTextDiffTests
     }
 
     [Fact]
+    public void RichFormattersRenderEmptyInnerSpanAtExactOffset()
+    {
+        var startAnchored = IntralineInsertion(beforeOffset: 0);
+        var endAnchored = IntralineInsertion(beforeOffset: 4);
+        var options = new MarkoutWriterOptions { TextDiffContextLines = 0 };
+        var startUnicode = MarkoutWriter.Create(new UnicodeFormatter(), options);
+        var endUnicode = MarkoutWriter.Create(new UnicodeFormatter(), options);
+        var startSpectre = MarkoutWriter.Create(NewSpectreFormatter(), options);
+        var endSpectre = MarkoutWriter.Create(NewSpectreFormatter(), options);
+
+        startUnicode.WriteTextDiff(startAnchored);
+        endUnicode.WriteTextDiff(endAnchored);
+        startSpectre.WriteTextDiff(startAnchored);
+        endSpectre.WriteTextDiff(endAnchored);
+
+        Assert.Contains("[--]aaaa", startUnicode.ToString());
+        Assert.Contains("aaaa[--]", endUnicode.ToString());
+        Assert.NotEqual(startUnicode.ToString(), endUnicode.ToString());
+        Assert.Contains("\u001b[7m\u001b[4m│\u001b[24m\u001b[27m", startSpectre.ToString());
+        Assert.NotEqual(startSpectre.ToString(), endSpectre.ToString());
+    }
+
+    [Fact]
+    public void RichFormattersRenderEmptyAfterSpan()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["Xaaaa"]),
+            new TextDiffSequence(["aaaa"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    [
+                        new TextDiffInnerMapping(
+                            new TextDiffSpan(0, 0, 1),
+                            new TextDiffSpan(0, 4, 0))
+                    ])
+            ]);
+        var options = new MarkoutWriterOptions { TextDiffContextLines = 0 };
+        var unicode = MarkoutWriter.Create(new UnicodeFormatter(), options);
+        var spectre = MarkoutWriter.Create(NewSpectreFormatter(), options);
+
+        unicode.WriteTextDiff(diff);
+        spectre.WriteTextDiff(diff);
+
+        Assert.Contains("aaaa{++}", unicode.ToString());
+        Assert.Contains("\u001b[7m\u001b[4m│\u001b[24m\u001b[27m", spectre.ToString());
+    }
+
+    [Fact]
     public void PlainTextCompletionPreservesFinalUnifiedLineWhitespace()
     {
         var diff = new MappedTextDiff(
@@ -777,6 +827,20 @@ public partial class MappedTextDiffTests
                         new TextDiffSpan(0, 10, 2),
                         "Includes zero",
                         CalloutSeverity.Warning)
+                ])
+        ]);
+
+    private static MappedTextDiff IntralineInsertion(int beforeOffset) => new(
+        new TextDiffSequence(["aaaa"]),
+        new TextDiffSequence(["aaaaX"]),
+        [
+            new TextDiffChange(
+                new TextDiffRange(0, 1),
+                new TextDiffRange(0, 1),
+                [
+                    new TextDiffInnerMapping(
+                        new TextDiffSpan(0, beforeOffset, 0),
+                        new TextDiffSpan(0, 4, 1))
                 ])
         ]);
 

--- a/tests/Markout.Tests/MappedTextDiffTests.cs
+++ b/tests/Markout.Tests/MappedTextDiffTests.cs
@@ -1,0 +1,571 @@
+using System.Text.RegularExpressions;
+using Markout;
+using Markout.Ansi.Spectre;
+using Markout.Formatting;
+using Spectre.Console;
+
+namespace Markout.Tests;
+
+public partial class MappedTextDiffTests
+{
+    [Fact]
+    public void ConstructorSnapshotsSequencesAndChanges()
+    {
+        var beforeLines = new[] { "old" };
+        var afterLines = new[] { "new" };
+        var changes = new[]
+        {
+            new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))
+        };
+
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(beforeLines),
+            new TextDiffSequence(afterLines),
+            changes);
+        beforeLines[0] = "mutated";
+        afterLines[0] = "mutated";
+        changes[0] = new TextDiffChange(new TextDiffRange(0, 0), new TextDiffRange(0, 1));
+
+        Assert.Equal("old", diff.Before.Lines[0]);
+        Assert.Equal("new", diff.After.Lines[0]);
+        Assert.Equal(TextDiffChangeForm.Replacement, diff.Changes[0].Form);
+    }
+
+    [Fact]
+    public void ConstructorRejectsUnequalUnchangedGaps()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new MappedTextDiff(
+            new TextDiffSequence(["old", "tail"]),
+            new TextDiffSequence(["new", "tail", "extra"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]));
+
+        Assert.Contains("trailing unchanged gap", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ConstructorAllowsAdditionThenRemovalAtOneBoundary()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old", "tail"]),
+            new TextDiffSequence(["new", "tail"]),
+            [
+                new TextDiffChange(new TextDiffRange(0, 0), new TextDiffRange(0, 1)),
+                new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(1, 0))
+            ]);
+
+        Assert.Equal(2, diff.Changes.Length);
+    }
+
+    [Fact]
+    public void ConstructorRejectsAnInnerSpanThatSplitsASurrogatePair()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new MappedTextDiff(
+            new TextDiffSequence(["a😀b"]),
+            new TextDiffSequence(["a😁b"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    [new TextDiffInnerMapping(
+                        new TextDiffSpan(0, 1, 1),
+                        new TextDiffSpan(0, 1, 2))])
+            ]));
+
+        Assert.Contains("surrogate pair", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ConstructorRejectsAnUnterminatedFinalLineSharedWithANonFinalLine()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new MappedTextDiff(
+            new TextDiffSequence(["a"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            new TextDiffSequence(["a", "b"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            [new TextDiffChange(new TextDiffRange(1, 0), new TextDiffRange(1, 1))]));
+
+        Assert.Contains("unterminated final line", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ConstructorAcceptsGnuShapeForAppendingAfterAnUnterminatedLine()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["a"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            new TextDiffSequence(["a", "b"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 2))]);
+
+        Assert.Equal(TextDiffChangeForm.Replacement, diff.Changes[0].Form);
+    }
+
+    [Fact]
+    public void ConstructorRejectsMalformedUtf16()
+    {
+        Assert.Throws<ArgumentException>(() => new TextDiffSequence(["\uD800"]));
+    }
+
+    [Theory]
+    [InlineData("line\rbreak", null)]
+    [InlineData("line\nbreak", null)]
+    [InlineData("line", "label\rbreak")]
+    [InlineData("line", "label\nbreak")]
+    public void SequenceRejectsEmbeddedLineTerminators(string line, string? label)
+    {
+        Assert.Throws<ArgumentException>(() => new TextDiffSequence([line], label));
+    }
+
+    [Fact]
+    public void ConstructorAllowsEmptySequencesWithoutTerminatorAssertions()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence([]),
+            new TextDiffSequence([]),
+            []);
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { NewLine = "\n" });
+
+        Assert.True(diff.IsEmpty);
+        Assert.True(writer.WriteTextDiff(diff));
+        Assert.Empty(writer.ToString());
+    }
+
+    [Fact]
+    public void ContextSelectionReportsExactOmittedRanges()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["0", "1", "2", "old", "4", "5", "6"]),
+            new TextDiffSequence(["0", "1", "2", "new", "4", "5", "6"]),
+            [new TextDiffChange(new TextDiffRange(3, 1), new TextDiffRange(3, 1))]);
+
+        var records = MappedTextDiffLowering.ToDisplayLines(diff, contextLines: 1);
+        var omissions = records.Where(r => r.Kind == TextDiffDisplayLineKind.Omission).ToArray();
+
+        Assert.Equal(2, omissions.Length);
+        Assert.Equal(new TextDiffRange(0, 2), omissions[0].BeforeRange);
+        Assert.Equal(new TextDiffRange(0, 2), omissions[0].AfterRange);
+        Assert.Equal(new TextDiffRange(5, 2), omissions[1].BeforeRange);
+        Assert.Equal(new TextDiffRange(5, 2), omissions[1].AfterRange);
+    }
+
+    [Fact]
+    public void MarkdownRendersGnuCompatibleReplacementAndAnnotation()
+    {
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        Assert.True(writer.WriteTextDiff(Sample()));
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("```diff\n--- Before\n+++ After\n@@ -1,2 +1,2 @@", output);
+        Assert.Contains("-if (value < 0)\n-return 0;", output);
+        Assert.Contains("+if (value <= 0)\n+return 1;", output);
+        Assert.Contains("> **WARNING — After line 1, columns 11-12:** Includes zero", output);
+    }
+
+    [Fact]
+    public void MarkdownPreservesTabsAndContainsTerminalControls()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["\told\u001b[31m\u202e\u2028"]),
+            new TextDiffSequence(["\tnew\u200b\u2029"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("-\told\\u001B[31m\\u202E\\u2028", output);
+        Assert.Contains("+\tnew\\u200B\\u2029", output);
+        Assert.True(output.IndexOf('\u001b') < 0, $"Raw ESC at {output.IndexOf('\u001b')}");
+        Assert.True(output.IndexOf('\u202e') < 0, $"Raw bidi control at {output.IndexOf('\u202e')}");
+        Assert.True(output.IndexOf('\u200b') < 0, $"Raw zero-width control at {output.IndexOf('\u200b')}");
+        Assert.True(output.IndexOf('\u2028') < 0, $"Raw line separator at {output.IndexOf('\u2028')}");
+        Assert.True(output.IndexOf('\u2029') < 0, $"Raw paragraph separator at {output.IndexOf('\u2029')}");
+    }
+
+    [Fact]
+    public void MarkdownContainsAnnotationLineTerminatorsAndInlineSyntax()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old"]),
+            new TextDiffSequence(["new"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    annotations:
+                    [
+                        TextDiffAnnotation.ForChange(
+                            "line\r\n**bold** ~~strike~~ [link] <script> \u001b")
+                    ])
+            ]);
+        var writer = MarkoutWriter.Create(new MarkdownFormatter());
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+
+        Assert.Contains(
+            "line\\\\r\\\\n\\*\\*bold\\*\\* \\~\\~strike\\~\\~ "
+            + "\\[link\\] &lt;script&gt; \\\\u001B",
+            output);
+        Assert.True(output.IndexOf('\u001b') < 0, $"Raw ESC at {output.IndexOf('\u001b')}");
+    }
+
+    [Fact]
+    public void MarkdownChoosesAFenceLongerThanCallerContent()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["```old"]),
+            new TextDiffSequence(["```new"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(new MarkdownFormatter());
+
+        writer.WriteTextDiff(diff);
+
+        Assert.StartsWith("````diff", writer.ToString(), StringComparison.Ordinal);
+        Assert.EndsWith("````", writer.ToString().TrimEnd(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownTerminatesDiffBeforeTheFollowingBlock()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old"]),
+            new TextDiffSequence(["new"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        using var output = new StringWriter();
+        var writer = new MarkoutWriter(
+            output,
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+        writer.WriteHeading(2, "Following");
+        writer.Flush();
+
+        Assert.Contains("```\n\n## Following", Normalize(output.ToString()));
+    }
+
+    [Fact]
+    public void MarkdownEmitsFinalTerminatorMarkersAtTheOwningLines()
+    {
+        var replacement = new MappedTextDiff(
+            new TextDiffSequence(["old"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            new TextDiffSequence(["new"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var sharedContext = new MappedTextDiff(
+            new TextDiffSequence(["old", "same"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            new TextDiffSequence(["new", "same"], finalLineTerminator: TextDiffLineTerminator.Absent),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+
+        var replacementOutput = RenderMarkdown(replacement, contextLines: 0);
+        var contextOutput = RenderMarkdown(sharedContext, contextLines: null);
+
+        Assert.Equal(2, Regex.Matches(replacementOutput, @"\\ No newline at end of file").Count);
+        Assert.Single(Regex.Matches(contextOutput, @"\\ No newline at end of file").Cast<Match>());
+        Assert.Contains(" same\n\\ No newline at end of file", contextOutput);
+    }
+
+    [Fact]
+    public void MarkdownUsesCanonicalPureAdditionAndRemovalRanges()
+    {
+        var addition = new MappedTextDiff(
+            new TextDiffSequence(["same"]),
+            new TextDiffSequence(["same", "added"]),
+            [new TextDiffChange(new TextDiffRange(1, 0), new TextDiffRange(1, 1))]);
+        var removal = new MappedTextDiff(
+            new TextDiffSequence(["same", "removed"]),
+            new TextDiffSequence(["same"]),
+            [new TextDiffChange(new TextDiffRange(1, 1), new TextDiffRange(1, 0))]);
+
+        Assert.Contains("@@ -1,0 +2 @@", RenderMarkdown(addition, contextLines: 0));
+        Assert.Contains("@@ -2 +1,0 @@", RenderMarkdown(removal, contextLines: 0));
+    }
+
+    [Fact]
+    public void HumanAnnotationsIdentifyChangesAndEmptySpanInsertionPoints()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old-1", "same", "old-2"]),
+            new TextDiffSequence(["new-1", "same", "new-2"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    annotations: [TextDiffAnnotation.ForChange("first")]),
+                new TextDiffChange(
+                    new TextDiffRange(2, 1),
+                    new TextDiffRange(2, 1),
+                    annotations:
+                    [
+                        TextDiffAnnotation.ForSpan(
+                            TextDiffSide.After,
+                            new TextDiffSpan(2, 3, 0),
+                            "caret")
+                    ])
+            ]);
+        var plain = MarkoutWriter.Create(
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+        var unicode = MarkoutWriter.Create(
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        plain.WriteTextDiff(diff);
+        unicode.WriteTextDiff(diff);
+
+        Assert.Contains("Annotation (change 1): first", plain.ToString());
+        Assert.Contains(
+            "After line 3, insertion point at column 4",
+            unicode.ToString());
+    }
+
+    [Fact]
+    public void TableDiffIgnoresGenericProjectionAndRowLimits()
+    {
+        var writer = MarkoutWriter.Create(
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                MaxItems = 1,
+                RowWindow = MarkoutRowWindow.Head(1),
+                Projection = new MarkoutProjection { IncludeColumns = ["after_text"] },
+                TableMode = MarkoutTableMode.Tsv,
+                NewLine = "\n"
+            });
+
+        writer.WriteTextDiff(Sample());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("record_kind\tchange_address\tchange_form", output);
+        Assert.Contains("sequence", output);
+        Assert.Contains("removal", output);
+        Assert.Contains("addition", output);
+        Assert.Contains("inner_mapping", output);
+        Assert.DoesNotContain("more", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void JsonlDiffCarriesChangeAndSequenceProvenance()
+    {
+        var writer = MarkoutWriter.Create(
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = MarkoutTableMode.Jsonl,
+                OmitEmptyJsonFields = true,
+                NewLine = "\n"
+            });
+
+        writer.WriteTextDiff(Sample());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("\"record_kind\":\"sequence\"", output);
+        Assert.Contains("\"record_kind\":\"removal\"", output);
+        Assert.Contains("\"change_address\":\"0\"", output);
+        Assert.Contains("\"before_text\":\"if (value < 0)\"", output);
+        Assert.Contains("\"record_kind\":\"inner_mapping\"", output);
+    }
+
+    [Theory]
+    [InlineData(MarkoutTableMode.Pretty)]
+    [InlineData(MarkoutTableMode.Tsv)]
+    [InlineData(MarkoutTableMode.Jsonl)]
+    public void StructuredDiffPreservesInlineSyntaxAndContainsNonGraphicText(
+        MarkoutTableMode mode)
+    {
+        var longSuffix = new string('x', 4096);
+        var before = "<code>x</code>\t| \u001b \u202e \u200b \u2028 \u2029 " + longSuffix;
+        var diff = new MappedTextDiff(
+            new TextDiffSequence([before], "Before <code>"),
+            new TextDiffSequence(["after"], "After |"),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = mode,
+                OmitEmptyJsonFields = true,
+                NewLine = "\n"
+            });
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+        var visibleOutput = mode == MarkoutTableMode.Jsonl
+            ? output.Replace("\\\\", "\\")
+            : output;
+
+        Assert.Contains(
+            "<code>x</code>\\t| \\u001B \\u202E \\u200B \\u2028 \\u2029 " + longSuffix,
+            visibleOutput);
+        Assert.Contains("Before <code>", output);
+        Assert.Contains("After |", output);
+        Assert.True(output.IndexOf('\u001b') < 0, $"Raw ESC at {output.IndexOf('\u001b')}");
+        Assert.True(output.IndexOf('\u202e') < 0, $"Raw bidi control at {output.IndexOf('\u202e')}");
+        Assert.True(output.IndexOf('\u200b') < 0, $"Raw zero-width control at {output.IndexOf('\u200b')}");
+        Assert.True(output.IndexOf('\u2028') < 0, $"Raw line separator at {output.IndexOf('\u2028')}");
+        Assert.True(output.IndexOf('\u2029') < 0, $"Raw paragraph separator at {output.IndexOf('\u2029')}");
+    }
+
+    [Fact]
+    public void JsonlTypedValuesKeepTextualDiffFieldsAsStrings()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["1"], "true"),
+            new TextDiffSequence(["false"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = MarkoutTableMode.Jsonl,
+                JsonTypedValues = true,
+                OmitEmptyJsonFields = true,
+                NewLine = "\n"
+            });
+
+        writer.WriteTextDiff(diff);
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("\"label\":\"true\"", output);
+        Assert.Contains("\"before_text\":\"1\"", output);
+        Assert.Contains("\"after_text\":\"false\"", output);
+        Assert.Contains("\"before_line\":0", output);
+        Assert.DoesNotContain("\"before_text\":1", output);
+    }
+
+    [Fact]
+    public void StructuredOmissionCarriesExactRangesAndHiddenCount()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["0", "1", "old", "3", "4"]),
+            new TextDiffSequence(["0", "1", "new", "3", "4"]),
+            [new TextDiffChange(new TextDiffRange(2, 1), new TextDiffRange(2, 1))]);
+        var writer = MarkoutWriter.Create(
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = MarkoutTableMode.Jsonl,
+                OmitEmptyJsonFields = true,
+                TextDiffContextLines = 0,
+                NewLine = "\n"
+            });
+
+        writer.WriteTextDiff(diff);
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains(
+            "\"record_kind\":\"omission\",\"side\":\"both\",\"before_start\":\"0\","
+            + "\"before_count\":\"2\",\"after_start\":\"0\",\"after_count\":\"2\","
+            + "\"hidden_count\":\"2\"",
+            output);
+        Assert.Contains(
+            "\"record_kind\":\"omission\",\"side\":\"both\",\"before_start\":\"3\","
+            + "\"before_count\":\"2\",\"after_start\":\"3\",\"after_count\":\"2\","
+            + "\"hidden_count\":\"2\"",
+            output);
+    }
+
+    [Fact]
+    public void UnicodeDiffShowsLineNumbersInnerSpansAndAnnotations()
+    {
+        var writer = MarkoutWriter.Create(
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        writer.WriteTextDiff(Sample());
+        var output = Normalize(writer.ToString());
+
+        Assert.Contains("1      - if (value [-<-] 0)", output);
+        Assert.Contains("1 + if (value {+<=+} 0)", output);
+        Assert.Contains("↳ Warning — After line 1, columns 11-12: Includes zero", output);
+    }
+
+    [Fact]
+    public void SpectreDiffUsesAnsiForSidesAndInnerSpans()
+    {
+        var writer = MarkoutWriter.Create(
+            NewSpectreFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        writer.WriteTextDiff(Sample());
+        var output = writer.ToString();
+
+        Assert.Contains("\u001b[31m", output);
+        Assert.Contains("\u001b[32m", output);
+        Assert.Contains("\u001b[7m<\u001b[27m", output);
+        Assert.Contains("Includes zero", output);
+    }
+
+    [Fact]
+    public void WriteTextDiffReturnsFalseForUnsupportedFormatter()
+    {
+        var writer = MarkoutWriter.Create(new TextDiffLessFormatter());
+
+        Assert.False(writer.WriteTextDiff(Sample()));
+    }
+
+    [Fact]
+    public void MarkoutShapeAllIncludesMappedTextDiffs()
+    {
+        Assert.True(MarkoutShape.All.HasFlag(MarkoutShape.TextDiffs));
+    }
+
+    internal static MappedTextDiff Sample() => new(
+        new TextDiffSequence(
+            ["if (value < 0)", "return 0;"],
+            "Before",
+            TextDiffLineTerminator.Present),
+        new TextDiffSequence(
+            ["if (value <= 0)", "return 1;"],
+            "After",
+            TextDiffLineTerminator.Present),
+        [
+            new TextDiffChange(
+                new TextDiffRange(0, 2),
+                new TextDiffRange(0, 2),
+                [
+                    new TextDiffInnerMapping(
+                        new TextDiffSpan(0, 10, 1),
+                        new TextDiffSpan(0, 10, 2)),
+                    new TextDiffInnerMapping(
+                        new TextDiffSpan(1, 7, 1),
+                        new TextDiffSpan(1, 7, 1))
+                ],
+                [
+                    TextDiffAnnotation.ForSpan(
+                        TextDiffSide.After,
+                        new TextDiffSpan(0, 10, 2),
+                        "Includes zero",
+                        CalloutSeverity.Warning)
+                ])
+        ]);
+
+    private static SpectreFormatter NewSpectreFormatter()
+        => new(AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(TextWriter.Null)
+        }));
+
+    private static string Normalize(string value)
+        => value.Replace("\r\n", "\n").TrimEnd();
+
+    private static string RenderMarkdown(MappedTextDiff diff, int? contextLines)
+    {
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions
+            {
+                TextDiffContextLines = contextLines,
+                NewLine = "\n"
+            });
+        writer.WriteTextDiff(diff);
+        return Normalize(writer.ToString());
+    }
+
+    private sealed class TextDiffLessFormatter : IMarkoutFormatter;
+}

--- a/tests/Markout.Tests/MappedTextDiffTests.cs
+++ b/tests/Markout.Tests/MappedTextDiffTests.cs
@@ -377,6 +377,165 @@ public partial class MappedTextDiffTests
     }
 
     [Fact]
+    public void UnicodeMarkerEscapingDistinguishesCallerBackslashes()
+    {
+        var mappedBackslash = new MappedTextDiff(
+            new TextDiffSequence([@"\\"]),
+            new TextDiffSequence([""]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    [
+                        new TextDiffInnerMapping(
+                            new TextDiffSpan(0, 1, 1),
+                            new TextDiffSpan(0, 0, 0))
+                    ])
+            ]);
+        var literalMarkers = new MappedTextDiff(
+            new TextDiffSequence(["[--]"]),
+            new TextDiffSequence([""]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var options = new MarkoutWriterOptions { TextDiffContextLines = 0 };
+        var mappedWriter = MarkoutWriter.Create(new UnicodeFormatter(), options);
+        var literalWriter = MarkoutWriter.Create(new UnicodeFormatter(), options);
+
+        mappedWriter.WriteTextDiff(mappedBackslash);
+        literalWriter.WriteTextDiff(literalMarkers);
+
+        Assert.NotEqual(mappedWriter.ToString(), literalWriter.ToString());
+        Assert.Contains(@"\\[-\\-]", mappedWriter.ToString());
+        Assert.Contains(@"\[-\-]", literalWriter.ToString());
+    }
+
+    [Fact]
+    public void UnicodeEscapesMarkerTokensFormedAtMappedSpanBoundaries()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["]["]),
+            new TextDiffSequence(["}{"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    [
+                        new TextDiffInnerMapping(
+                            new TextDiffSpan(0, 0, 2),
+                            new TextDiffSpan(0, 0, 2))
+                    ])
+            ]);
+        var writer = MarkoutWriter.Create(
+            new UnicodeFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 });
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+
+        Assert.Contains(@"[-\]\[-]", output);
+        Assert.Contains(@"{+\}\{+}", output);
+    }
+
+    [Fact]
+    public void PlainTextCompletionPreservesFinalUnifiedLineWhitespace()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["alpha", "beta", "gamma", ""]),
+            new TextDiffSequence(["alpha", "BETA", "gamma", ""]),
+            [new TextDiffChange(new TextDiffRange(1, 1), new TextDiffRange(1, 1))]);
+        var writer = MarkoutWriter.Create(
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 3, NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+        var preview = writer.ToString();
+        var completed = writer.Complete();
+
+        Assert.Equal(preview, completed);
+        Assert.EndsWith(" \n", completed, StringComparison.Ordinal);
+        Assert.Contains("@@ -1,4 +1,4 @@", completed);
+    }
+
+    [Fact]
+    public void PlainTextCompletionTrimsAFollowingBlankWithoutTruncatingTheDiff()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["alpha", "beta", "gamma", ""]),
+            new TextDiffSequence(["alpha", "BETA", "gamma", ""]),
+            [new TextDiffChange(new TextDiffRange(1, 1), new TextDiffRange(1, 1))]);
+        var writer = MarkoutWriter.Create(
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 3, NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+        var diffOnly = writer.ToString();
+        writer.WriteBlankLine();
+
+        Assert.Equal(diffOnly, writer.ToString());
+        Assert.Equal(diffOnly, writer.Complete());
+    }
+
+    [Fact]
+    public void PlainTextCompletionPreservesTrailingCallerSpaces()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old"]),
+            new TextDiffSequence(["new   "]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+
+        Assert.EndsWith("+new   \n", writer.Complete(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlainTextCompletionStillTrimsAnOrdinaryFinalLine()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old"]),
+            new TextDiffSequence(["new"]),
+            [new TextDiffChange(new TextDiffRange(0, 1), new TextDiffRange(0, 1))]);
+        var writer = MarkoutWriter.Create(
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0, NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+        var output = writer.Complete();
+
+        Assert.EndsWith("+new", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SectionOrderingPreservesWhitespaceWhenPlainTextDiffMovesLast()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["alpha", "beta", "gamma", ""]),
+            new TextDiffSequence(["alpha", "BETA", "gamma", ""]),
+            [new TextDiffChange(new TextDiffRange(1, 1), new TextDiffRange(1, 1))]);
+        var writer = MarkoutWriter.Create(
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions
+            {
+                SectionOrder = ["Tail", "Diff"],
+                TextDiffContextLines = 3,
+                NewLine = "\n"
+            });
+
+        writer.WriteSectionStart(2, "Diff");
+        writer.WriteTextDiff(diff);
+        writer.WriteSectionStart(2, "Tail");
+        writer.WriteParagraph("tail");
+        var output = writer.Complete();
+
+        Assert.True(
+            output.IndexOf("tail", StringComparison.Ordinal) <
+            output.IndexOf("---", StringComparison.Ordinal));
+        Assert.EndsWith(" \n", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TableDiffIgnoresGenericProjectionAndRowLimits()
     {
         var writer = MarkoutWriter.Create(


### PR DESCRIPTION
## Summary

- Adds `MappedTextDiff`, an immutable correspondence shape over complete Before and After logical-line sequences, exact mapped line ranges, optional UTF-16 intraline mappings, annotations, and final-line-terminator assertions.
- Keeps comparison semantics producer-owned: Markout validates, selects unchanged context, records exact omissions, dispatches formatters, and renders; it never computes or repairs a diff.
- Adds GNU-compatible Markdown/plain output, structured pretty/TSV/JSONL provenance records, rich Unicode and Spectre terminal output, exact-type source-generator support, public lowering records, documentation, consumer grounding, and demos.
- Contains untrusted caller text at construction and formatter boundaries, including malformed UTF-16, Markdown syntax, terminal controls, BMP and supplementary format scalars, bidi/zero-width controls, Unicode line separators, dynamic fence runs, and literal rich-marker tokens.

## Supported formats

| Formatter or mode | Mapped-diff presentation |
| --- | --- |
| Markdown | Dynamically fenced GNU-compatible unified diff with Markdown callouts |
| Plain text | GNU-compatible unified diff with plain annotations |
| Pretty table | Aligned structured provenance records |
| TSV | Tab-separated structured provenance records |
| JSONL | Object-per-line structured provenance records |
| Unicode | Numbered rich diff with intraline markers and annotations |
| Spectre ANSI | Colored numbered diff with intraline emphasis |

**Stack:** slice 2 of 2 for #218. Parent/design PR: #219. This PR intentionally targets `docs/218-mapped-text-diff`; merge the design slice first. Remaining cross-repository work is the package release followed by the package-based `dotnet-inspect` adoption PR.

**Replacement:** supersedes #220 after its round-1 review. The accepted findings and their regression coverage are carried forward: literal rich-marker containment, Unicode-scalar containment, annotated-Markdown spacing, and inclusion of every new demo in the existing CI demo-lint gate. This successor avoids a workflow-file change by using CI-compatible demo names.

## Demo

`Markout.Demo` emits lintable Markdown documents while each payload comes from the public shape and selected formatter API.

```bash
dotnet run --project src/Markout.Demo -c Release -- textdiff
```

```diff
--- Before
+++ After
@@ -1,2 +1,2 @@
-if (value < 0)
-    return 0;
+if (value <= 0)
+    return 1;
```

> **WARNING — After line 1, columns 11-12:** Boundary now includes zero

The identical model lowers to machine-readable provenance:

```bash
dotnet run --project src/Markout.Demo -c Release -- textdiffjsonl
```

```jsonl
{"record_kind":"sequence","side":"before","label":"Before","line_count":"2","terminator":"present"}
{"record_kind":"sequence","side":"after","label":"After","line_count":"2","terminator":"present"}
{"record_kind":"removal","change_address":"0","change_form":"replacement","side":"before","before_line":"0","before_start":"0","before_count":"2","after_start":"0","after_count":"2","before_text":"if (value < 0)"}
{"record_kind":"addition","change_address":"0","change_form":"replacement","side":"after","after_line":"0","before_start":"0","before_count":"2","after_start":"0","after_count":"2","after_text":"if (value <= 0)"}
{"record_kind":"annotation","change_address":"0","change_form":"replacement","side":"after","after_line":"0","before_start":"0","before_count":"2","after_start":"0","after_count":"2","after_offset":"10","after_length":"2","annotation":"Boundary now includes zero","target":"After line 1, columns 11-12","severity":"warning"}
{"record_kind":"inner_mapping","change_address":"0","change_form":"replacement","side":"both","before_line":"0","after_line":"0","before_offset":"10","before_length":"1","after_offset":"10","after_length":"2"}
```

The rich terminal lowering adds line numbers and caller-issued intraline emphasis:

```text
   1      - if (value [-<-] 0)
   2      -     return [-0-];
        1 + if (value {+<=+} 0)
        2 +     return {+1+};
         ↳ Warning — After line 1, columns 11-12: Boundary now includes zero
```

The same shape has no C# assumptions; `textdiffil` renders:

```text
   1      - IL_0000: ldc.i4.0
        1 + IL_0000: ldc.i4.1
   2    2   IL_0001: ret
```

## Adopter evidence

An unpublished `dotnet-inspect` peer worktree temporarily source-referenced this exact Markout branch.

- Source Diff maps `FindingComparison<string>` anchors to exact ranges, preserves GNU final-newline behavior and PDB/checksum provenance, and renders valid Markdown, TSV, and object-per-line JSONL.
- A separate CLI-owned IL adapter maps `IlDiffDisplayResult` hunk boundaries and operation sides to the same shape without adding a Markout dependency to the IL comparison layer.
- Producer failures remain failures; neither adapter manufactures an empty successful diff.
- The absolute project-reference scaffolding remains local and is not present in this PR or any published `dotnet-inspect` branch.

## Validation

- `dotnet build Markout.sln -c Release`
- `dotnet run --project tests/Markout.Tests -c Release` — 5,310 passed
- Focused mapped-diff/source-generation tests — 37 passed
- `dotnet pack -c Release --no-build`
- `dotnet publish src/Markout.Demo -c Release` — NativeAOT publication succeeded
- Existing CI demo selector includes all four `textdiff*` demos; all 12 generated demo documents pass `markdownlint`
- `markdownlint` on every changed Markdown file
- `dotnet-inspect` Source Diff and IL adapter classes — 16 passed
- `dotnet-inspect` Source Diff command paths, including Markdown/TSV/JSONL — 10 passed

Closes #218