### PR TITLE
Prepare Markout 0.36.0 release

### DIFF
--- a/skills/markout-built-in-shapes/SKILL.md
+++ b/skills/markout-built-in-shapes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-built-in-shapes
-version: 0.35.2
+version: 0.36.0
 description: >-
   Use when a report needs rich visual elements — bar charts, stacked/proportional bars, alert
   boxes, tree hierarchies, term/definition glossaries, or code blocks — instead of hand-drawn

--- a/skills/markout-composite-cells-cards/SKILL.md
+++ b/skills/markout-composite-cells-cards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-composite-cells-cards
-version: 0.35.2
+version: 0.36.0
 description: >-
   Use when a single value must render dense in Markdown but decompose into typed columns in
   TSV/JSONL — before/after changes, fractions, shares, percentages, segment breakdowns, deltas

--- a/skills/markout-conditional-composition/SKILL.md
+++ b/skills/markout-conditional-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-conditional-composition
-version: 0.35.2
+version: 0.36.0
 description: >-
   Use when a Markout report must adapt to its data — show or hide whole sections, drop table
   columns that are empty/uniform, filter output to a chosen set of sections, or render one

--- a/skills/markout-output-formats/SKILL.md
+++ b/skills/markout-output-formats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout-output-formats
-version: 0.35.2
+version: 0.36.0
 description: >-
   Use when you need output other than default Markdown — plain text / Unicode, ANSI terminal
   (Spectre), pretty aligned tables, or TSV/JSONL exports — or when one model must serve several

--- a/skills/markout/SKILL.md
+++ b/skills/markout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: markout
-version: 0.35.2
+version: 0.36.0
 description: >-
   Use when generating Markdown or other structured output (plain text, ANSI, pretty tables,
   TSV/JSONL) from C# objects, or when diagnosing Markout source-generator errors such as

--- a/skills/plugin.json
+++ b/skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "markout",
-  "version": "0.35.2",
+  "version": "0.36.0",
   "description": "Markout library skills: one base skill, markout; four workflow-specific skills, markout-conditional-composition, markout-output-formats, markout-built-in-shapes, markout-composite-cells-cards. Each workflow-specific skill carries the required serializer-context setup so it works on its own; the base skill is the fuller treatment of the library.",
   "skills": ["."]
 }

--- a/src/Markout/Markout.csproj
+++ b/src/Markout/Markout.csproj
@@ -9,8 +9,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>A source-generated Markdown serializer for .NET</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.35.2</Version>
-    <PackageReleaseNotes>Includes Markdown graph edge-table and Mermaid rendering from 0.35.1. Fixes serializer and writer lifecycle, projection integrity, table completion, structured output keys, Unicode headers, configurable in-memory newlines, and source-generator diagnostics. ToString() now provides a non-committing preview; use Complete() to finalize and return in-memory output. JSONL sections now form one uninterrupted row stream without blank records.</PackageReleaseNotes>
+    <Version>0.36.0</Version>
+    <PackageReleaseNotes>Adds MappedTextDiff as a host-neutral presentation shape for caller-issued complete Before and After text sequences, exact line and UTF-16 intraline mappings, annotations, context selection, and Markdown, plain-text, structured, Unicode, and Spectre rendering.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Prepare the mapped-text-diff release as Markout 0.36.0.

- Bump the `Markout` package from 0.35.2 to 0.36.0.
- Replace the previous release notes with the `MappedTextDiff` capability summary.
- Keep every packed consumer-skill and plugin version stamp synchronized with the package.

**Stack:** final release slice for #218. Parent implementation PR: #221. This PR intentionally targets `feature/218-mapped-text-diff-v2`; merge the lower slices first.

## Demo

```text
Successfully created package 'artifacts/package/release/Markout.0.36.0.nupkg'.
```

The package pack gate verifies that all five `skills/*/SKILL.md` files and `skills/plugin.json` carry version `0.36.0`.

## Compatibility and boundaries

This slice changes package identity and release metadata only. It adds no API or formatter behavior beyond the implementation in #221.

## Validation

- `dotnet pack -c Release`
- `npx markdownlint-cli skills/markout/SKILL.md skills/markout-built-in-shapes/SKILL.md skills/markout-composite-cells-cards/SKILL.md skills/markout-conditional-composition/SKILL.md skills/markout-output-formats/SKILL.md`
- `git diff --check`