### PR TITLE
Demonstrate every mapped text diff format

### DIFF
--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -1,5 +1,7 @@
 using Markout;
+using Markout.Ansi.Spectre;
 using Markout.Formatting;
+using Spectre.Console;
 
 namespace Markout.Demo;
 
@@ -20,6 +22,10 @@ public static class Demos
         ["textdiff"] = TextDiff,
         ["textdiffil"] = TextDiffIl,
         ["textdiffjsonl"] = TextDiffJsonl,
+        ["textdiffplain"] = TextDiffPlain,
+        ["textdiffpretty"] = TextDiffPretty,
+        ["textdiffspectre"] = TextDiffSpectre,
+        ["textdifftsv"] = TextDiffTsv,
         ["textdiffunicode"] = TextDiffUnicode,
         ["schema"] = Schema,
     };
@@ -34,9 +40,13 @@ public static class Demos
         "pivot",
         "tree",
         "textdiff",
-        "textdiffil",
+        "textdiffplain",
+        "textdiffpretty",
+        "textdifftsv",
         "textdiffjsonl",
         "textdiffunicode",
+        "textdiffspectre",
+        "textdiffil",
         "schema"
     ];
 
@@ -197,6 +207,47 @@ public static class Demos
         writer.Flush();
     }
 
+    /// <summary>Mapped text diff demo: GNU-compatible plain-text lowering.</summary>
+    private static void TextDiffPlain(TextWriter output)
+    {
+        WriteEmbeddedDiff(
+            output,
+            "Mapped Text Diff — Plain Text",
+            "diff",
+            SampleDiff(),
+            new PlainTextFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 });
+    }
+
+    /// <summary>Mapped text diff demo: structured pretty-table provenance records.</summary>
+    private static void TextDiffPretty(TextWriter output)
+    {
+        WriteEmbeddedDiff(
+            output,
+            "Mapped Text Diff — Pretty Table",
+            "text",
+            SampleDiff(),
+            new TableFormatter(),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 });
+    }
+
+    /// <summary>Mapped text diff demo: structured TSV provenance records.</summary>
+    private static void TextDiffTsv(TextWriter output)
+    {
+        WriteEmbeddedDiff(
+            output,
+            "Mapped Text Diff — TSV",
+            "tsv",
+            SampleDiff(),
+            new TableFormatter(),
+            new MarkoutWriterOptions
+            {
+                TableMode = MarkoutTableMode.Tsv,
+                TextDiffContextLines = 0
+            },
+            static text => text.Replace("\t", "\\t", StringComparison.Ordinal));
+    }
+
     /// <summary>Mapped text diff demo: structured JSONL provenance records.</summary>
     private static void TextDiffJsonl(TextWriter output)
     {
@@ -242,13 +293,27 @@ public static class Demos
             new MarkoutWriterOptions { TextDiffContextLines = 0 });
     }
 
+    /// <summary>Mapped text diff demo: Spectre ANSI terminal lowering.</summary>
+    private static void TextDiffSpectre(TextWriter output)
+    {
+        WriteEmbeddedDiff(
+            output,
+            "Mapped Text Diff — Spectre ANSI",
+            "text",
+            SampleDiff(),
+            new SpectreFormatter(AnsiConsole.Console),
+            new MarkoutWriterOptions { TextDiffContextLines = 0 },
+            static text => text.Replace("\u001b", "\\e", StringComparison.Ordinal));
+    }
+
     private static void WriteEmbeddedDiff(
         TextWriter output,
         string title,
         string language,
         MappedTextDiff diff,
         IMarkoutFormatter formatter,
-        MarkoutWriterOptions options)
+        MarkoutWriterOptions options,
+        Func<string, string>? prepareForCodeFence = null)
     {
         var rendered = MarkoutWriter.Create(formatter, options);
         rendered.WriteTextDiff(diff);
@@ -256,7 +321,8 @@ public static class Demos
         var document = new MarkoutWriter(output, new MarkdownFormatter());
         document.WriteHeading(1, title);
         document.WriteCodeStart(language);
-        document.WriteParagraph(rendered.ToString());
+        var text = rendered.ToString();
+        document.WriteParagraph(prepareForCodeFence is null ? text : prepareForCodeFence(text));
         document.WriteCodeEnd();
         document.Flush();
     }

--- a/src/Markout.Demo/Markout.Demo.csproj
+++ b/src/Markout.Demo/Markout.Demo.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Markout.Ansi.Spectre\Markout.Ansi.Spectre.csproj" />
     <ProjectReference Include="..\Markout\Markout.csproj" />
     <ProjectReference Include="..\Markout.SourceGeneration\Markout.SourceGeneration.csproj"
                       OutputItemType="Analyzer"

--- a/src/Markout.Demo/README.md
+++ b/src/Markout.Demo/README.md
@@ -215,17 +215,23 @@ formatters:
 
 ```bash
 dotnet run --project src/Markout.Demo -- textdiff
+dotnet run --project src/Markout.Demo -- textdiffplain
+dotnet run --project src/Markout.Demo -- textdiffpretty
+dotnet run --project src/Markout.Demo -- textdifftsv
 dotnet run --project src/Markout.Demo -- textdiffjsonl
 dotnet run --project src/Markout.Demo -- textdiffunicode
+dotnet run --project src/Markout.Demo -- textdiffspectre
 dotnet run --project src/Markout.Demo -- textdiffil
 ```
 
-Each command emits a lintable Markdown demo document. The first contains the
-GNU-compatible diff directly; the JSONL, Unicode, and IL commands embed the
-actual selected formatter output in code fences. The rich output adds line
-numbers, intraline markers, and the caller-issued annotation. The IL example
-applies the same shape to instructions, demonstrating that the contract has no
-source-language assumptions.
+Each command emits a lintable Markdown demo document. Together they cover every
+mapped-diff output mode: fenced GNU-compatible Markdown, plain GNU-compatible
+text, structured pretty-table, TSV, and JSONL records, rich Unicode, and
+Spectre ANSI. Embedded TSV spells tab separators as `\t`, and embedded Spectre
+output spells the escape byte as `\e`, so both formats remain visible in the
+lintable Markdown artifacts. The IL example applies the Unicode lowering to
+instructions, demonstrating that the contract has no source-language
+assumptions.
 
 ---
 


### PR DESCRIPTION
## Summary

Make mapped-text-diff support discoverable by demonstrating every supported formatter and structured output mode.

| Demo | Formatter or mode | Presentation |
| --- | --- | --- |
| `textdiff` | Markdown | Fenced GNU-compatible unified diff and callout |
| `textdiffplain` | Plain text | GNU-compatible unified diff and annotation |
| `textdiffpretty` | Pretty table | Aligned provenance records |
| `textdifftsv` | TSV | Tab-separated provenance records |
| `textdiffjsonl` | JSONL | Object-per-line provenance records |
| `textdiffunicode` | Unicode | Numbered rich diff with intraline markers |
| `textdiffspectre` | Spectre ANSI | Colored numbered diff with intraline emphasis |
| `textdiffil` | Unicode over IL | Domain-neutral instruction comparison |

The TSV demo spells separators as `\t` and the Spectre demo spells the escape byte as `\e` so the actual formatter controls remain visible inside lintable Markdown artifacts.

Follow-up to #218 and the Markout 0.36.0 release.

## Demo

```bash
dotnet run --project src/Markout.Demo -- textdiff
dotnet run --project src/Markout.Demo -- textdiffplain
dotnet run --project src/Markout.Demo -- textdiffpretty
dotnet run --project src/Markout.Demo -- textdifftsv
dotnet run --project src/Markout.Demo -- textdiffjsonl
dotnet run --project src/Markout.Demo -- textdiffunicode
dotnet run --project src/Markout.Demo -- textdiffspectre
dotnet run --project src/Markout.Demo -- textdiffil
```

## Output examples

### Markdown

```diff
--- Before
+++ After
@@ -1,2 +1,2 @@
-if (value < 0)
-    return 0;
+if (value <= 0)
+    return 1;
```

> **NOTE — After line 1, columns 11-12:** Boundary now includes zero

### Structured JSONL

```jsonl
{"record_kind":"sequence","side":"before","label":"Before","line_count":"2","terminator":"present"}
{"record_kind":"sequence","side":"after","label":"After","line_count":"2","terminator":"present"}
{"record_kind":"removal","change_address":"0","change_form":"replacement","side":"before","before_line":"0","before_start":"0","before_count":"2","after_start":"0","after_count":"2","before_text":"if (value < 0)"}
{"record_kind":"addition","change_address":"0","change_form":"replacement","side":"after","after_line":"0","before_start":"0","before_count":"2","after_start":"0","after_count":"2","after_text":"if (value <= 0)"}
```

### Rich Unicode

```text
   1      - if (value [-<-] 0)
   2      -     return [-0-];
        1 + if (value {+<=+} 0)
        2 +     return {+1+};
         ↳ Note — After line 1, columns 11-12: Boundary now includes zero
```

### Spectre ANSI

The Markdown artifact makes the ANSI escape byte visible as `\e`:

```text
\e[90m   1      \e[31m- if (value \e[7m<\e[27m 0)\e[m
\e[90m   2      \e[31m-     return \e[7m0\e[27m;\e[m
\e[90m        1 \e[32m+ if (value \e[7m<=\e[27m 0)\e[m
\e[90m        2 \e[32m+     return \e[7m1\e[27m;\e[m
\e[33m         > Note - After line 1, columns 11-12: Boundary now includes zero\e[m
```

## Compatibility and boundaries

This changes demonstration and documentation only. It adds a `Markout.Ansi.Spectre` project reference to `Markout.Demo` so the demo can exercise the existing formatter; no library API or mapped-diff behavior changes.

## Validation

- `dotnet build Markout.sln -c Release`
- All 16 dynamically discovered demos rendered and passed the repository markdownlint configuration
- `dotnet publish src/Markout.Demo -c Release`
- `npx markdownlint-cli src/Markout.Demo/README.md`
- `git diff --check`