### PR TITLE
Demonstrate multiple mapped-diff changes and annotations

### DIFF
--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -352,8 +352,7 @@ public static class Demos
                     TextDiffAnnotation.ForSpan(
                         TextDiffSide.After,
                         new TextDiffSpan(0, 10, 2),
-                        "Boundary now includes zero",
-                        CalloutSeverity.Warning)
+                        "Boundary now includes zero")
                 ])
         ]);
 }

--- a/src/Markout.Demo/Demos.cs
+++ b/src/Markout.Demo/Demos.cs
@@ -329,11 +329,11 @@ public static class Demos
 
     private static MappedTextDiff SampleDiff() => new(
         new TextDiffSequence(
-            ["if (value < 0)", "    return 0;"],
+            ["if (value < 0)", "    return 0;", "", "Process(value);", "return value;"],
             "Before",
             TextDiffLineTerminator.Present),
         new TextDiffSequence(
-            ["if (value <= 0)", "    return 1;"],
+            ["if (value <= 0)", "    return 1;", "", "Process(value);", "Log(value);", "return value;"],
             "After",
             TextDiffLineTerminator.Present),
         [
@@ -352,7 +352,21 @@ public static class Demos
                     TextDiffAnnotation.ForSpan(
                         TextDiffSide.After,
                         new TextDiffSpan(0, 10, 2),
-                        "Boundary now includes zero")
+                        "Boundary now includes zero"),
+                    TextDiffAnnotation.ForSpan(
+                        TextDiffSide.After,
+                        new TextDiffSpan(1, 11, 1),
+                        "Branch now returns one")
+                ]),
+            new TextDiffChange(
+                new TextDiffRange(4, 0),
+                new TextDiffRange(4, 1),
+                annotations:
+                [
+                    TextDiffAnnotation.ForLine(
+                        TextDiffSide.After,
+                        4,
+                        "Processed values are now logged")
                 ])
         ]);
 }

--- a/src/Markout/MarkdownFormatter.cs
+++ b/src/Markout/MarkdownFormatter.cs
@@ -581,12 +581,17 @@ public class MarkdownFormatter : IMarkoutFormatter,
             w.WriteLine(line);
         w.WriteLine(fence);
 
+        var wroteAnnotation = false;
         for (var address = 0; address < diff.Changes.Length; address++)
         {
             var change = diff.Changes[address];
             foreach (var annotation in change.Annotations)
             {
-                w.WriteLine();
+                if (wroteAnnotation)
+                    w.WriteLine(">");
+                else
+                    w.WriteLine();
+
                 w.Write("> **");
                 w.Write(annotation.Severity.ToString().ToUpperInvariant());
                 w.Write(" — ");
@@ -595,6 +600,7 @@ public class MarkdownFormatter : IMarkoutFormatter,
                 w.Write(":** ");
                 w.Write(FormatHelper.EscapeMarkdownText(TextDiffEscaping.MarkdownInline(annotation.Text)));
                 w.WriteLine();
+                wroteAnnotation = true;
             }
         }
     }

--- a/tests/Markout.Tests/MappedTextDiffTests.cs
+++ b/tests/Markout.Tests/MappedTextDiffTests.cs
@@ -216,6 +216,37 @@ public partial class MappedTextDiffTests
     }
 
     [Fact]
+    public void MarkdownKeepsMultipleAnnotationsInOneBlockquote()
+    {
+        var diff = new MappedTextDiff(
+            new TextDiffSequence(["old"]),
+            new TextDiffSequence(["new"]),
+            [
+                new TextDiffChange(
+                    new TextDiffRange(0, 1),
+                    new TextDiffRange(0, 1),
+                    annotations:
+                    [
+                        TextDiffAnnotation.ForChange("first"),
+                        TextDiffAnnotation.ForChange("second", CalloutSeverity.Warning)
+                    ])
+            ]);
+        var writer = MarkoutWriter.Create(
+            new MarkdownFormatter(),
+            new MarkoutWriterOptions { NewLine = "\n" });
+
+        writer.WriteTextDiff(diff);
+        var output = writer.ToString();
+
+        Assert.Contains(
+            "> **NOTE — change 1:** first\n>\n> **WARNING — change 1:** second",
+            output);
+        Assert.DoesNotContain(
+            "> **NOTE — change 1:** first\n\n> **WARNING — change 1:** second",
+            output);
+    }
+
+    [Fact]
     public void MarkdownChoosesAFenceLongerThanCallerContent()
     {
         var diff = new MappedTextDiff(


### PR DESCRIPTION
## Summary

Show a genuine multi-change mapped text diff and make multiple Markdown annotations lint-clean.

- Expand the demo from one replacement to a two-line replacement plus a separate line addition.
- Attach three independently targeted `Note` annotations across the two changes.
- Preserve annotation order in every human and structured formatter.
- Render consecutive Markdown annotations inside one blockquote with quoted separators, fixing #226 without combining their severity, target, or text.

## Demo

```diff
--- Before
+++ After
@@ -1,2 +1,2 @@
-if (value < 0)
-    return 0;
+if (value <= 0)
+    return 1;
@@ -4,0 +5 @@
+Log(value);
```

> **NOTE — After line 1, columns 11-12:** Boundary now includes zero
>
> **NOTE — After line 2, columns 12-12:** Branch now returns one
>
> **NOTE — After line 5:** Processed values are now logged

The same three annotations become three records in structured output. Their `change_address` values retain which of the two changes owns each annotation:

```jsonl
{"record_kind":"annotation","change_address":"0","change_form":"replacement","side":"after","after_line":"0","after_offset":"10","after_length":"2","annotation":"Boundary now includes zero","target":"After line 1, columns 11-12","severity":"note"}
{"record_kind":"annotation","change_address":"0","change_form":"replacement","side":"after","after_line":"1","after_offset":"11","after_length":"1","annotation":"Branch now returns one","target":"After line 2, columns 12-12","severity":"note"}
{"record_kind":"annotation","change_address":"1","change_form":"addition","side":"after","after_line":"4","annotation":"Processed values are now logged","target":"After line 5","severity":"note"}
```

## Compatibility and boundaries

The comparison and annotations remain entirely caller-issued. This changes only Markdown layout between consecutive annotations and the demo data; no correspondence, severity, or target is inferred.

Markout 0.36.0 was published before this follow-up. A later package release is required for package consumers to receive the Markdown adjacency fix.

## Validation

- `dotnet build Markout.sln -c Release`
- `dotnet run --project tests/Markout.Tests -c Release` — 5,321 passed
- `dotnet publish src/Markout.Demo -c Release`
- All 16 generated demos passed the repository markdownlint configuration
- `npx markdownlint-cli src/Markout.Demo/README.md`
- `git diff --check`

Closes #226